### PR TITLE
feat: retrieving message from error code to tell where logic error occurs in contract enhancement

### DIFF
--- a/app/exceptions.py
+++ b/app/exceptions.py
@@ -16,6 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
+from app.utils.contract_error_code import error_code_msg
 
 
 class InvalidParameterError(Exception):
@@ -24,6 +25,15 @@ class InvalidParameterError(Exception):
 
 class SendTransactionError(Exception):
     pass
+
+
+class ContractRevertError(Exception):
+
+    def __init__(self, code_msg: str):
+        code, message = error_code_msg(code_msg)
+        self.code = code
+        self.message = message
+        super().__init__(message)
 
 
 class AuthorizationError(Exception):

--- a/app/main.py
+++ b/app/main.py
@@ -136,6 +136,19 @@ async def send_transaction_error_handler(request: Request, exc: SendTransactionE
     )
 
 
+# 400:ContractRevertError
+@app.exception_handler(ContractRevertError)
+async def contract_revert_error_handler(request: Request, exc: ContractRevertError):
+    meta = {
+        "code": exc.code,
+        "title": "ContractRevertError"
+    }
+    return JSONResponse(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        content=jsonable_encoder({"meta": meta, "detail": exc.message}),
+    )
+
+
 # 401:AuthorizationError
 @app.exception_handler(AuthorizationError)
 async def authorization_error_handler(request: Request, exc: AuthorizationError):

--- a/app/model/blockchain/e2e_messaging.py
+++ b/app/model/blockchain/e2e_messaging.py
@@ -36,7 +36,7 @@ from config import (
     AWS_REGION_NAME
 )
 from app.utils.contract_utils import ContractUtils
-from app.exceptions import SendTransactionError
+from app.exceptions import SendTransactionError, ContractRevertError
 
 
 class E2EMessaging:
@@ -64,6 +64,8 @@ class E2EMessaging:
             })
             tx_hash, tx_receipt = ContractUtils.send_transaction(tx, private_key)
             return tx_hash, tx_receipt
+        except ContractRevertError:
+            raise
         except TimeExhausted as timeout_error:
             raise SendTransactionError(timeout_error)
         except Exception as err:
@@ -140,6 +142,8 @@ class E2EMessaging:
             })
             tx_hash, tx_receipt = ContractUtils.send_transaction(tx, private_key)
             return tx_hash, tx_receipt
+        except ContractRevertError:
+            raise
         except TimeExhausted as timeout_error:
             raise SendTransactionError(timeout_error)
         except Exception as err:

--- a/app/model/blockchain/exchange.py
+++ b/app/model/blockchain/exchange.py
@@ -24,7 +24,7 @@ from config import (
 )
 from app.utils.contract_utils import ContractUtils
 from app.model.schema import IbetSecurityTokenEscrowApproveTransfer
-from app.exceptions import SendTransactionError
+from app.exceptions import SendTransactionError, ContractRevertError
 
 
 class IbetExchangeInterface:
@@ -84,6 +84,8 @@ class IbetSecurityTokenEscrow(IbetExchangeInterface):
             })
             tx_hash, tx_receipt = ContractUtils.send_transaction(transaction=tx, private_key=private_key)
             return tx_hash, tx_receipt
+        except ContractRevertError:
+            raise
         except TimeExhausted as timeout_error:
             raise SendTransactionError(timeout_error)
         except Exception as err:

--- a/app/model/blockchain/personal_info.py
+++ b/app/model/blockchain/personal_info.py
@@ -39,7 +39,7 @@ from app.utils.contract_utils import ContractUtils
 from app.utils.web3_utils import Web3Wrapper
 from app.model.db import Account
 from app.utils.e2ee_utils import E2EEUtils
-from app.exceptions import SendTransactionError
+from app.exceptions import SendTransactionError, ContractRevertError
 
 web3 = Web3Wrapper()
 
@@ -164,6 +164,8 @@ class PersonalInfoContract:
                     "gasPrice": 0
                 })
             ContractUtils.send_transaction(transaction=tx, private_key=private_key)
+        except ContractRevertError:
+            raise
         except TimeExhausted as timeout_error:
             raise SendTransactionError(timeout_error)
         except Exception as err:
@@ -211,6 +213,8 @@ class PersonalInfoContract:
                     "gasPrice": 0
                 })
             ContractUtils.send_transaction(transaction=tx, private_key=private_key)
+        except ContractRevertError:
+            raise
         except TimeExhausted as timeout_error:
             raise SendTransactionError(timeout_error)
         except Exception as err:

--- a/app/model/blockchain/token.py
+++ b/app/model/blockchain/token.py
@@ -50,7 +50,7 @@ from app.model.schema import (
     IbetSecurityTokenCancelTransfer
 )
 from app.model.blockchain import IbetExchangeInterface
-from app.exceptions import SendTransactionError
+from app.exceptions import SendTransactionError, ContractRevertError
 from app import log
 from app.utils.contract_utils import ContractUtils
 from app.utils.web3_utils import Web3Wrapper
@@ -162,6 +162,8 @@ class IbetSecurityTokenInterface(IbetStandardTokenInterface):
             })
             tx_hash, tx_receipt = ContractUtils.send_transaction(transaction=tx, private_key=private_key)
             return tx_hash, tx_receipt
+        except ContractRevertError:
+            raise
         except TimeExhausted as timeout_error:
             raise SendTransactionError(timeout_error)
         except Exception as err:
@@ -188,6 +190,8 @@ class IbetSecurityTokenInterface(IbetStandardTokenInterface):
             })
             tx_hash, tx_receipt = ContractUtils.send_transaction(transaction=tx, private_key=private_key)
             return tx_hash, tx_receipt
+        except ContractRevertError:
+            raise
         except TimeExhausted as timeout_error:
             raise SendTransactionError(timeout_error)
         except Exception as err:
@@ -380,6 +384,8 @@ class IbetStraightBondContract(IbetSecurityTokenInterface):
             })
             try:
                 ContractUtils.send_transaction(transaction=tx, private_key=private_key)
+            except ContractRevertError:
+                raise
             except TimeExhausted as timeout_error:
                 raise SendTransactionError(timeout_error)
             except Exception as err:
@@ -397,6 +403,8 @@ class IbetStraightBondContract(IbetSecurityTokenInterface):
             })
             try:
                 ContractUtils.send_transaction(transaction=tx, private_key=private_key)
+            except ContractRevertError:
+                raise
             except TimeExhausted as timeout_error:
                 raise SendTransactionError(timeout_error)
             except Exception as err:
@@ -417,6 +425,8 @@ class IbetStraightBondContract(IbetSecurityTokenInterface):
             })
             try:
                 ContractUtils.send_transaction(transaction=tx, private_key=private_key)
+            except ContractRevertError:
+                raise
             except TimeExhausted as timeout_error:
                 raise SendTransactionError(timeout_error)
             except Exception as err:
@@ -449,6 +459,8 @@ class IbetStraightBondContract(IbetSecurityTokenInterface):
             })
             try:
                 ContractUtils.send_transaction(transaction=tx, private_key=private_key)
+            except ContractRevertError:
+                raise
             except TimeExhausted as timeout_error:
                 raise SendTransactionError(timeout_error)
             except Exception as err:
@@ -465,6 +477,8 @@ class IbetStraightBondContract(IbetSecurityTokenInterface):
             })
             try:
                 ContractUtils.send_transaction(transaction=tx, private_key=private_key)
+            except ContractRevertError:
+                raise
             except TimeExhausted as timeout_error:
                 raise SendTransactionError(timeout_error)
             except Exception as err:
@@ -481,6 +495,8 @@ class IbetStraightBondContract(IbetSecurityTokenInterface):
             })
             try:
                 ContractUtils.send_transaction(transaction=tx, private_key=private_key)
+            except ContractRevertError:
+                raise
             except TimeExhausted as timeout_error:
                 raise SendTransactionError(timeout_error)
             except Exception as err:
@@ -495,6 +511,8 @@ class IbetStraightBondContract(IbetSecurityTokenInterface):
             })
             try:
                 ContractUtils.send_transaction(transaction=tx, private_key=private_key)
+            except ContractRevertError:
+                raise
             except TimeExhausted as timeout_error:
                 raise SendTransactionError(timeout_error)
             except Exception as err:
@@ -511,6 +529,8 @@ class IbetStraightBondContract(IbetSecurityTokenInterface):
             })
             try:
                 ContractUtils.send_transaction(transaction=tx, private_key=private_key)
+            except ContractRevertError:
+                raise
             except TimeExhausted as timeout_error:
                 raise SendTransactionError(timeout_error)
             except Exception as err:
@@ -527,6 +547,8 @@ class IbetStraightBondContract(IbetSecurityTokenInterface):
             })
             try:
                 ContractUtils.send_transaction(transaction=tx, private_key=private_key)
+            except ContractRevertError:
+                raise
             except TimeExhausted as timeout_error:
                 raise SendTransactionError(timeout_error)
             except Exception as err:
@@ -543,6 +565,8 @@ class IbetStraightBondContract(IbetSecurityTokenInterface):
             })
             try:
                 ContractUtils.send_transaction(transaction=tx, private_key=private_key)
+            except ContractRevertError:
+                raise
             except TimeExhausted as timeout_error:
                 raise SendTransactionError(timeout_error)
             except Exception as err:
@@ -559,6 +583,8 @@ class IbetStraightBondContract(IbetSecurityTokenInterface):
             })
             try:
                 ContractUtils.send_transaction(transaction=tx, private_key=private_key)
+            except ContractRevertError:
+                raise
             except TimeExhausted as timeout_error:
                 raise SendTransactionError(timeout_error)
             except Exception as err:
@@ -575,6 +601,8 @@ class IbetStraightBondContract(IbetSecurityTokenInterface):
             })
             try:
                 ContractUtils.send_transaction(transaction=tx, private_key=private_key)
+            except ContractRevertError:
+                raise
             except TimeExhausted as timeout_error:
                 raise SendTransactionError(timeout_error)
             except Exception as err:
@@ -591,6 +619,8 @@ class IbetStraightBondContract(IbetSecurityTokenInterface):
             })
             try:
                 ContractUtils.send_transaction(transaction=tx, private_key=private_key)
+            except ContractRevertError:
+                raise
             except TimeExhausted as timeout_error:
                 raise SendTransactionError(timeout_error)
             except Exception as err:
@@ -622,6 +652,8 @@ class IbetStraightBondContract(IbetSecurityTokenInterface):
                 "gasPrice": 0
             })
             ContractUtils.send_transaction(transaction=tx, private_key=private_key)
+        except ContractRevertError:
+            raise
         except TimeExhausted as timeout_error:
             raise SendTransactionError(timeout_error)
         except Exception as err:
@@ -653,6 +685,8 @@ class IbetStraightBondContract(IbetSecurityTokenInterface):
             # Delete Cache
             IbetStraightBondContract.set_token_attr_update(contract_address)
             IbetStraightBondContract.cache.pop(contract_address)
+        except ContractRevertError:
+            raise
         except TimeExhausted as timeout_error:
             raise SendTransactionError(timeout_error)
         except Exception as err:
@@ -684,6 +718,8 @@ class IbetStraightBondContract(IbetSecurityTokenInterface):
             # Delete Cache
             IbetStraightBondContract.set_token_attr_update(contract_address)
             IbetStraightBondContract.cache.pop(contract_address)
+        except ContractRevertError:
+            raise
         except TimeExhausted as timeout_error:
             raise SendTransactionError(timeout_error)
         except Exception as err:
@@ -850,6 +886,8 @@ class IbetShareContract(IbetSecurityTokenInterface):
             })
             try:
                 ContractUtils.send_transaction(transaction=tx, private_key=private_key)
+            except ContractRevertError:
+                raise
             except TimeExhausted as timeout_error:
                 raise SendTransactionError(timeout_error)
             except Exception as err:
@@ -866,6 +904,8 @@ class IbetShareContract(IbetSecurityTokenInterface):
             })
             try:
                 ContractUtils.send_transaction(transaction=tx, private_key=private_key)
+            except ContractRevertError:
+                raise
             except TimeExhausted as timeout_error:
                 raise SendTransactionError(timeout_error)
             except Exception as err:
