### PR TITLE
feat: upgrade fastapi

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ web3==5.15.0
 eth-keyfile==0.5.1
 pysha3==1.0.2
 coincurve==14.0.0
+pydantic==1.8.2
 fastapi==0.68.1
 uvicorn==0.13.3
 gunicorn==20.0.4


### PR DESCRIPTION
- Apply patches for [dependabot security alerts](https://github.com/BoostryJP/ibet-Prime/security/dependabot/requirements.txt/fastapi/open).　
- Upgrade the fastapi version to the latest version.