### PR TITLE
feat: Validate environment variables at server startup

### DIFF
--- a/bin/run_server.sh
+++ b/bin/run_server.sh
@@ -27,6 +27,12 @@ function start () {
     exit 1
   fi
 
+  # E2E_MESSAGING_CONTRACT_ADDRESS is HEX_ADDRESS
+  if [[ ! ${E2E_MESSAGING_CONTRACT_ADDRESS} =~ 0x[0-9a-fA-F]{40} ]]; then
+    echo 'Please set the "E2E_MESSAGING_CONTRACT_ADDRESS" environment variable and try again.' >&2
+    exit 1
+  fi
+
   # Use Shared Memory
   export SHARED_MEMORY_USE_LOCK=1
 


### PR DESCRIPTION
close #323 

---
1.
I wondered that ```config.py``` should validate environment variables and changed only script file.

2.
I noticed that ```config.py``` can be made more secure to avoid using global variable.

```python
# Global Config
def ConfigLoader():
    self: Dict = {}
    self.__setitem__(SERVER_NAME, "ibet-Prime")
    self.__setitem__(APP_ENV, os.environ.get('APP_ENV') or "local")
    self.__setitem__(NETWORK, os.environ.get("NETWORK") or "IBET")
    ...

    def get(key: str):
        nonlocal self
        return self.__getitem__(key)
    return get


get = ConfigLoader()
```

and in other file, variables can be read like below.

```python
import config
from config import SERVER_NAME

config.get(SERVER_NAME)
```