@@ -885,6 +925,8 @@ class IbetShareContract(IbetSecurityTokenInterface):
             })
             try:
                 ContractUtils.send_transaction(transaction=tx, private_key=private_key)
+            except ContractRevertError:
+                raise
             except TimeExhausted as timeout_error:
                 raise SendTransactionError(timeout_error)
             except Exception as err:
@@ -901,6 +943,8 @@ class IbetShareContract(IbetSecurityTokenInterface):
             })
             try:
                 ContractUtils.send_transaction(transaction=tx, private_key=private_key)
+            except ContractRevertError:
+                raise
             except TimeExhausted as timeout_error:
                 raise SendTransactionError(timeout_error)
             except Exception as err:
@@ -917,6 +961,8 @@ class IbetShareContract(IbetSecurityTokenInterface):
             })
             try:
                 ContractUtils.send_transaction(transaction=tx, private_key=private_key)
+            except ContractRevertError:
+                raise
             except TimeExhausted as timeout_error:
                 raise SendTransactionError(timeout_error)
             except Exception as err:
@@ -933,6 +979,8 @@ class IbetShareContract(IbetSecurityTokenInterface):
             })
             try:
                 ContractUtils.send_transaction(transaction=tx, private_key=private_key)
+            except ContractRevertError:
+                raise
             except TimeExhausted as timeout_error:
                 raise SendTransactionError(timeout_error)
             except Exception as err:
@@ -949,6 +997,8 @@ class IbetShareContract(IbetSecurityTokenInterface):
             })
             try:
                 ContractUtils.send_transaction(transaction=tx, private_key=private_key)
+            except ContractRevertError:
+                raise
             except TimeExhausted as timeout_error:
                 raise SendTransactionError(timeout_error)
             except Exception as err:
@@ -965,6 +1015,8 @@ class IbetShareContract(IbetSecurityTokenInterface):
             })
             try:
                 ContractUtils.send_transaction(transaction=tx, private_key=private_key)
+            except ContractRevertError:
+                raise
             except TimeExhausted as timeout_error:
                 raise SendTransactionError(timeout_error)
             except Exception as err:
@@ -981,6 +1033,8 @@ class IbetShareContract(IbetSecurityTokenInterface):
             })
             try:
                 ContractUtils.send_transaction(transaction=tx, private_key=private_key)
+            except ContractRevertError:
+                raise
             except TimeExhausted as timeout_error:
                 raise SendTransactionError(timeout_error)
             except Exception as err:
@@ -997,6 +1051,8 @@ class IbetShareContract(IbetSecurityTokenInterface):
             })
             try:
                 ContractUtils.send_transaction(transaction=tx, private_key=private_key)
+            except ContractRevertError:
+                raise
             except TimeExhausted as timeout_error:
                 raise SendTransactionError(timeout_error)
             except Exception as err:
@@ -1013,6 +1069,8 @@ class IbetShareContract(IbetSecurityTokenInterface):
             })
             try:
                 ContractUtils.send_transaction(transaction=tx, private_key=private_key)
+            except ContractRevertError:
+                raise
             except TimeExhausted as timeout_error:
                 raise SendTransactionError(timeout_error)
             except Exception as err:
@@ -1027,6 +1085,8 @@ class IbetShareContract(IbetSecurityTokenInterface):
             })
             try:
                 ContractUtils.send_transaction(transaction=tx, private_key=private_key)
+            except ContractRevertError:
+                raise
             except TimeExhausted as timeout_error:
                 raise SendTransactionError(timeout_error)
             except Exception as err:
@@ -1043,6 +1103,8 @@ class IbetShareContract(IbetSecurityTokenInterface):
             })
             try:
                 ContractUtils.send_transaction(transaction=tx, private_key=private_key)
+            except ContractRevertError:
+                raise
             except TimeExhausted as timeout_error:
                 raise SendTransactionError(timeout_error)
             except Exception as err:
@@ -1074,6 +1136,8 @@ class IbetShareContract(IbetSecurityTokenInterface):
                 "gasPrice": 0
             })
             ContractUtils.send_transaction(transaction=tx, private_key=private_key)
+        except ContractRevertError:
+            raise
         except TimeExhausted as timeout_error:
             raise SendTransactionError(timeout_error)
         except Exception as err:
@@ -1105,6 +1169,8 @@ class IbetShareContract(IbetSecurityTokenInterface):
             # Delete Cache
             IbetShareContract.set_token_attr_update(contract_address)
             IbetShareContract.cache.pop(contract_address)
+        except ContractRevertError:
+            raise
         except TimeExhausted as timeout_error:
             raise SendTransactionError(timeout_error)
         except Exception as err:
@@ -1136,6 +1202,8 @@ class IbetShareContract(IbetSecurityTokenInterface):
             # Delete Cache
             IbetShareContract.set_token_attr_update(contract_address)
             IbetShareContract.cache.pop(contract_address)
+        except ContractRevertError:
+            raise
         except TimeExhausted as timeout_error:
             raise SendTransactionError(timeout_error)
         except Exception as err:

--- a/app/model/blockchain/token_list.py
+++ b/app/model/blockchain/token_list.py
@@ -22,7 +22,7 @@ from config import (
     CHAIN_ID,
     TX_GAS_LIMIT
 )
-from app.exceptions import SendTransactionError
+from app.exceptions import SendTransactionError, ContractRevertError
 from app.utils.contract_utils import ContractUtils
 from app.utils.web3_utils import Web3Wrapper
 
@@ -62,6 +62,8 @@ class TokenListContract:
                 })
             ContractUtils.send_transaction(transaction=tx, private_key=private_key)
 
+        except ContractRevertError:
+            raise
         except TimeExhausted as timeout_error:
             raise SendTransactionError(timeout_error)
         except Exception as err:

--- a/app/routers/bond.py
+++ b/app/routers/bond.py
@@ -111,7 +111,8 @@ from app.model.blockchain import (
 )
 from app.exceptions import (
     InvalidParameterError,
-    SendTransactionError
+    SendTransactionError,
+    ContractRevertError
 )
 from config import TZ
 
