### PR TITLE
fix: Delete local filter middleware

### DIFF
--- a/app/model/blockchain/personal_info.py
+++ b/app/model/blockchain/personal_info.py
@@ -25,10 +25,7 @@ import logging
 from Crypto.Cipher import PKCS1_OAEP
 from Crypto.PublicKey import RSA
 from web3 import Web3
-from web3.middleware import (
-    geth_poa_middleware,
-    local_filter_middleware
-)
+from web3.middleware import geth_poa_middleware
 from web3.exceptions import TimeExhausted
 from eth_keyfile import decode_keyfile_json
 
@@ -47,7 +44,6 @@ from app.exceptions import SendTransactionError
 
 web3 = Web3(Web3.HTTPProvider(WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(geth_poa_middleware, layer=0)
-web3.middleware_onion.add(local_filter_middleware)
 
 
 class PersonalInfoContract:
@@ -173,11 +169,11 @@ class PersonalInfoContract:
         :param block_to: block to
         :return: event entries
         """
-        _build_filter = self.personal_info_contract.events.Register.build_filter()
-        _build_filter.fromBlock = block_from
-        _build_filter.toBlock = block_to
-        event_filter = _build_filter.deploy(web3)
-        return event_filter.get_all_entries()
+        events = self.personal_info_contract.events.Register.getLogs(
+            fromBlock=block_from,
+            toBlock=block_to
+        )
+        return events
 
     def get_modify_event(self, block_from, block_to):
         """Get Modify event
@@ -186,8 +182,8 @@ class PersonalInfoContract:
         :param block_to: block to
         :return: event entries
         """
-        _build_filter = self.personal_info_contract.events.Modify.build_filter()
-        _build_filter.fromBlock = block_from
-        _build_filter.toBlock = block_to
-        event_filter = _build_filter.deploy(web3)
-        return event_filter.get_all_entries()
+        events = self.personal_info_contract.events.Modify.getLogs(
+            fromBlock=block_from,
+            toBlock=block_to
+        )
+        return events

--- a/batch/indexer_personal_info.py
+++ b/batch/indexer_personal_info.py
@@ -27,10 +27,7 @@ from sqlalchemy.orm import (
     scoped_session
 )
 from web3 import Web3
-from web3.middleware import (
-    geth_poa_middleware,
-    local_filter_middleware
-)
+from web3.middleware import geth_poa_middleware
 from web3.exceptions import BadFunctionCallOutput
 from eth_utils import to_checksum_address
 
@@ -55,7 +52,6 @@ LOG = batch_log.get_logger(process_name=process_name)
 
 web3 = Web3(Web3.HTTPProvider(WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(geth_poa_middleware, layer=0)
-web3.middleware_onion.add(local_filter_middleware)
 
 engine = create_engine(DATABASE_URL, echo=False)
 db_session = scoped_session(sessionmaker())

--- a/batch/indexer_position_bond.py
+++ b/batch/indexer_position_bond.py
@@ -25,10 +25,7 @@ from sqlalchemy.orm import (
     scoped_session
 )
 from web3 import Web3
-from web3.middleware import (
-    geth_poa_middleware,
-    local_filter_middleware
-)
+from web3.middleware import geth_poa_middleware
 from eth_utils import to_checksum_address
 
 path = os.path.join(os.path.dirname(__file__), '../')
@@ -52,7 +49,6 @@ LOG = batch_log.get_logger(process_name=process_name)
 
 web3 = Web3(Web3.HTTPProvider(WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(geth_poa_middleware, layer=0)
-web3.middleware_onion.add(local_filter_middleware)
 
 engine = create_engine(DATABASE_URL, echo=False)
 db_session = scoped_session(sessionmaker())
@@ -164,11 +160,11 @@ class Processor:
         """
         for token in self.token_list:
             try:
-                _build_filter = token.events.Issue.build_filter()
-                _build_filter.fromBlock = block_from
-                _build_filter.toBlock = block_to
-                event_filter = _build_filter.deploy(web3)
-                for event in event_filter.get_all_entries():
+                events = token.events.Issue.getLogs(
+                    fromBlock=block_from,
+                    toBlock=block_to
+                )
+                for event in events:
                     args = event['args']
                     account = args.get("target_address", ZERO_ADDRESS)
                     balance = token.functions.balanceOf(account).call()
@@ -189,11 +185,11 @@ class Processor:
         """
         for token in self.token_list:
             try:
-                _build_filter = token.events.Transfer.build_filter()
-                _build_filter.fromBlock = block_from
-                _build_filter.toBlock = block_to
-                event_filter = _build_filter.deploy(web3)
-                for event in event_filter.get_all_entries():
+                events = token.events.Transfer.getLogs(
+                    fromBlock=block_from,
+                    toBlock=block_to
+                )
+                for event in events:
                     args = event['args']
                     # from address
                     from_account = args.get("from", ZERO_ADDRESS)
@@ -223,11 +219,11 @@ class Processor:
         """
         for token in self.token_list:
             try:
-                _build_filter = token.events.Lock.build_filter()
-                _build_filter.fromBlock = block_from
-                _build_filter.toBlock = block_to
-                event_filter = _build_filter.deploy(web3)
-                for event in event_filter.get_all_entries():
+                events = token.events.Lock.getLogs(
+                    fromBlock=block_from,
+                    toBlock=block_to
+                )
+                for event in events:
                     args = event['args']
                     account = args.get("from", ZERO_ADDRESS)
                     balance = token.functions.balanceOf(account).call()
@@ -248,11 +244,11 @@ class Processor:
         """
         for token in self.token_list:
             try:
-                _build_filter = token.events.Unlock.build_filter()
-                _build_filter.fromBlock = block_from
-                _build_filter.toBlock = block_to
-                event_filter = _build_filter.deploy(web3)
-                for event in event_filter.get_all_entries():
+                events = token.events.Unlock.getLogs(
+                    fromBlock=block_from,
+                    toBlock=block_to
+                )
+                for event in events:
                     args = event['args']
                     account = args.get("to", ZERO_ADDRESS)
                     balance = token.functions.balanceOf(account).call()

--- a/batch/indexer_position_share.py
+++ b/batch/indexer_position_share.py
@@ -25,10 +25,7 @@ from sqlalchemy.orm import (
     scoped_session
 )
 from web3 import Web3
-from web3.middleware import (
-    geth_poa_middleware,
-    local_filter_middleware
-)
+from web3.middleware import geth_poa_middleware
 from eth_utils import to_checksum_address
 
 path = os.path.join(os.path.dirname(__file__), "../")
@@ -52,7 +49,6 @@ LOG = batch_log.get_logger(process_name=process_name)
 
 web3 = Web3(Web3.HTTPProvider(WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(geth_poa_middleware, layer=0)
-web3.middleware_onion.add(local_filter_middleware)
 
 engine = create_engine(DATABASE_URL, echo=False)
 db_session = scoped_session(sessionmaker())
@@ -179,11 +175,11 @@ class Processor:
         """
         for token in self.token_list:
             try:
-                _build_filter = token.events.Issue.build_filter()
-                _build_filter.fromBlock = block_from
-                _build_filter.toBlock = block_to
-                event_filter = _build_filter.deploy(web3)
-                for event in event_filter.get_all_entries():
+                events = token.events.Issue.getLogs(
+                    fromBlock=block_from,
+                    toBlock=block_to
+                )
+                for event in events:
                     args = event["args"]
                     account = args.get("target_address", ZERO_ADDRESS)
                     balance = token.functions.balanceOf(account).call()
@@ -204,11 +200,11 @@ class Processor:
         """
         for token in self.token_list:
             try:
-                _build_filter = token.events.Transfer.build_filter()
-                _build_filter.fromBlock = block_from
-                _build_filter.toBlock = block_to
-                event_filter = _build_filter.deploy(web3)
-                for event in event_filter.get_all_entries():
+                events = token.events.Transfer.getLogs(
+                    fromBlock=block_from,
+                    toBlock=block_to
+                )
+                for event in events:
                     args = event["args"]
                     # from address
                     from_account = args.get("from", ZERO_ADDRESS)
@@ -238,11 +234,11 @@ class Processor:
         """
         for token in self.token_list:
             try:
-                _build_filter = token.events.Lock.build_filter()
-                _build_filter.fromBlock = block_from
-                _build_filter.toBlock = block_to
-                event_filter = _build_filter.deploy(web3)
-                for event in event_filter.get_all_entries():
+                events = token.events.Lock.getLogs(
+                    fromBlock=block_from,
+                    toBlock=block_to
+                )
+                for event in events:
                     args = event["args"]
                     account = args.get("from", ZERO_ADDRESS)
                     balance = token.functions.balanceOf(account).call()
@@ -263,11 +259,11 @@ class Processor:
         """
         for token in self.token_list:
             try:
-                _build_filter = token.events.Unlock.build_filter()
-                _build_filter.fromBlock = block_from
-                _build_filter.toBlock = block_to
-                event_filter = _build_filter.deploy(web3)
-                for event in event_filter.get_all_entries():
+                events = token.events.Unlock.getLogs(
+                    fromBlock=block_from,
+                    toBlock=block_to
+                )
+                for event in events:
                     args = event["args"]
                     account = args.get("to", ZERO_ADDRESS)
                     balance = token.functions.balanceOf(account).call()
@@ -288,11 +284,11 @@ class Processor:
         """
         for token in self.token_list:
             try:
-                _build_filter = token.events.Redeem.build_filter()
-                _build_filter.fromBlock = block_from
-                _build_filter.toBlock = block_to
-                event_filter = _build_filter.deploy(web3)
-                for event in event_filter.get_all_entries():
+                events = token.events.Redeem.getLogs(
+                    fromBlock=block_from,
+                    toBlock=block_to
+                )
+                for event in events:
                     args = event["args"]
                     account = args.get("target_address", ZERO_ADDRESS)
                     balance = token.functions.balanceOf(account).call()

--- a/batch/indexer_transfer.py
+++ b/batch/indexer_transfer.py
@@ -27,10 +27,7 @@ from sqlalchemy.orm import (
     scoped_session
 )
 from web3 import Web3
-from web3.middleware import (
-    geth_poa_middleware,
-    local_filter_middleware
-)
+from web3.middleware import geth_poa_middleware
 
 path = os.path.join(os.path.dirname(__file__), "../")
 sys.path.append(path)
@@ -51,7 +48,6 @@ LOG = batch_log.get_logger(process_name=process_name)
 
 web3 = Web3(Web3.HTTPProvider(WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(geth_poa_middleware, layer=0)
-web3.middleware_onion.add(local_filter_middleware)
 
 engine = create_engine(DATABASE_URL, echo=False)
 db_session = scoped_session(sessionmaker())
@@ -156,11 +152,11 @@ class Processor:
         """
         for token in self.token_list:
             try:
-                _build_filter = token.events.Transfer.build_filter()
-                _build_filter.fromBlock = block_from
-                _build_filter.toBlock = block_to
-                event_filter = _build_filter.deploy(web3)
-                for event in event_filter.get_all_entries():
+                events = token.events.Transfer.getLogs(
+                    fromBlock=block_from,
+                    toBlock=block_to
+                )
+                for event in events:
                     args = event["args"]
                     transaction_hash = event["transactionHash"].hex()
                     block_timestamp = datetime.utcfromtimestamp(web3.eth.get_block(event["blockNumber"])["timestamp"])

--- a/batch/processor_create_utxo.py
+++ b/batch/processor_create_utxo.py
@@ -26,10 +26,7 @@ from sqlalchemy.orm import (
     scoped_session
 )
 from web3 import Web3
-from web3.middleware import (
-    geth_poa_middleware,
-    local_filter_middleware
-)
+from web3.middleware import geth_poa_middleware
 
 path = os.path.join(os.path.dirname(__file__), '../')
 sys.path.append(path)
@@ -58,7 +55,6 @@ db_session.configure(bind=engine)
 
 web3 = Web3(Web3.HTTPProvider(WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(geth_poa_middleware, layer=0)
-web3.middleware_onion.add(local_filter_middleware)
 
 
 class Sinks:
@@ -180,11 +176,11 @@ class Processor:
     def __process_transfer(self, token_contract, block_from: int, block_to: int):
         try:
             # When a Transfer event occurs
-            _build_filter = token_contract.events.Transfer.build_filter()
-            _build_filter.fromBlock = block_from
-            _build_filter.toBlock = block_to
-            _event_filter = _build_filter.deploy(web3)
-            for event in _event_filter.get_all_entries():
+            events = token_contract.events.Transfer.getLogs(
+                fromBlock=block_from,
+                toBlock=block_to
+            )
+            for event in events:
 
                 # Get contract event args
                 args = event["args"]


### PR DESCRIPTION
- Changed the way to get the event log because the use of local filter middleware was causing memory leaks.