@@ -127,7 +128,7 @@ local_tz = timezone(TZ)
 @router.post(
     "/tokens",
     response_model=TokenAddressResponse,
-    responses=get_routers_responses(422, 401, SendTransactionError)
+    responses=get_routers_responses(422, 401, SendTransactionError, ContractRevertError)
 )
 def issue_token(
         request: Request,
@@ -364,7 +365,7 @@ def retrieve_token(
 @router.post(
     "/tokens/{token_address}",
     response_model=None,
-    responses=get_routers_responses(422, 401, 404, InvalidParameterError, SendTransactionError)
+    responses=get_routers_responses(422, 401, 404, InvalidParameterError, SendTransactionError, ContractRevertError)
 )
 def update_token(
         request: Request,
@@ -431,7 +432,7 @@ def update_token(
 @router.post(
     "/tokens/{token_address}/additional_issue",
     response_model=None,
-    responses=get_routers_responses(422, 401, 404, InvalidParameterError, SendTransactionError)
+    responses=get_routers_responses(422, 401, 404, InvalidParameterError, SendTransactionError, ContractRevertError)
 )
 def additional_issue(
         request: Request,
@@ -486,7 +487,7 @@ def additional_issue(
 @router.post(
     "/tokens/{token_address}/redeem",
     response_model=None,
-    responses=get_routers_responses(422, 401, 404, InvalidParameterError, SendTransactionError)
+    responses=get_routers_responses(422, 401, 404, InvalidParameterError, SendTransactionError, ContractRevertError)
 )
 def redeem_token(
         request: Request,
@@ -893,7 +894,7 @@ def retrieve_holder(
 @router.post(
     "/tokens/{token_address}/holders/{account_address}/personal_info",
     response_model=None,
-    responses=get_routers_responses(422, 401, 404, InvalidParameterError, SendTransactionError)
+    responses=get_routers_responses(422, 401, 404, InvalidParameterError, SendTransactionError, ContractRevertError)
 )
 def modify_holder_personal_info(
         request: Request,
@@ -948,7 +949,7 @@ def modify_holder_personal_info(
 @router.post(
     "/tokens/{token_address}/personal_info",
     response_model=None,
-    responses=get_routers_responses(422, 401, 404, InvalidParameterError, SendTransactionError)
+    responses=get_routers_responses(422, 401, 404, InvalidParameterError, SendTransactionError, ContractRevertError)
 )
 def register_holder_personal_info(
         request: Request,
@@ -1002,7 +1003,7 @@ def register_holder_personal_info(
 @router.post(
     "/transfers",
     response_model=None,
-    responses=get_routers_responses(422, 401, InvalidParameterError, SendTransactionError)
+    responses=get_routers_responses(422, 401, InvalidParameterError, SendTransactionError, ContractRevertError)
 )
 def transfer_ownership(
         request: Request,
@@ -1378,7 +1379,7 @@ def list_token_transfer_approval_history(
 # POST: /bond/transfer_approvals/{token_address}/{id}
 @router.post(
     "/transfer_approvals/{token_address}/{id}",
-    responses=get_routers_responses(422, 401, 404, InvalidParameterError)
+    responses=get_routers_responses(422, 401, 404, InvalidParameterError, SendTransactionError, ContractRevertError)
 )
 def update_transfer_approval(
         request: Request,

--- a/app/routers/e2e_messaging.py
+++ b/app/routers/e2e_messaging.py
@@ -84,7 +84,8 @@ from app.model.db import (
 from app.model.blockchain import E2EMessaging
 from app.exceptions import (
     InvalidParameterError,
-    SendTransactionError
+    SendTransactionError,
+    ContractRevertError
 )
 from app import log
 
@@ -100,7 +101,7 @@ utc_tz = pytz.timezone("UTC")
 @router.post(
     "/accounts",
     response_model=E2EMessagingAccountResponse,
-    responses=get_routers_responses(422, InvalidParameterError, SendTransactionError)
+    responses=get_routers_responses(422, InvalidParameterError, SendTransactionError, ContractRevertError)
 )
 def create_account(
         data: E2EMessagingAccountCreateRequest,

--- a/app/routers/share.py
+++ b/app/routers/share.py
@@ -111,7 +111,8 @@ from app.model.blockchain import (
 )
 from app.exceptions import (
     InvalidParameterError,
-    SendTransactionError
+    SendTransactionError,
+    ContractRevertError
 )
 
 router = APIRouter(
@@ -126,7 +127,7 @@ local_tz = timezone(config.TZ)
 @router.post(
     "/tokens",
     response_model=TokenAddressResponse,
-    responses=get_routers_responses(422, 401, SendTransactionError)
+    responses=get_routers_responses(422, 401, SendTransactionError, ContractRevertError)
 )
 def issue_token(
         request: Request,
@@ -173,7 +174,7 @@ def issue_token(
             tx_from=issuer_address,
             private_key=private_key
         )
-    except SendTransactionError:
+    except SendTransactionError as e:
         raise SendTransactionError("failed to send transaction")
 
     # Check need update
@@ -350,7 +351,7 @@ def retrieve_token(
 @router.post(
     "/tokens/{token_address}",
     response_model=None,
-    responses=get_routers_responses(422, 401, 404, InvalidParameterError, SendTransactionError)
+    responses=get_routers_responses(422, 401, 404, InvalidParameterError, SendTransactionError, ContractRevertError)
 )
 def update_token(
         request: Request,
@@ -417,7 +418,7 @@ def update_token(
 @router.post(
     "/tokens/{token_address}/additional_issue",
     response_model=None,
-    responses=get_routers_responses(422, 401, 404, InvalidParameterError, SendTransactionError)
+    responses=get_routers_responses(422, 401, 404, InvalidParameterError, SendTransactionError, ContractRevertError)
 )
 def additional_issue(
         request: Request,
@@ -472,7 +473,7 @@ def additional_issue(
 @router.post(
     "/tokens/{token_address}/redeem",
     response_model=None,
-    responses=get_routers_responses(422, 401, 404, InvalidParameterError, SendTransactionError)
+    responses=get_routers_responses(422, 401, 404, InvalidParameterError, SendTransactionError, ContractRevertError)
 )
 def redeem_token(
         request: Request,
@@ -879,7 +880,7 @@ def retrieve_holder(
 @router.post(
     "/tokens/{token_address}/holders/{account_address}/personal_info",
     response_model=None,
-    responses=get_routers_responses(422, 401, 404, InvalidParameterError, SendTransactionError)
+    responses=get_routers_responses(422, 401, 404, InvalidParameterError, SendTransactionError, ContractRevertError)
 )
 def modify_holder_personal_info(
         request: Request,
@@ -934,7 +935,7 @@ def modify_holder_personal_info(
 @router.post(
     "/tokens/{token_address}/personal_info",
     response_model=None,
-    responses=get_routers_responses(422, 401, 404, InvalidParameterError, SendTransactionError)
+    responses=get_routers_responses(422, 401, 404, InvalidParameterError, SendTransactionError, ContractRevertError)
 )
 def register_holder_personal_info(
         request: Request,
@@ -988,7 +989,7 @@ def register_holder_personal_info(
 @router.post(
     "/transfers",
     response_model=None,
-    responses=get_routers_responses(422, 401, 404, InvalidParameterError, SendTransactionError)
+    responses=get_routers_responses(422, 401, 404, InvalidParameterError, SendTransactionError, ContractRevertError)
 )
 def transfer_ownership(
         request: Request,
@@ -1364,7 +1365,7 @@ def list_token_transfer_approval_history(
 # POST: /share/transfer_approvals/{token_address}/{id}
 @router.post(
     "/transfer_approvals/{token_address}/{id}",
-    responses=get_routers_responses(422, 401, 404, InvalidParameterError)
+    responses=get_routers_responses(422, 401, 404, InvalidParameterError, SendTransactionError, ContractRevertError)
 )
 def update_transfer_approval(
         request: Request,
@@ -1442,45 +1443,60 @@ def update_transfer_approval(
                     "application_id": _transfer_approval.application_id,
                     "data": now
                 }
-                _, tx_receipt = IbetShareContract.approve_transfer(
-                    contract_address=token_address,
-                    data=IbetSecurityTokenApproveTransfer(**_data),
-                    tx_from=issuer_address,
-                    private_key=private_key,
-                )
-                if tx_receipt["status"] != 1:  # Success
-                    IbetShareContract.cancel_transfer(
+                try:
+                    _, tx_receipt = IbetShareContract.approve_transfer(
                         contract_address=token_address,
-                        data=IbetSecurityTokenCancelTransfer(**_data),
+                        data=IbetSecurityTokenApproveTransfer(**_data),
                         tx_from=issuer_address,
                         private_key=private_key,
                     )
-                    raise SendTransactionError
+                except ContractRevertError:
+                    # If approveTransfer end with revert,
+                    # cancelTransfer should be performed immediately.
+                    try:
+                        IbetShareContract.cancel_transfer(
+                            contract_address=token_address,
+                            data=IbetSecurityTokenCancelTransfer(**_data),
+                            tx_from=issuer_address,
+                            private_key=private_key,
+                        )
+                    except ContractRevertError:
+                        raise
+                    except Exception:
+                        raise SendTransactionError
             else:
                 _data = {
                     "escrow_id": _transfer_approval.application_id,
                     "data": now
                 }
                 escrow = IbetSecurityTokenEscrow(_transfer_approval.exchange_address)
-                _, tx_receipt = escrow.approve_transfer(
-                    data=IbetSecurityTokenEscrowApproveTransfer(**_data),
-                    tx_from=issuer_address,
-                    private_key=private_key,
-                )
-                if tx_receipt["status"] != 1:  # Success
+                try:
+                    _, tx_receipt = escrow.approve_transfer(
+                        data=IbetSecurityTokenEscrowApproveTransfer(**_data),
+                        tx_from=issuer_address,
+                        private_key=private_key,
+                    )
+                except ContractRevertError:
+                    # If approveTransfer end with revert, error should be thrown immediately.
+                    raise
+                except Exception:
                     raise SendTransactionError
         else:  # CANCEL
             _data = {
                 "application_id": _transfer_approval.application_id,
                 "data": now
             }
-            _, tx_receipt = IbetShareContract.cancel_transfer(
-                contract_address=token_address,
-                data=IbetSecurityTokenCancelTransfer(**_data),
-                tx_from=issuer_address,
-                private_key=private_key,
-            )
-            if tx_receipt["status"] != 1:  # Success
+            try:
+                _, tx_receipt = IbetShareContract.cancel_transfer(
+                    contract_address=token_address,
+                    data=IbetSecurityTokenCancelTransfer(**_data),
+                    tx_from=issuer_address,
+                    private_key=private_key,
+                )
+            except ContractRevertError:
+                # If cancelTransfer end with revert, error should be thrown immediately.
+                raise
+            except Exception:
                 raise SendTransactionError
     except SendTransactionError:
         raise SendTransactionError("failed to send transaction")

--- a/app/routers/share.py
+++ b/app/routers/share.py
@@ -1450,9 +1450,10 @@ def update_transfer_approval(
                         tx_from=issuer_address,
                         private_key=private_key,
                     )
-                except ContractRevertError:
+                except ContractRevertError as approve_transfer_err:
                     # If approveTransfer end with revert,
                     # cancelTransfer should be performed immediately.
+                    # After cancelTransfer, ContractRevertError is returned.
                     try:
                         IbetShareContract.cancel_transfer(
                             contract_address=token_address,
@@ -1460,10 +1461,12 @@ def update_transfer_approval(
                             tx_from=issuer_address,
                             private_key=private_key,
                         )
-                    except ContractRevertError:
+                    except ContractRevertError as cancel_transfer_err:
                         raise
                     except Exception:
                         raise SendTransactionError
+                    # If cancel transfer is successful, approve_transfer error is raised.
+                    raise
             else:
                 _data = {
                     "escrow_id": _transfer_approval.application_id,

--- a/app/utils/contract_error_code.py
+++ b/app/utils/contract_error_code.py
@@ -1,0 +1,191 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+from typing import Tuple
+
+
+def error_code_msg(code_str: str) -> Tuple[int, str]:
+    """Retrieve contract error message from error code.
+
+    :param code_str: error code thrown by contract
+    :return: [error_code, error_message]
+    """
+    if not code_str.isdigit():
+        # If contract doesn't throw error code,
+        # consider the raw message as an error log.
+        return 999999, code_str
+
+    code = int(code_str)
+    return code, {
+        # TokenList (10XXXX)
+        100001: "The address has already been registered.",
+        100002: "Message sender must be the token owner.",
+        100101: "The address has not been registered.",
+        100102: "Message sender must be the token owner.",
+        # IbetShare (11XXXX)
+        110001:	"Lock address is invalid.",
+        110002: "Lock amount is greater than message sender balance.",
+        110101: "Unlock address is invalid.",
+        110102: "Unlock amount is greater than locked amount.",
+        110201: "The token isn't transferable.",
+        110202: "Destination address check is failed.",
+        110301: "Destination address isn't tradable exchange.",
+        110401: "Message sender balance is insufficient.",
+        110402: "The token isn't transferable.",
+        110501: "Transferring of this token requires approval.",
+        110502: "Length of To and of Value aren't matched.",
+        110503: "Transfer amount is greater than from address balance.",
+        110504: "The token isn't transferable.",
+        110601: "Transfer amount is greater than from address balance.",
+        110701: "Apply for transfer is invalid.",
+        110702: "Destination address check is failed.",
+        110801: "Canceling application for transfer is invalid.",
+        110802: "Application is invalid.",
+        110901: "Token isn't transferable.",
+        110902: "Application is invalid.",
+        111001: "Offering is stopped.",
+        111002: "Personal information of message sender isn't registered to token owner.",
+        111101: "Redeem amount is less than locked address balance.",
+        111102: "Redeem amount is less than target address balance.",
+        # IbetStraightBond (12XXXX)
+        120001: "Lock address is invalid.",
+        120002: "Lock amount is greater than message sender balance.",
+        120101: "Unlock address is invalid.",
+        120102: "Unlock amount is greater than locked amount.",
+        120201: "The token isn't transferable.",
+        120202: "Destination address check is failed.",
+        120301: "Destination address isn't tradable exchange.",
+        120401: "Message sender balance is insufficient.",
+        120402: "The token isn't transferable.",
+        120501: "Length of To and of Value aren't matched.",
+        120502: "Transfer amount is greater than from address balance.",
+        120503: "The token isn't transferable.",
+        120601: "Transfer amount is greater than from address balance.",
+        120701: "Apply for transfer is invalid.",
+        120702: "Destination address check is failed.",
+        120801: "Canceling application for transfer is invalid.",
+        120802: "Application is invalid.",
+        120901: "Token isn't transferable.",
+        120902: "Application is invalid.",
+        121001: "Offering is stopped.",
+        121002: "Personal information of message sender isn't registered to token owner.",
+        121101: "Redeem amount is less than locked address balance.",
+        121102: "Redeem amount is less than target address balance.",
+        # IbetCoupon (13XXXX)
+        130001: "Destination address isn't tradable exchange.",
+        130101: "Message sender balance is insufficient.",
+        130102: "The token isn't transferable.",
+        130201: "Length of To and of Value aren't matched.",
+        130202: "Transfer amount is greater than from address balance.",
+        130203: "The token isn't transferable.",
+        130301: "Transfer amount is greater than from address balance.",
+        130401: "Message sender balance is insufficient.",
+        130501: "Offering is stopped.",
+        130502: "Personal information of message sender isn't registered to token owner.",
+        # IbetMembership (14XXXX)
+        140001: "Destination address isn't tradable exchange.",
+        140101: "Message sender balance is insufficient.",
+        140102: "The token isn't transferable.",
+        140201: "Length of To and of Value aren't matched.",
+        140202: "Transfer amount is greater than from address balance.",
+        140203: "The token isn't transferable.",
+        140301: "Transfer amount is greater than from address balance.",
+        140401: "Offering is stopped.",
+        140402: "Personal information of message sender isn't registered to token owner.",
+        # IbetStandardToken (15XXXX)
+        150001: "Destination address isn't tradable exchange.",
+        150101: "Message sender balance is insufficient.",
+        150201: "Length of To and of Value aren't matched.",
+        150202: "Transfer amount is greater than from address balance.",
+        150301: "Transfer amount is greater than from address balance.",
+        # ExchangeStorage (20XXXX)
+        200001: "Message sender(exchange contract) isn't latest version.",
+        # IbetExchange (21XXXX)
+        210001: "Create order condition is invalid.",
+        210101: "Cancel order ID is invalid.",
+        210102: "Amount of target order is remaining.",
+        210103: "Order has already been canceled.",
+        210104: "Message sender is not the order owner.",
+        210201: "Cancel order ID is invalid.",
+        210202: "Amount of target order is remaining.",
+        210203: "Order has already been canceled.",
+        210204: "Message sender is not the order agent.",
+        210301: "Target order ID is invalid.",
+        210302: "Execute order condition is invalid.",
+        210401: "Target order ID is invalid.",
+        210402: "Target agreement ID is invalid.",
+        210403: "Agreement condition is invalid.",
+        210501: "Target order ID is invalid.",
+        210502: "Target agreement ID is invalid.",
+        210503: "Expired agreement condition is invalid.",
+        210504: "Unexpired agreement condition is invalid.",
+        210601: "Message sender balance is insufficient.",
+        220001: "Message sender(exchange contract) isn't latest version.",
+        # IbetEscrow (23XXXX)
+        230001: "Escrow amount is 0.",
+        230002: "Message sender balance is insufficient.",
+        230003: "Token status of escrow is inactive.",
+        230101: "Target escrow ID is invalid.",
+        230102: "Target escrow status is invalid.",
+        230103: "Message sender is not escrow sender and escrow agent.",
+        230104: "Token status of escrow is inactive.",
+        230201: "Target escrow ID is invalid.",
+        230202: "Target escrow status is invalid.",
+        230203: "Message sender is not escrow agent.",
+        230204: "Token status of escrow is inactive.",
+        230301: "Message sender balance is insufficient.",
+        # IbetSecurityTokenEscrow (24XXXX)
+        240001: "Escrow amount is 0.",
+        240002: "Message sender balance is insufficient.",
+        240003: "Token status of escrow is inactive.",
+        240101: "Target escrow ID is invalid.",
+        240102: "Target escrow status is invalid.",
+        240103: "Message sender is not escrow sender and escrow agent.",
+        240104: "Token status of escrow is inactive.",
+        240201: "Application doesn't exist.",
+        240202: "Message sender is not token owner.",
+        240203: "Target escrow status is invalid.",
+        240204: "Target escrow status has not been finished.",
+        240205: "Token status of escrow is inactive.",
+        240301: "Target escrow ID is invalid.",
+        240302: "Target escrow status is invalid.",
+        240303: "Message sender is not escrow agent.",
+        240304: "Token status of escrow is inactive.",
+        240401: "Message sender balance is insufficient.",
+        # PaymentGateway (30XXXX)
+        300001: "Payment account is banned.",
+        300101: "Target account address is not registered.",
+        300201: "Target account address is not registered.",
+        300301: "Target account address is not registered.",
+        300401: "Target account address is not registered.",
+        300501: "Target account address is not registered.",
+        # PersonalInfo (40XXXX)
+        400001: "Target account address is not registered.",
+        400002: "Target account address is not linked to message sender.",
+        # Ownable (50XXXX)
+        500001: "Message sender is not contract owner.",
+        500101: "New owner address is not set.",
+        # ContractRegistry (60XXXX)
+        600001: "Target address is not contract address.",
+        600002: "Message sender is not contract owner.",
+        # E2EMessaging (61XXXX)
+        610001: "E2E Message for message owner doesn't exist.",
+        610011: "Message sender is not E2E Message sender.",
+        # FreezeLog (62XXXX)
+        620001: "Log is frozen.",
+    }.get(code, "")

--- a/app/utils/docs_utils.py
+++ b/app/utils/docs_utils.py
@@ -181,7 +181,7 @@ def get_routers_responses(*args):
     responses = {}
     for arg in args:
         if isinstance(arg, int):
-                responses[arg] = DEFAULT_RESPONSE.get(arg, {})
+            responses[arg] = DEFAULT_RESPONSE.get(arg, {})
         elif arg == InvalidParameterError:
             responses[400] = DEFAULT_RESPONSE[400]
         elif arg == SendTransactionError:

--- a/app/utils/docs_utils.py
+++ b/app/utils/docs_utils.py
@@ -19,6 +19,7 @@ SPDX-License-Identifier: Apache-2.0
 from typing import (
     List,
     Dict,
+    Union,
     Any
 )
 
@@ -30,7 +31,8 @@ from app.exceptions import (
     InvalidParameterError,
     SendTransactionError,
     AuthorizationError,
-    ServiceUnavailableError
+    ServiceUnavailableError,
+    ContractRevertError
 )
 
 
@@ -44,13 +46,23 @@ class Error400MetaModel(MetaModel):
         @staticmethod
         def schema_extra(schema: Dict[str, Any], _) -> None:
             properties = schema["properties"]
-            properties["code"]["example"] = 1
-            properties["title"]["example"] = "InvalidParameterError"
+            properties["code"]["examples"] = [0, 1, 2, 100001]
+            properties["title"]["examples"] = ["InvalidParameterError", "SendTransactionError", "ContractRevertError"]
 
 
 class Error400Model(BaseModel):
     meta: Error400MetaModel
     detail: str
+
+    class Config:
+        @staticmethod
+        def schema_extra(schema: Dict[str, Any], _) -> None:
+            properties = schema["properties"]
+            properties["detail"]["examples"] = [
+                "wait for a while as the token is being processed",
+                "failed to register token address token list",
+                "The address has already been registered."
+            ]
 
 
 class Error401MetaModel(MetaModel):
@@ -139,7 +151,7 @@ class Error503Model(BaseModel):
 
 DEFAULT_RESPONSE = {
     400: {
-        "description": "Invalid Parameter Error / Send Transaction Error",
+        "description": "Invalid Parameter Error / Send Transaction Error / Contract Revert Error",
         "model": Error400Model
     },
     401: {
@@ -169,10 +181,12 @@ def get_routers_responses(*args):
     responses = {}
     for arg in args:
         if isinstance(arg, int):
-            responses[arg] = DEFAULT_RESPONSE.get(arg, {})
+                responses[arg] = DEFAULT_RESPONSE.get(arg, {})
         elif arg == InvalidParameterError:
             responses[400] = DEFAULT_RESPONSE[400]
         elif arg == SendTransactionError:
+            responses[400] = DEFAULT_RESPONSE[400]
+        elif arg == ContractRevertError:
             responses[400] = DEFAULT_RESPONSE[400]
         elif arg == AuthorizationError:
             responses[401] = DEFAULT_RESPONSE[401]

--- a/batch/processor_auto_transfer_approval.py
+++ b/batch/processor_auto_transfer_approval.py
@@ -252,11 +252,11 @@ class Processor:
                 if tx_receipt["status"] == 1:  # Success
                     result = 1
             except ContractRevertError as e:
-                LOG.warning(f"Transaction reverted: "
-                            f"token_address={application.token_address} "
-                            f"exchange_address={application.exchange_address} "
-                            f"application_id={application.application_id} "
-                            f"error_code:<{e.code}> error_msg:<{e.message}>")
+                LOG.error(f"Transaction reverted: "
+                          f"token_address={application.token_address} "
+                          f"exchange_address={application.exchange_address} "
+                          f"application_id={application.application_id} "
+                          f"error_code:<{e.code}> error_msg:<{e.message}>")
                 result = 2
 
             self.__sink_on_transfer_approval_history(

--- a/batch/processor_auto_transfer_approval.py
+++ b/batch/processor_auto_transfer_approval.py
@@ -54,7 +54,8 @@ from app.model.schema import (
 )
 from app.exceptions import (
     SendTransactionError,
-    ServiceUnavailableError
+    ServiceUnavailableError,
+    ContractRevertError
 )
 import batch_log
 
@@ -177,15 +178,25 @@ class Processor:
                 "application_id": application.application_id,
                 "data": now
             }
-            tx_hash, tx_receipt = IbetSecurityTokenInterface.approve_transfer(
-                contract_address=application.token_address,
-                data=IbetSecurityTokenApproveTransfer(**_data),
-                tx_from=issuer_address,
-                private_key=private_key
-            )
-            if tx_receipt["status"] == 1:  # Success
-                result = 1
-            else:
+            result = 2
+            try:
+                # If approveTransfer end with revert,
+                # cancelTransfer should be performed immediately.
+                # After cancelTransfer, result is saved as 2(failed).
+                tx_hash, tx_receipt = IbetSecurityTokenInterface.approve_transfer(
+                    contract_address=application.token_address,
+                    data=IbetSecurityTokenApproveTransfer(**_data),
+                    tx_from=issuer_address,
+                    private_key=private_key
+                )
+                if tx_receipt["status"] == 1:  # Success
+                    result = 1
+            except ContractRevertError as e:
+                LOG.warning(f"Transaction reverted: "
+                            f"token_address={application.token_address} "
+                            f"exchange_address={application.exchange_address} "
+                            f"application_id={application.application_id} "
+                            f"error_code:<{e.code}> error_msg:<{e.message}>")
                 IbetSecurityTokenInterface.cancel_transfer(
                     contract_address=application.token_address,
                     data=IbetSecurityTokenCancelTransfer(**_data),
@@ -205,6 +216,13 @@ class Processor:
                 application_id=application.application_id,
                 result=result
             )
+        except ContractRevertError as e:
+            # If cancelTransfer end with revert, then logs output.
+            LOG.warning(f"Transaction reverted: "
+                        f"token_address={application.token_address} "
+                        f"exchange_address={application.exchange_address} "
+                        f"application_id={application.application_id} "
+                        f"error_code:<{e.code}> error_msg:<{e.message}>")
         except SendTransactionError:
             LOG.warning(f"Failed to send transaction: "
                         f"token_address={application.token_address} "
@@ -223,19 +241,23 @@ class Processor:
                 "data": now
             }
             _escrow = IbetSecurityTokenEscrow(application.exchange_address)
-            tx_hash, tx_receipt = _escrow.approve_transfer(
-                data=IbetSecurityTokenEscrowApproveTransfer(**_data),
-                tx_from=issuer_address,
-                private_key=private_key
-            )
-            if tx_receipt["status"] == 1:  # Success
-                result = 1
-            else:
+            result = 2
+            try:
+                # If approveTransfer end with revert, result is saved as 2(failed).
+                tx_hash, tx_receipt = _escrow.approve_transfer(
+                    data=IbetSecurityTokenEscrowApproveTransfer(**_data),
+                    tx_from=issuer_address,
+                    private_key=private_key
+                )
+                if tx_receipt["status"] == 1:  # Success
+                    result = 1
+            except ContractRevertError as e:
+                LOG.warning(f"Transaction reverted: "
+                            f"token_address={application.token_address} "
+                            f"exchange_address={application.exchange_address} "
+                            f"application_id={application.application_id} "
+                            f"error_code:<{e.code}> error_msg:<{e.message}>")
                 result = 2
-                LOG.error(f"Failed to send transaction: "
-                          f"token_address={application.token_address} "
-                          f"exchange_address={application.exchange_address} "
-                          f"application_id={application.application_id}")
 
             self.__sink_on_transfer_approval_history(
                 db_session=db_session,

--- a/batch/processor_bulk_transfer.py
+++ b/batch/processor_bulk_transfer.py
@@ -57,7 +57,8 @@ from app.model.schema import (
 from app.utils.web3_utils import Web3Wrapper
 from app.exceptions import (
     SendTransactionError,
-    ServiceUnavailableError
+    ServiceUnavailableError,
+    ContractRevertError
 )
 import batch_log
 
@@ -165,6 +166,13 @@ class Processor:
                             db_session=db_session,
                             record_id=_transfer.id,
                             status=1
+                        )
+                    except ContractRevertError as e:
+                        LOG.warning(f"Transaction reverted: id=<{_transfer.id}> error_code:<{e.code}> error_msg:<{e.message}>")
+                        self.__sink_on_finish_transfer_process(
+                            db_session=db_session,
+                            record_id=_transfer.id,
+                            status=2
                         )
                     except SendTransactionError:
                         LOG.warning(f"Failed to send transaction: id=<{_transfer.id}>")

--- a/tests/model/blockchain/test_PersonalInfo.py
+++ b/tests/model/blockchain/test_PersonalInfo.py
@@ -25,14 +25,14 @@ from Crypto.PublicKey import RSA
 from eth_keyfile import decode_keyfile_json
 from web3 import Web3
 from web3.middleware import geth_poa_middleware
-from web3.exceptions import TimeExhausted
+from web3.exceptions import TimeExhausted, ContractLogicError
 from unittest.mock import MagicMock
 from unittest import mock
 
 from config import WEB3_HTTP_PROVIDER, TX_GAS_LIMIT, CHAIN_ID
 from app.model.blockchain import PersonalInfoContract
 from app.utils.contract_utils import ContractUtils
-from app.exceptions import SendTransactionError
+from app.exceptions import SendTransactionError, ContractRevertError
 from app.model.db import Account
 from app.utils.e2ee_utils import E2EEUtils
 
@@ -356,7 +356,7 @@ class TestRegisterInfo:
             with pytest.raises(SendTransactionError):
                 personal_info_contract.register_info(setting_user["address"], register_data)
 
-    # <Error_1>
+    # <Error_2>
     # SendTransactionError(Other Error)
     def test_error_2(self, db):
         issuer = config_eth_account("user1")
@@ -376,7 +376,13 @@ class TestRegisterInfo:
         }
         with mock.patch("web3.eth.Eth.waitForTransactionReceipt", MagicMock(side_effect=TypeError())):
             with pytest.raises(SendTransactionError):
-                personal_info_contract.modify_info(setting_user["address"], register_data)
+                personal_info_contract.register_info(setting_user["address"], register_data)
+
+    # <Error_3>
+    # Transaction REVERT
+    def test_error_3(self, db):
+        # Transaction REVERT would not occur in PersonalInfo_register
+        pass
 
 
 class TestModifyInfo:
@@ -494,7 +500,7 @@ class TestModifyInfo:
             with pytest.raises(SendTransactionError):
                 personal_info_contract.modify_info(setting_user["address"], update_data)
 
-    # <Error_1>
+    # <Error_2>
     # SendTransactionError(Other Error)
     def test_error_2(self, db):
         issuer = config_eth_account("user1")
@@ -545,6 +551,41 @@ class TestModifyInfo:
         with mock.patch("web3.eth.Eth.waitForTransactionReceipt", MagicMock(side_effect=TypeError())):
             with pytest.raises(SendTransactionError):
                 personal_info_contract.modify_info(setting_user["address"], update_data)
+
+    # <Error_3>
+    # Transaction REVERT(not registered)
+    def test_error_3(self, db):
+        issuer = config_eth_account("user1")
+        personal_info_contract = initialize(issuer, db)
+
+        # Set personal information data
+        setting_user = config_eth_account("user2")
+
+        # Run Test
+        update_data = {
+            "key_manager": "0987654321",
+            "name": "name_test2",
+            "postal_code": "2002000",
+            "address": "テスト住所2",
+            "email": "sample@test.test2",
+            "birth": "19800101",
+            "is_corporate": False,
+            "tax_category": 10
+        }
+
+        # mock
+        # NOTE: Ganacheがrevertする際にweb3.pyからraiseされるExceptionはGethと異なる
+        #         ganache: ValueError({'message': 'VM Exception while processing transaction: revert',...})
+        #         geth: ContractLogicError("execution reverted")
+        InspectionMock = mock.patch(
+            "web3.eth.Eth.call",
+            MagicMock(side_effect=ContractLogicError("execution reverted"))
+        )
+        # test IbetSecurityTokenEscrow.approve_transfer
+        with InspectionMock, pytest.raises(ContractRevertError) as exc_info:
+            personal_info_contract.modify_info(setting_user["address"], update_data)
+
+        assert exc_info.value.args[0] == "execution reverted"
 
 
 class TestGetRegisterEvent:

--- a/tests/model/blockchain/test_token_IbetShare.py
+++ b/tests/model/blockchain/test_token_IbetShare.py
@@ -24,12 +24,12 @@ from datetime import datetime
 
 from pydantic.error_wrappers import ValidationError
 from eth_keyfile import decode_keyfile_json
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 from web3.exceptions import (
     InvalidAddress,
     TimeExhausted,
     TransactionNotFound,
-    ValidationError as Web3ValidationError
+    ValidationError as Web3ValidationError, ContractLogicError
 )
 
 from config import ZERO_ADDRESS
@@ -44,7 +44,7 @@ from app.model.schema import (
     IbetSecurityTokenApproveTransfer,
     IbetSecurityTokenCancelTransfer
 )
-from app.exceptions import SendTransactionError
+from app.exceptions import SendTransactionError, ContractRevertError
 
 from tests.account_config import config_eth_account
 from tests.utils.contract_utils import (
@@ -983,6 +983,65 @@ class TestUpdate:
         # assertion
         assert isinstance(exc_info.value.args[0], TransactionNotFound)
 
+    # <Error_10>
+    # Transaction REVERT(not owner)
+    def test_error_10(self, db):
+        test_account = config_eth_account("user1")
+        issuer_address = test_account.get("address")
+        user_account = config_eth_account("user2")
+        user_address = user_account.get("address")
+        private_key = decode_keyfile_json(
+            raw_keyfile_json=test_account.get("keyfile_json"),
+            password=test_account.get("password").encode("utf-8")
+        )
+        user_private_key = decode_keyfile_json(
+            raw_keyfile_json=user_account.get("keyfile_json"),
+            password=user_account.get("password").encode("utf-8")
+        )
+
+        # deploy token
+        arguments = [
+            "テスト株式",
+            "TEST",
+            10000,
+            20000,
+            1,
+            "20211231",
+            "20211231",
+            "20221231",
+            10000
+        ]
+        contract_address, abi, tx_hash = IbetShareContract.create(
+            args=arguments,
+            tx_from=issuer_address,
+            private_key=private_key
+        )
+
+        # mock
+        # NOTE: Ganacheがrevertする際にweb3.pyからraiseされるExceptionはGethと異なる
+        #         ganache: ValueError({'message': 'VM Exception while processing transaction: revert',...})
+        #         geth: ContractLogicError("execution reverted")
+        InspectionMock = mock.patch(
+            "web3.eth.Eth.call",
+            MagicMock(side_effect=ContractLogicError("execution reverted: 500001"))
+        )
+
+        # update
+        _data = {
+            "cancellation_date": "20211231"
+        }
+        _add_data = IbetShareUpdate(**_data)
+        with InspectionMock, pytest.raises(ContractRevertError) as exc_info:
+            IbetShareContract.update(
+                contract_address=contract_address,
+                data=_add_data,
+                tx_from=user_address,
+                private_key=user_private_key
+            )
+
+        # assertion
+        assert exc_info.value.args[0] == "Message sender is not contract owner."
+
 
 class TestTransfer:
 
@@ -1336,6 +1395,65 @@ class TestTransfer:
                     private_key=private_key
                 )
         assert isinstance(exc_info.value.args[0], TransactionNotFound)
+
+    # <Error_8>
+    # Transaction REVERT(insufficient balance)
+    def test_error_8(self, db):
+        test_account = config_eth_account("user1")
+        issuer_address = test_account.get("address")
+        private_key = decode_keyfile_json(
+            raw_keyfile_json=test_account.get("keyfile_json"),
+            password=test_account.get("password").encode("utf-8")
+        )
+
+        to_account = config_eth_account("user2")
+        to_address = to_account.get("address")
+
+        # deploy token
+        arguments = [
+            "テスト株式",
+            "TEST",
+            10000,
+            20000,
+            1,
+            "20211231",
+            "20211231",
+            "20221231",
+            10000
+        ]
+        contract_address, abi, tx_hash = IbetShareContract.create(
+            args=arguments,
+            tx_from=issuer_address,
+            private_key=private_key
+        )
+
+        # transfer with insufficient balance
+        _data = {
+            "token_address": contract_address,
+            "from_address": issuer_address,
+            "to_address": to_address,
+            "amount": 10000000
+        }
+        _transfer_data = IbetShareTransfer(**_data)
+
+        # mock
+        # NOTE: Ganacheがrevertする際にweb3.pyからraiseされるExceptionはGethと異なる
+        #         ganache: ValueError({'message': 'VM Exception while processing transaction: revert',...})
+        #         geth: ContractLogicError("execution reverted: ")
+        InspectionMock = mock.patch(
+            "web3.eth.Eth.call",
+            MagicMock(side_effect=ContractLogicError("execution reverted: 110401"))
+        )
+
+        with InspectionMock, pytest.raises(ContractRevertError) as exc_info:
+            IbetShareContract.transfer(
+                data=_transfer_data,
+                tx_from=issuer_address,
+                private_key=private_key
+            )
+
+        # assertion
+        assert exc_info.value.args[0] == "Message sender balance is insufficient."
 
 
 class TestAdditionalIssue:
@@ -1703,6 +1821,68 @@ class TestAdditionalIssue:
                 )
         assert isinstance(exc_info.value.args[0], TransactionNotFound)
 
+    # <Error_9>
+    # Transaction REVERT(not owner)
+    def test_error_9(self, db):
+        test_account = config_eth_account("user1")
+        issuer_address = test_account.get("address")
+        user_account = config_eth_account("user2")
+        user_address = user_account.get("address")
+        issuer_private_key = decode_keyfile_json(
+            raw_keyfile_json=test_account.get("keyfile_json"),
+            password=test_account.get("password").encode("utf-8")
+        )
+        user_private_key = decode_keyfile_json(
+            raw_keyfile_json=user_account.get("keyfile_json"),
+            password=user_account.get("password").encode("utf-8")
+        )
+
+        # deploy token
+        arguments = [
+            "テスト株式",
+            "TEST",
+            10000,
+            20000,
+            1,
+            "20211231",
+            "20211231",
+            "20221231",
+            10000
+        ]
+        contract_address, abi, tx_hash = IbetShareContract.create(
+            args=arguments,
+            tx_from=issuer_address,
+            private_key=issuer_private_key
+        )
+
+        # additional issue
+        _data = {
+            "account_address": issuer_address,
+            "amount": 10
+        }
+        _add_data = IbetShareAdditionalIssue(**_data)
+        pre_datetime = datetime.utcnow()
+
+        # mock
+        # NOTE: Ganacheがrevertする際にweb3.pyからraiseされるExceptionはGethと異なる
+        #         ganache: ValueError({'message': 'VM Exception while processing transaction: revert',...})
+        #         geth: ContractLogicError("execution reverted")
+        InspectionMock = mock.patch(
+            "web3.eth.Eth.call",
+            MagicMock(side_effect=ContractLogicError("execution reverted: 500001"))
+        )
+
+        with InspectionMock, pytest.raises(ContractRevertError) as exc_info:
+            IbetShareContract.additional_issue(
+                contract_address=contract_address,
+                data=_add_data,
+                tx_from=user_address,
+                private_key=user_private_key
+            )
+
+        # assertion
+        assert exc_info.value.args[0] == "Message sender is not contract owner."
+
 
 class TestRedeem:
 
@@ -2068,6 +2248,62 @@ class TestRedeem:
                     private_key=private_key
                 )
         assert isinstance(exc_info.value.args[0], TransactionNotFound)
+
+    # <Error_9>
+    # Transaction REVERT(lack balance)
+    def test_error_9(self, db):
+        test_account = config_eth_account("user1")
+        issuer_address = test_account.get("address")
+        private_key = decode_keyfile_json(
+            raw_keyfile_json=test_account.get("keyfile_json"),
+            password=test_account.get("password").encode("utf-8")
+        )
+
+        # deploy token
+        arguments = [
+            "テスト株式",
+            "TEST",
+            10000,
+            20000,
+            1,
+            "20211231",
+            "20211231",
+            "20221231",
+            10000
+        ]
+        contract_address, abi, tx_hash = IbetShareContract.create(
+            args=arguments,
+            tx_from=issuer_address,
+            private_key=private_key
+        )
+
+        # redeem
+        _data = {
+            "account_address": issuer_address,
+            "amount": 100_000_000
+        }
+        _add_data = IbetShareRedeem(**_data)
+        pre_datetime = datetime.utcnow()
+
+        # mock
+        # NOTE: Ganacheがrevertする際にweb3.pyからraiseされるExceptionはGethと異なる
+        #         ganache: ValueError({'message': 'VM Exception while processing transaction: revert',...})
+        #         geth: ContractLogicError("execution reverted")
+        InspectionMock = mock.patch(
+            "web3.eth.Eth.call",
+            MagicMock(side_effect=ContractLogicError("execution reverted: 111102"))
+        )
+
+        with InspectionMock, pytest.raises(ContractRevertError) as exc_info:
+            IbetShareContract.redeem(
+                contract_address=contract_address,
+                data=_add_data,
+                tx_from=issuer_address,
+                private_key=private_key
+            )
+
+        # assertion
+        assert exc_info.value.args[0] == "Redeem amount is less than target address balance."
 
 
 class TestGetAccountBalance:
@@ -2567,6 +2803,121 @@ class TestApproveTransfer:
             )
         assert ex_info.match("Non-hexadecimal digit found")
 
+    # <Error_5>
+    # Transaction REVERT(application invalid)
+    def test_error_5(self, db):
+        issuer = config_eth_account("user1")
+        issuer_address = issuer.get("address")
+        issuer_pk = decode_keyfile_json(
+            raw_keyfile_json=issuer.get("keyfile_json"),
+            password=issuer.get("password").encode("utf-8")
+        )
+
+        to_account = config_eth_account("user2")
+        to_address = to_account.get("address")
+        to_pk = decode_keyfile_json(
+            raw_keyfile_json=to_account.get("keyfile_json"),
+            password=to_account.get("password").encode("utf-8")
+        )
+
+        deployer = config_eth_account("user3")
+        deployer_address = deployer.get("address")
+        deployer_pk = decode_keyfile_json(
+            raw_keyfile_json=deployer.get("keyfile_json"),
+            password=deployer.get("password").encode("utf-8")
+        )
+
+        # deploy new personal info contract (from deployer)
+        personal_info_contract_address, _, _ = ContractUtils.deploy_contract(
+            contract_name="PersonalInfo",
+            args=[],
+            deployer=deployer_address,
+            private_key=deployer_pk
+        )
+
+        # deploy token
+        arguments = [
+            "テスト株式",
+            "TEST",
+            10000,
+            20000,
+            1,
+            "20211231",
+            "20211231",
+            "20221231",
+            10000
+        ]
+
+        token_address, _, _ = IbetShareContract.create(
+            args=arguments,
+            tx_from=issuer_address,
+            private_key=issuer_pk
+        )
+
+        # update token (from issuer)
+        update_data = {
+            "personal_info_contract_address": personal_info_contract_address,
+            "transfer_approval_required": True,
+            "transferable": True
+        }
+        IbetShareContract.update(
+            contract_address=token_address,
+            data=IbetShareUpdate(**update_data),
+            tx_from=issuer_address,
+            private_key=issuer_pk
+        )
+
+        # register personal info (to_account)
+        PersonalInfoContractTestUtils.register(
+            contract_address=personal_info_contract_address,
+            tx_from=to_address,
+            private_key=to_pk,
+            args=[issuer_address, "test_personal_info"]
+        )
+
+        # apply transfer (from issuer)
+        IbetSecurityTokenContractTestUtils.apply_for_transfer(
+            contract_address=token_address,
+            tx_from=issuer_address,
+            private_key=issuer_pk,
+            args=[to_address, 10, "test_data"]
+        )
+
+        # approve transfer (from issuer)
+        approve_data = {
+            "application_id": 0,
+            "data": "approve transfer test"
+        }
+        IbetShareContract.approve_transfer(
+            contract_address=token_address,
+            data=IbetSecurityTokenApproveTransfer(**approve_data),
+            tx_from=issuer_address,
+            private_key=issuer_pk
+        )
+
+        # Then send approveTransfer transaction again.
+        # This would be failed.
+
+        # mock
+        # NOTE: Ganacheがrevertする際にweb3.pyからraiseされるExceptionはGethと異なる
+        #         ganache: ValueError({'message': 'VM Exception while processing transaction: revert',...})
+        #         geth: ContractLogicError("execution reverted")
+        InspectionMock = mock.patch(
+            "web3.eth.Eth.call",
+            MagicMock(side_effect=ContractLogicError("execution reverted: 120902"))
+        )
+
+        with InspectionMock, pytest.raises(ContractRevertError) as exc_info:
+            IbetShareContract.approve_transfer(
+                contract_address=token_address,
+                data=IbetSecurityTokenApproveTransfer(**approve_data),
+                tx_from=issuer_address,
+                private_key=issuer_pk
+            )
+
+        # assertion
+        assert exc_info.value.args[0] == "Application is invalid."
+
 
 class TestCancelTransfer:
 
@@ -2823,3 +3174,118 @@ class TestCancelTransfer:
                 private_key="dummy-private"
             )
         assert ex_info.match("Non-hexadecimal digit found")
+
+    # <Error_5>
+    # Transaction REVERT(application invalid)
+    def test_error_5(self, db):
+        issuer = config_eth_account("user1")
+        issuer_address = issuer.get("address")
+        issuer_pk = decode_keyfile_json(
+            raw_keyfile_json=issuer.get("keyfile_json"),
+            password=issuer.get("password").encode("utf-8")
+        )
+
+        to_account = config_eth_account("user2")
+        to_address = to_account.get("address")
+        to_pk = decode_keyfile_json(
+            raw_keyfile_json=to_account.get("keyfile_json"),
+            password=to_account.get("password").encode("utf-8")
+        )
+
+        deployer = config_eth_account("user3")
+        deployer_address = deployer.get("address")
+        deployer_pk = decode_keyfile_json(
+            raw_keyfile_json=deployer.get("keyfile_json"),
+            password=deployer.get("password").encode("utf-8")
+        )
+
+        # deploy new personal info contract (from deployer)
+        personal_info_contract_address, _, _ = ContractUtils.deploy_contract(
+            contract_name="PersonalInfo",
+            args=[],
+            deployer=deployer_address,
+            private_key=deployer_pk
+        )
+
+        # deploy token
+        arguments = [
+            "テスト株式",
+            "TEST",
+            10000,
+            20000,
+            1,
+            "20211231",
+            "20211231",
+            "20221231",
+            10000
+        ]
+
+        token_address, _, _ = IbetShareContract.create(
+            args=arguments,
+            tx_from=issuer_address,
+            private_key=issuer_pk
+        )
+
+        # update token (from issuer)
+        update_data = {
+            "personal_info_contract_address": personal_info_contract_address,
+            "transfer_approval_required": True,
+            "transferable": True
+        }
+        IbetShareContract.update(
+            contract_address=token_address,
+            data=IbetShareUpdate(**update_data),
+            tx_from=issuer_address,
+            private_key=issuer_pk
+        )
+
+        # register personal info (to_account)
+        PersonalInfoContractTestUtils.register(
+            contract_address=personal_info_contract_address,
+            tx_from=to_address,
+            private_key=to_pk,
+            args=[issuer_address, "test_personal_info"]
+        )
+
+        # apply transfer (from issuer)
+        IbetSecurityTokenContractTestUtils.apply_for_transfer(
+            contract_address=token_address,
+            tx_from=issuer_address,
+            private_key=issuer_pk,
+            args=[to_address, 10, "test_data"]
+        )
+
+        # approve transfer (from issuer)
+        approve_data = {
+            "application_id": 0,
+            "data": "approve transfer test"
+        }
+        IbetShareContract.approve_transfer(
+            contract_address=token_address,
+            data=IbetSecurityTokenApproveTransfer(**approve_data),
+            tx_from=issuer_address,
+            private_key=issuer_pk
+        )
+
+        # Then send cancelTransfer transaction. This would be failed.
+        cancel_data = approve_data
+
+        # mock
+        # NOTE: Ganacheがrevertする際にweb3.pyからraiseされるExceptionはGethと異なる
+        #         ganache: ValueError({'message': 'VM Exception while processing transaction: revert',...})
+        #         geth: ContractLogicError("execution reverted")
+        InspectionMock = mock.patch(
+            "web3.eth.Eth.call",
+            MagicMock(side_effect=ContractLogicError("execution reverted: 120802"))
+        )
+
+        with InspectionMock, pytest.raises(ContractRevertError) as exc_info:
+            IbetShareContract.cancel_transfer(
+                contract_address=token_address,
+                data=IbetSecurityTokenCancelTransfer(**cancel_data),
+                tx_from=issuer_address,
+                private_key=issuer_pk
+            )
+
+        # assertion
+        assert exc_info.value.args[0] == "Application is invalid."

--- a/tests/model/blockchain/test_token_IbetStraightBond.py
+++ b/tests/model/blockchain/test_token_IbetStraightBond.py
@@ -20,7 +20,7 @@ import pytest
 import time
 from unittest import mock
 from binascii import Error
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 from datetime import datetime
 
 from pydantic.error_wrappers import ValidationError
@@ -29,7 +29,7 @@ from web3.exceptions import (
     InvalidAddress,
     TimeExhausted,
     TransactionNotFound,
-    ValidationError as Web3ValidationError
+    ValidationError as Web3ValidationError, ContractLogicError
 )
 from config import ZERO_ADDRESS
 from app.model.db import TokenAttrUpdate
@@ -43,7 +43,7 @@ from app.model.schema import (
     IbetSecurityTokenApproveTransfer,
     IbetSecurityTokenCancelTransfer
 )
-from app.exceptions import SendTransactionError
+from app.exceptions import SendTransactionError, ContractRevertError
 
 from tests.account_config import config_eth_account
 from tests.utils.contract_utils import (
@@ -491,9 +491,9 @@ class TestGet:
     # Error Case
     ###########################################################################
 
-    # <Error_2>
+    # <Error_1>
     # Invalid argument type (contract_address is not address)
-    def test_error_2(self, db):
+    def test_error_1(self, db):
         # get token data
         with pytest.raises(ValueError) as exc_info:
             IbetStraightBondContract.get(contract_address=ZERO_ADDRESS[:-1])
@@ -961,6 +961,61 @@ class TestUpdate:
                 )
         assert isinstance(exc_info.value.args[0], TransactionNotFound)
 
+    # <Error_5>
+    # Transaction REVERT(not owner)
+    def test_error_9(self, db):
+        test_account = config_eth_account("user1")
+        issuer_address = test_account.get("address")
+        user_account = config_eth_account("user2")
+        user_address = user_account.get("address")
+        issuer_private_key = decode_keyfile_json(
+            raw_keyfile_json=test_account.get("keyfile_json"),
+            password=test_account.get("password").encode("utf-8")
+        )
+        user_private_key = decode_keyfile_json(
+            raw_keyfile_json=user_account.get("keyfile_json"),
+            password=user_account.get("password").encode("utf-8")
+        )
+
+        # deploy token
+        arguments = [
+            "テスト債券", "TEST", 10000, 20000,
+            "20211231", 30000,
+            "20211231", "リターン内容",
+            "発行目的"
+        ]
+        contract_address, abi, tx_hash = IbetStraightBondContract.create(
+            args=arguments,
+            tx_from=issuer_address,
+            private_key=issuer_private_key
+        )
+
+        # update
+        _data = {
+            "face_value": 20001
+        }
+        _add_data = IbetStraightBondUpdate(**_data)
+
+        # mock
+        # NOTE: Ganacheがrevertする際にweb3.pyからraiseされるExceptionはGethと異なる
+        #         ganache: ValueError({'message': 'VM Exception while processing transaction: revert',...})
+        #         geth: ContractLogicError("execution reverted")
+        InspectionMock = mock.patch(
+            "web3.eth.Eth.call",
+            MagicMock(side_effect=ContractLogicError("execution reverted: 500001"))
+        )
+
+        with InspectionMock, pytest.raises(ContractRevertError) as exc_info:
+            IbetStraightBondContract.update(
+                contract_address=contract_address,
+                data=_add_data,
+                tx_from=user_address,
+                private_key=user_private_key
+            )
+
+        # assertion
+        assert exc_info.value.args[0] == "Message sender is not contract owner."
+
 
 class TestTransfer:
 
@@ -1300,6 +1355,60 @@ class TestTransfer:
                 )
         assert isinstance(exc_info.value.args[0], TransactionNotFound)
 
+    # <Error_8>
+    # Transaction REVERT(insufficient balance)
+    def test_error_8(self, db):
+        test_account = config_eth_account("user1")
+        issuer_address = test_account.get("address")
+        private_key = decode_keyfile_json(
+            raw_keyfile_json=test_account.get("keyfile_json"),
+            password=test_account.get("password").encode("utf-8")
+        )
+
+        to_account = config_eth_account("user2")
+        to_address = to_account.get("address")
+
+        # deploy token
+        arguments = [
+            "テスト債券", "TEST", 10000, 20000,
+            "20211231", 30000,
+            "20211231", "リターン内容",
+            "発行目的"
+        ]
+        contract_address, abi, tx_hash = IbetStraightBondContract.create(
+            args=arguments,
+            tx_from=issuer_address,
+            private_key=private_key
+        )
+
+        # transfer with insufficient balance
+        _data = {
+            "token_address": contract_address,
+            "from_address": issuer_address,
+            "to_address": to_address,
+            "amount": 10000000
+        }
+        _transfer_data = IbetStraightBondTransfer(**_data)
+
+        # mock
+        # NOTE: Ganacheがrevertする際にweb3.pyからraiseされるExceptionはGethと異なる
+        #         ganache: ValueError({'message': 'VM Exception while processing transaction: revert',...})
+        #         geth: ContractLogicError("execution reverted: ")
+        InspectionMock = mock.patch(
+            "web3.eth.Eth.call",
+            MagicMock(side_effect=ContractLogicError("execution reverted: 120401"))
+        )
+
+        with InspectionMock, pytest.raises(ContractRevertError) as exc_info:
+            IbetStraightBondContract.transfer(
+                data=_transfer_data,
+                tx_from=issuer_address,
+                private_key=private_key
+            )
+
+        # assertion
+        assert exc_info.value.args[0] == "Message sender balance is insufficient."
+
 
 class TestAdditionalIssue:
 
@@ -1633,6 +1742,63 @@ class TestAdditionalIssue:
                 )
         assert isinstance(exc_info.value.args[0], TransactionNotFound)
 
+    # <Error_9>
+    # Transaction REVERT(not owner)
+    def test_error_9(self, db):
+        test_account = config_eth_account("user1")
+        issuer_address = test_account.get("address")
+        user_account = config_eth_account("user2")
+        user_address = user_account.get("address")
+        issuer_private_key = decode_keyfile_json(
+            raw_keyfile_json=test_account.get("keyfile_json"),
+            password=test_account.get("password").encode("utf-8")
+        )
+        user_private_key = decode_keyfile_json(
+            raw_keyfile_json=user_account.get("keyfile_json"),
+            password=user_account.get("password").encode("utf-8")
+        )
+
+        # deploy token
+        arguments = [
+            "テスト債券", "TEST", 10000, 20000,
+            "20211231", 30000,
+            "20211231", "リターン内容",
+            "発行目的"
+        ]
+        contract_address, abi, tx_hash = IbetStraightBondContract.create(
+            args=arguments,
+            tx_from=issuer_address,
+            private_key=issuer_private_key
+        )
+
+        # additional issue
+        _data = {
+            "account_address": issuer_address,
+            "amount": 10
+        }
+        _add_data = IbetStraightBondAdditionalIssue(**_data)
+        pre_datetime = datetime.utcnow()
+
+        # mock
+        # NOTE: Ganacheがrevertする際にweb3.pyからraiseされるExceptionはGethと異なる
+        #         ganache: ValueError({'message': 'VM Exception while processing transaction: revert',...})
+        #         geth: ContractLogicError("execution reverted")
+        InspectionMock = mock.patch(
+            "web3.eth.Eth.call",
+            MagicMock(side_effect=ContractLogicError("execution reverted: 500001"))
+        )
+
+        with InspectionMock, pytest.raises(ContractRevertError) as exc_info:
+            IbetStraightBondContract.additional_issue(
+                contract_address=contract_address,
+                data=_add_data,
+                tx_from=user_address,
+                private_key=user_private_key
+            )
+
+        # assertion
+        assert exc_info.value.args[0] == "Message sender is not contract owner."
+
 
 class TestRedeem:
 
@@ -1965,6 +2131,57 @@ class TestRedeem:
                     private_key=private_key
                 )
         assert isinstance(exc_info.value.args[0], TransactionNotFound)
+
+    # <Error_9>
+    # Transaction REVERT(lack balance)
+    def test_error_9(self, db):
+        test_account = config_eth_account("user1")
+        issuer_address = test_account.get("address")
+        private_key = decode_keyfile_json(
+            raw_keyfile_json=test_account.get("keyfile_json"),
+            password=test_account.get("password").encode("utf-8")
+        )
+
+        # deploy token
+        arguments = [
+            "テスト債券", "TEST", 10000, 20000,
+            "20211231", 30000,
+            "20211231", "リターン内容",
+            "発行目的"
+        ]
+        contract_address, abi, tx_hash = IbetStraightBondContract.create(
+            args=arguments,
+            tx_from=issuer_address,
+            private_key=private_key
+        )
+
+        # redeem
+        _data = {
+            "account_address": issuer_address,
+            "amount": 100_000_000
+        }
+        _add_data = IbetStraightBondRedeem(**_data)
+        pre_datetime = datetime.utcnow()
+
+        # mock
+        # NOTE: Ganacheがrevertする際にweb3.pyからraiseされるExceptionはGethと異なる
+        #         ganache: ValueError({'message': 'VM Exception while processing transaction: revert',...})
+        #         geth: ContractLogicError("execution reverted")
+        InspectionMock = mock.patch(
+            "web3.eth.Eth.call",
+            MagicMock(side_effect=ContractLogicError("execution reverted: 121102"))
+        )
+
+        with InspectionMock, pytest.raises(ContractRevertError) as exc_info:
+            IbetStraightBondContract.redeem(
+                contract_address=contract_address,
+                data=_add_data,
+                tx_from=issuer_address,
+                private_key=private_key
+            )
+
+        # assertion
+        assert exc_info.value.args[0] == "Redeem amount is less than target address balance."
 
 
 class TestGetAccountBalance:
@@ -2465,6 +2682,120 @@ class TestApproveTransfer:
             )
         assert ex_info.match("Non-hexadecimal digit found")
 
+    # <Error_5>
+    # Transaction REVERT(application invalid)
+    def test_error_5(self, db):
+        issuer = config_eth_account("user1")
+        issuer_address = issuer.get("address")
+        issuer_pk = decode_keyfile_json(
+            raw_keyfile_json=issuer.get("keyfile_json"),
+            password=issuer.get("password").encode("utf-8")
+        )
+
+        to_account = config_eth_account("user2")
+        to_address = to_account.get("address")
+        to_pk = decode_keyfile_json(
+            raw_keyfile_json=to_account.get("keyfile_json"),
+            password=to_account.get("password").encode("utf-8")
+        )
+
+        deployer = config_eth_account("user3")
+        deployer_address = deployer.get("address")
+        deployer_pk = decode_keyfile_json(
+            raw_keyfile_json=deployer.get("keyfile_json"),
+            password=deployer.get("password").encode("utf-8")
+        )
+
+        # deploy new personal info contract (from deployer)
+        personal_info_contract_address, _, _ = ContractUtils.deploy_contract(
+            contract_name="PersonalInfo",
+            args=[],
+            deployer=deployer_address,
+            private_key=deployer_pk
+        )
+
+        # deploy ibet bond token (from issuer)
+        arguments = [
+            "テスト債券",
+            "TEST",
+            10000,
+            20000,
+            "20211231",
+            30000,
+            "20211231",
+            "リターン内容",
+            "発行目的"
+        ]
+        token_address, _, _ = IbetStraightBondContract.create(
+            args=arguments,
+            tx_from=issuer_address,
+            private_key=issuer_pk
+        )
+
+        # update token (from issuer)
+        update_data = {
+            "personal_info_contract_address": personal_info_contract_address,
+            "transfer_approval_required": True,
+            "transferable": True
+        }
+        IbetStraightBondContract.update(
+            contract_address=token_address,
+            data=IbetStraightBondUpdate(**update_data),
+            tx_from=issuer_address,
+            private_key=issuer_pk
+        )
+
+        # register personal info (to_account)
+        PersonalInfoContractTestUtils.register(
+            contract_address=personal_info_contract_address,
+            tx_from=to_address,
+            private_key=to_pk,
+            args=[issuer_address, "test_personal_info"]
+        )
+
+        # apply transfer (from issuer)
+        IbetSecurityTokenContractTestUtils.apply_for_transfer(
+            contract_address=token_address,
+            tx_from=issuer_address,
+            private_key=issuer_pk,
+            args=[to_address, 10, "test_data"]
+        )
+
+        # approve transfer (from issuer)
+        approve_data = {
+            "application_id": 0,
+            "data": "approve transfer test"
+        }
+        IbetStraightBondContract.approve_transfer(
+            contract_address=token_address,
+            data=IbetSecurityTokenApproveTransfer(**approve_data),
+            tx_from=issuer_address,
+            private_key=issuer_pk
+        )
+
+        # Then send approveTransfer transaction again.
+        # This would be failed.
+
+        # mock
+        # NOTE: Ganacheがrevertする際にweb3.pyからraiseされるExceptionはGethと異なる
+        #         ganache: ValueError({'message': 'VM Exception while processing transaction: revert',...})
+        #         geth: ContractLogicError("execution reverted")
+        InspectionMock = mock.patch(
+            "web3.eth.Eth.call",
+            MagicMock(side_effect=ContractLogicError("execution reverted: 120902"))
+        )
+
+        with InspectionMock, pytest.raises(ContractRevertError) as exc_info:
+            IbetStraightBondContract.approve_transfer(
+                contract_address=token_address,
+                data=IbetSecurityTokenApproveTransfer(**approve_data),
+                tx_from=issuer_address,
+                private_key=issuer_pk
+            )
+
+        # assertion
+        assert exc_info.value.args[0] == "Application is invalid."
+
 
 class TestCancelTransfer:
 
@@ -2721,3 +3052,118 @@ class TestCancelTransfer:
                 private_key="dummy-private"
             )
         assert ex_info.match("Non-hexadecimal digit found")
+
+    # <Error_5>
+    # Transaction REVERT(application invalid)
+    def test_error_5(self, db):
+        issuer = config_eth_account("user1")
+        issuer_address = issuer.get("address")
+        issuer_pk = decode_keyfile_json(
+            raw_keyfile_json=issuer.get("keyfile_json"),
+            password=issuer.get("password").encode("utf-8")
+        )
+
+        to_account = config_eth_account("user2")
+        to_address = to_account.get("address")
+        to_pk = decode_keyfile_json(
+            raw_keyfile_json=to_account.get("keyfile_json"),
+            password=to_account.get("password").encode("utf-8")
+        )
+
+        deployer = config_eth_account("user3")
+        deployer_address = deployer.get("address")
+        deployer_pk = decode_keyfile_json(
+            raw_keyfile_json=deployer.get("keyfile_json"),
+            password=deployer.get("password").encode("utf-8")
+        )
+
+        # deploy new personal info contract (from deployer)
+        personal_info_contract_address, _, _ = ContractUtils.deploy_contract(
+            contract_name="PersonalInfo",
+            args=[],
+            deployer=deployer_address,
+            private_key=deployer_pk
+        )
+
+        # deploy ibet bond token (from issuer)
+        arguments = [
+            "テスト債券",
+            "TEST",
+            10000,
+            20000,
+            "20211231",
+            30000,
+            "20211231",
+            "リターン内容",
+            "発行目的"
+        ]
+        token_address, _, _ = IbetStraightBondContract.create(
+            args=arguments,
+            tx_from=issuer_address,
+            private_key=issuer_pk
+        )
+
+        # update token (from issuer)
+        update_data = {
+            "personal_info_contract_address": personal_info_contract_address,
+            "transfer_approval_required": True,
+            "transferable": True
+        }
+        IbetStraightBondContract.update(
+            contract_address=token_address,
+            data=IbetStraightBondUpdate(**update_data),
+            tx_from=issuer_address,
+            private_key=issuer_pk
+        )
+
+        # register personal info (to_account)
+        PersonalInfoContractTestUtils.register(
+            contract_address=personal_info_contract_address,
+            tx_from=to_address,
+            private_key=to_pk,
+            args=[issuer_address, "test_personal_info"]
+        )
+
+        # apply transfer (from issuer)
+        IbetSecurityTokenContractTestUtils.apply_for_transfer(
+            contract_address=token_address,
+            tx_from=issuer_address,
+            private_key=issuer_pk,
+            args=[to_address, 10, "test_data"]
+        )
+
+        # approve transfer (from issuer)
+        approve_data = {
+            "application_id": 0,
+            "data": "approve transfer test"
+        }
+        IbetStraightBondContract.approve_transfer(
+            contract_address=token_address,
+            data=IbetSecurityTokenApproveTransfer(**approve_data),
+            tx_from=issuer_address,
+            private_key=issuer_pk
+        )
+
+        # Then send cancelTransfer transaction. This would be failed.
+
+        cancel_data = approve_data
+
+        # mock
+        # NOTE: Ganacheがrevertする際にweb3.pyからraiseされるExceptionはGethと異なる
+        #         ganache: ValueError({'message': 'VM Exception while processing transaction: revert',...})
+        #         geth: ContractLogicError("execution reverted")
+        InspectionMock = mock.patch(
+            "web3.eth.Eth.call",
+            MagicMock(side_effect=ContractLogicError("execution reverted: 120802"))
+        )
+
+        with InspectionMock, pytest.raises(ContractRevertError) as exc_info:
+            IbetStraightBondContract.cancel_transfer(
+                contract_address=token_address,
+                data=IbetSecurityTokenCancelTransfer(**cancel_data),
+                tx_from=issuer_address,
+                private_key=issuer_pk
+            )
+
+        # assertion
+        assert exc_info.value.args[0] == "Application is invalid."

--- a/tests/test_app_routers_bond_transfer_approvals_{token_Address}_{id}_POST.py
+++ b/tests/test_app_routers_bond_transfer_approvals_{token_Address}_{id}_POST.py
@@ -39,7 +39,7 @@ from app.model.schema import (
     IbetSecurityTokenEscrowApproveTransfer
 )
 from app.utils.e2ee_utils import E2EEUtils
-from app.exceptions import SendTransactionError
+from app.exceptions import SendTransactionError, ContractRevertError
 
 from tests.account_config import config_eth_account
 
@@ -1159,7 +1159,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressIdPOST:
     # APPROVE
     # Send Transaction Error
     # IbetSecurityTokenInterface.approve_transfer
-    # return fail
+    # return fail with Revert
     def test_error_5_2(self, client, db):
         issuer = config_eth_account("user1")
         issuer_address = issuer["address"]
@@ -1203,7 +1203,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressIdPOST:
         # mock
         IbetSecurityTokenContract_approve_transfer = mock.patch(
             target="app.model.blockchain.token.IbetSecurityTokenInterface.approve_transfer",
-            return_value=("test_tx_hash", {"status": 0})
+            side_effect=ContractRevertError("120902")
         )
         IbetSecurityTokenContract_cancel_transfer = mock.patch(
             target="app.model.blockchain.token.IbetSecurityTokenInterface.cancel_transfer",
@@ -1227,10 +1227,10 @@ class TestAppRoutersBondTransferApprovalsTokenAddressIdPOST:
         assert resp.status_code == 400
         assert resp.json() == {
             "meta": {
-                "code": 2,
-                "title": "SendTransactionError"
+                "code": 120902,
+                "title": "ContractRevertError"
             },
-            "detail": "failed to send transaction"
+            "detail": "Application is invalid."
         }
 
     # <Error_5_3>
@@ -1308,7 +1308,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressIdPOST:
     # APPROVE
     # Send Transaction Error
     # IbetSecurityTokenEscrow.approve_transfer
-    # return fail
+    # return fail with Revert
     def test_error_5_4(self, client, db):
         issuer = config_eth_account("user1")
         issuer_address = issuer["address"]
@@ -1353,7 +1353,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressIdPOST:
         # mock
         IbetSecurityTokenEscrow_approve_transfer = mock.patch(
             target="app.model.blockchain.exchange.IbetSecurityTokenEscrow.approve_transfer",
-            return_value=("test_tx_hash", {"status": 0})
+            side_effect=ContractRevertError("120902")
         )
 
         # request target API
@@ -1373,10 +1373,10 @@ class TestAppRoutersBondTransferApprovalsTokenAddressIdPOST:
         assert resp.status_code == 400
         assert resp.json() == {
             "meta": {
-                "code": 2,
-                "title": "SendTransactionError"
+                "code": 120902,
+                "title": "ContractRevertError"
             },
-            "detail": "failed to send transaction"
+            "detail": "Application is invalid."
         }
 
     # <Error_6_1>
@@ -1453,7 +1453,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressIdPOST:
     # CANCEL
     # Send Transaction Error
     # IbetSecurityTokenInterface.cancel_transfer
-    # return fail
+    # return fail with Revert
     def test_error_6_2(self, client, db):
         issuer = config_eth_account("user1")
         issuer_address = issuer["address"]
@@ -1497,7 +1497,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressIdPOST:
         # mock
         IbetSecurityTokenContract_cancel_transfer = mock.patch(
             target="app.model.blockchain.token.IbetSecurityTokenInterface.cancel_transfer",
-            return_value=("test_tx_hash", {"status": 0})
+            side_effect=ContractRevertError("120802")
         )
 
         # request target API
@@ -1517,8 +1517,8 @@ class TestAppRoutersBondTransferApprovalsTokenAddressIdPOST:
         assert resp.status_code == 400
         assert resp.json() == {
             "meta": {
-                "code": 2,
-                "title": "SendTransactionError"
+                "code": 120802,
+                "title": "ContractRevertError"
             },
-            "detail": "failed to send transaction"
+            "detail": "Application is invalid."
         }

--- a/tests/test_app_routers_share_transfer_approvals_{token_Address}_{id}_POST.py
+++ b/tests/test_app_routers_share_transfer_approvals_{token_Address}_{id}_POST.py
@@ -39,7 +39,7 @@ from app.model.schema import (
     IbetSecurityTokenEscrowApproveTransfer
 )
 from app.utils.e2ee_utils import E2EEUtils
-from app.exceptions import SendTransactionError
+from app.exceptions import SendTransactionError, ContractRevertError
 
 from tests.account_config import config_eth_account
 
@@ -1159,7 +1159,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressIdPOST:
     # APPROVE
     # Send Transaction Error
     # IbetSecurityTokenInterface.approve_transfer
-    # return fail
+    # return fail with Revert
     def test_error_5_2(self, client, db):
         issuer = config_eth_account("user1")
         issuer_address = issuer["address"]
@@ -1203,7 +1203,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressIdPOST:
         # mock
         IbetSecurityTokenContract_approve_transfer = mock.patch(
             target="app.model.blockchain.token.IbetSecurityTokenInterface.approve_transfer",
-            return_value=("test_tx_hash", {"status": 0})
+            side_effect=ContractRevertError("110902")
         )
         IbetSecurityTokenContract_cancel_transfer = mock.patch(
             target="app.model.blockchain.token.IbetSecurityTokenInterface.cancel_transfer",
@@ -1227,10 +1227,10 @@ class TestAppRoutersShareTransferApprovalsTokenAddressIdPOST:
         assert resp.status_code == 400
         assert resp.json() == {
             "meta": {
-                "code": 2,
-                "title": "SendTransactionError"
+                "code": 110902,
+                "title": "ContractRevertError"
             },
-            "detail": "failed to send transaction"
+            "detail": "Application is invalid."
         }
 
     # <Error_5_3>
@@ -1308,7 +1308,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressIdPOST:
     # APPROVE
     # Send Transaction Error
     # IbetSecurityTokenEscrow.approve_transfer
-    # return fail
+    # return fail with Revert
     def test_error_5_4(self, client, db):
         issuer = config_eth_account("user1")
         issuer_address = issuer["address"]
@@ -1353,7 +1353,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressIdPOST:
         # mock
         IbetSecurityTokenEscrow_approve_transfer = mock.patch(
             target="app.model.blockchain.exchange.IbetSecurityTokenEscrow.approve_transfer",
-            return_value=("test_tx_hash", {"status": 0})
+            side_effect=ContractRevertError("110902")
         )
 
         # request target API
@@ -1373,10 +1373,10 @@ class TestAppRoutersShareTransferApprovalsTokenAddressIdPOST:
         assert resp.status_code == 400
         assert resp.json() == {
             "meta": {
-                "code": 2,
-                "title": "SendTransactionError"
+                "code": 110902,
+                "title": "ContractRevertError"
             },
-            "detail": "failed to send transaction"
+            "detail": "Application is invalid."
         }
 
     # <Error_6_1>
@@ -1453,7 +1453,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressIdPOST:
     # CANCEL
     # Send Transaction Error
     # IbetSecurityTokenInterface.cancel_transfer
-    # return fail
+    # return fail with Revert
     def test_error_6_2(self, client, db):
         issuer = config_eth_account("user1")
         issuer_address = issuer["address"]
@@ -1497,7 +1497,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressIdPOST:
         # mock
         IbetSecurityTokenContract_cancel_transfer = mock.patch(
             target="app.model.blockchain.token.IbetSecurityTokenInterface.cancel_transfer",
-            return_value=("test_tx_hash", {"status": 0})
+            side_effect=ContractRevertError("110802")
         )
 
         # request target API
@@ -1517,8 +1517,8 @@ class TestAppRoutersShareTransferApprovalsTokenAddressIdPOST:
         assert resp.status_code == 400
         assert resp.json() == {
             "meta": {
-                "code": 2,
-                "title": "SendTransactionError"
+                "code": 110802,
+                "title": "ContractRevertError"
             },
-            "detail": "failed to send transaction"
+            "detail": "Application is invalid."
         }

--- a/tests/test_batch_processor_auto_transfer_approval.py
+++ b/tests/test_batch_processor_auto_transfer_approval.py
@@ -38,7 +38,7 @@ from app.model.schema.token import (
     IbetSecurityTokenCancelTransfer,
     IbetSecurityTokenEscrowApproveTransfer
 )
-from app.exceptions import SendTransactionError
+from app.exceptions import SendTransactionError, ContractRevertError
 from batch.processor_auto_transfer_approval import Processor
 
 from tests.account_config import config_eth_account
@@ -597,7 +597,7 @@ class TestProcessor:
         # mock
         IbetSecurityTokenContract_approve_transfer = patch(
             target="app.model.blockchain.token.IbetSecurityTokenInterface.approve_transfer",
-            return_value=("test_tx_hash", {"status": 0})
+            side_effect=ContractRevertError("110902")
         )
 
         IbetSecurityTokenContract_cancel_transfer = patch(


### PR DESCRIPTION
## Issue ticket number and link
#329 

## Describe your changes
1. Added ContractRevertError as custom exception.
When you send transaction and revert is happened, contract_util inspects the reason of revert and raises reason with ContractRevertError.
If DB fails in sending transaction, SendTransactionError is raised as it is now.

2. In online API, added ContractRevertError to responses which API may return.
Fixed API documents.
For back compatible, ContractRevertError is returned with 400, same way as SendTransactionError.
(FastAPI in this repository uses OpenAPI 3.0.2. In 3.10.0, documents would be more understandable.)
URL: https://fastapi.tiangolo.com/tutorial/schema-extra-example/#body-with-multiple-examples:~:text=would%20look%20like%3A-,Technical%20Details,%C2%B6,-Warning 

<img width="925" alt="スクリーンショット 2022-06-07 18 44 09" src="https://user-images.githubusercontent.com/15183665/172350998-1b7e89d5-4d86-4c98-9ca6-39eb9d4bfcf4.png">

3. When you use an endpoint about approveTransfer or run batch about approveTransfer, server checks that transaction is reverted or not and decides what to do next.
Related to “1”, I fixed the logic properly.

4. When ContractRevertError is raised in batch process, logger will be output each error with code and message.

5. E2EMessaging_sendMessage wont be reverted, but I added error handling about that because of future enhancement.

6. Added unit tests in perspect below.
- API unit test is wrote with “contract util mock”, so I didn’t add any cases except about 3.
- Fixed batch unit tests about 3.
- Added each tests about blockchain model which wraps contract_utils and should be thrown revert.

<details>
<pre>
<code>
1
新しくContractRevertErrorを追加しました。
トランザクションを送った際にリバート時のメッセージが取得出来た場合には、ContractRevertErrorをraiseします。
トランザクション送信時にDBレイヤ等のエラーが発生した場合には、これまで通りSendTransactionErrorをraiseします。

2
オンラインAPIで返却しうるレスポンスとしてContractRevertErrorを追加しました。
APIドキュメントを修正しています。
後方互換性の観点から、ContractRevertErrorはSendTransactionErrorと同様400で返却します。

FastAPIではOpenAPIの3.0.2系を使用していますが、3.10.0に対応すればもう少しドキュメントを綺麗にかけるかもしれません。
URL: https://fastapi.tiangolo.com/tutorial/schema-extra-example/#body-with-multiple-examples:~:text=would%20look%20like%3A-,Technical%20Details,%C2%B6,-Warning 

3
Bond/ShareのapplicationForTransferに対してapproveTransferを行うエンドポイント・バッチ（以下）では、
既存処理の中でRevertしたかどうかを確認するロジックが含まれていました。
1の追加に伴い、Revert時に正しく処理が分岐するようロジックを修正しています。

4
バッチプロセス上でContractRevertErrorがraiseされた際に、エラーコード・メッセージがログ出力されるようになりました。

5
E2EMessaging_sendMessageはコントラクトロジック上revertが発生しませんが、
今後仕様変更があった際の対応漏れを防ぐため、revert時のエラーハンドリングを加えています。

6
以下の観点でユニットテストを追加しています。

・APIユニットテストはcontract_utilをMock化して行っているため、上記3以外のユニットテストは追加していません。
・バッチユニットテストは
・contract_utilsを内包しているblockchain modelのユニットテストは、revertが起こりうる全箇所に対してユニットテストを追加しました。
</code>
</pre>
</details>

## Before/After

- Endpoints which sends transaction can detect revert error and response it as code and message.
- Batch can detect revert error of contract and log it.