### PR TITLE
fix: An error occurs in the ledger API when personal information is null

### DIFF
--- a/app/model/db/idx_personal_info.py
+++ b/app/model/db/idx_personal_info.py
@@ -16,12 +16,13 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
-from sqlalchemy import Column
 from sqlalchemy import (
+    Column,
     BigInteger,
     String,
     JSON
 )
+from sqlalchemy.ext.hybrid import hybrid_property
 
 from .base import Base
 
@@ -46,7 +47,35 @@ class IDXPersonalInfo(Base):
     #       "is_corporate": "boolean",
     #       "tax_category": "integer"
     #   }
-    personal_info = Column(JSON, nullable=False)
+    _personal_info = Column('personal_info', JSON, nullable=False)
+
+    @hybrid_property
+    def personal_info(self):
+        if self._personal_info:
+            return {
+                "key_manager": self._personal_info.get("key_manager", None),
+                "name": self._personal_info.get("name", None),
+                "address": self._personal_info.get("address", None),
+                "postal_code": self._personal_info.get("postal_code", None),
+                "email": self._personal_info.get("email", None),
+                "birth": self._personal_info.get("birth", None),
+                "is_corporate": self._personal_info.get("is_corporate", None),
+                "tax_category": self._personal_info.get("tax_category", None)
+            }
+        return self._personal_info
+
+    @personal_info.setter  # type: ignore
+    def personal_info(self, personal_info_dict):
+        self._personal_info = {
+            "key_manager": personal_info_dict.get("key_manager", None),
+            "name": personal_info_dict.get("name", None),
+            "address": personal_info_dict.get("address", None),
+            "postal_code": personal_info_dict.get("postal_code", None),
+            "email": personal_info_dict.get("email", None),
+            "birth": personal_info_dict.get("birth", None),
+            "is_corporate": personal_info_dict.get("is_corporate", None),
+            "tax_category": personal_info_dict.get("tax_category", None)
+        }
 
 
 class IDXPersonalInfoBlockNumber(Base):

--- a/app/routers/bond.py
+++ b/app/routers/bond.py
@@ -937,7 +937,8 @@ def modify_holder_personal_info(
         )
         personal_info_contract.modify_info(
             account_address=account_address,
-            data=personal_info.dict()
+            data=personal_info.dict(),
+            default_value=None
         )
     except SendTransactionError:
         raise SendTransactionError("failed to modify personal information")
@@ -991,7 +992,8 @@ def register_holder_personal_info(
         )
         personal_info_contract.register_info(
             account_address=personal_info.account_address,
-            data=personal_info.dict()
+            data=personal_info.dict(),
+            default_value=None
         )
     except SendTransactionError:
         raise SendTransactionError("failed to register personal information")

--- a/app/routers/ledger.py
+++ b/app/routers/ledger.py
@@ -215,8 +215,8 @@ def retrieve_ledger_history(
                         db=db
                     )
                     if personal_info is not None:
-                        data["name"] = personal_info["name"]
-                        data["address"] = personal_info["address"]
+                        data["name"] = personal_info.get("name", "")
+                        data["address"] = personal_info.get("address", "")
 
     return resp
 
@@ -722,6 +722,6 @@ def __get_personal_info(token_address: str, token_type: str, account_address: st
             )
             personal_info = personal_info_contract.get_info(
                 account_address=account_address,
-                default_value=""
+                default_value=None
             )
         return personal_info

--- a/app/routers/ledger.py
+++ b/app/routers/ledger.py
@@ -215,8 +215,8 @@ def retrieve_ledger_history(
                         db=db
                     )
                     if personal_info is not None:
-                        data["name"] = personal_info.get("name", "")
-                        data["address"] = personal_info.get("address", "")
+                        data["name"] = personal_info.get("name", None) or ""
+                        data["address"] = personal_info.get("address", None) or ""
 
     return resp
 
@@ -534,8 +534,8 @@ def create_ledger_details_data(
         _details_data = LedgerDetailsData()
         _details_data.token_address = token_address
         _details_data.data_id = data_id
-        _details_data.name = data.name
-        _details_data.address = data.address
+        _details_data.name = getattr(data, "name") or ""
+        _details_data.address = getattr(data, "address") or ""
         _details_data.amount = data.amount
         _details_data.price = data.price
         _details_data.balance = data.balance

--- a/app/routers/share.py
+++ b/app/routers/share.py
@@ -923,7 +923,8 @@ def modify_holder_personal_info(
         )
         personal_info_contract.modify_info(
             account_address=account_address,
-            data=personal_info.dict()
+            data=personal_info.dict(),
+            default_value=None
         )
     except SendTransactionError:
         raise SendTransactionError("failed to modify personal information")
@@ -977,7 +978,8 @@ def register_holder_personal_info(
         )
         personal_info_contract.register_info(
             account_address=personal_info.account_address,
-            data=personal_info.dict()
+            data=personal_info.dict(),
+            default_value=None
         )
     except SendTransactionError:
         raise SendTransactionError("failed to register personal information")

--- a/app/utils/ledger_utils.py
+++ b/app/utils/ledger_utils.py
@@ -215,7 +215,7 @@ def __get_personal_info(account_address: str, issuer_address: str, personal_info
         first()
 
     if _idx_personal_info is None:  # Get PersonalInfo to Contract
-        personal_info = personal_info_contract.get_info(account_address, default_value="")
+        personal_info = personal_info_contract.get_info(account_address, default_value=None)
     else:
         personal_info = _idx_personal_info.personal_info
 

--- a/batch/indexer_personal_info.py
+++ b/batch/indexer_personal_info.py
@@ -155,7 +155,8 @@ class Processor:
                         block = web3.eth.get_block(event["blockNumber"])
                         timestamp = datetime.utcfromtimestamp(block["timestamp"])
                         decrypted_personal_info = _personal_info_contract.get_info(
-                            account_address=account_address
+                            account_address=account_address,
+                            default_value=None
                         )
                         self.__sink_on_personal_info(
                             db_session=db_session,
@@ -180,7 +181,8 @@ class Processor:
                         block = web3.eth.get_block(event["blockNumber"])
                         timestamp = datetime.utcfromtimestamp(block["timestamp"])
                         decrypted_personal_info = _personal_info_contract.get_info(
-                            account_address=account_address
+                            account_address=account_address,
+                            default_value=None
                         )
                         self.__sink_on_personal_info(
                             db_session=db_session,

--- a/batch/processor_modify_personal_info.py
+++ b/batch/processor_modify_personal_info.py
@@ -172,7 +172,10 @@ class Processor:
         # Modify
         LOG.info(
             f"Modify Start: issuer_address={temporary.issuer_address}, account_address={idx_personal_info.account_address}")
-        info = personal_info_contract_accessor.get_info(idx_personal_info.account_address)
+        info = personal_info_contract_accessor.get_info(
+            idx_personal_info.account_address,
+            default_value=None
+        )
         LOG.info(
             f"Modify End: issuer_address={temporary.issuer_address}, account_address={idx_personal_info.account_address}")
         # Back RSA
@@ -192,7 +195,11 @@ class Processor:
             return False
 
         # Modify personal information
-        personal_info_contract_accessor.modify_info(idx_personal_info.account_address, info)
+        personal_info_contract_accessor.modify_info(
+            account_address=idx_personal_info.account_address,
+            data=info,
+            default_value=None
+        )
         return True
 
     @staticmethod

--- a/tests/test_app_routers_bond_tokens_{token_address}_holders_GET.py
+++ b/tests/test_app_routers_bond_tokens_{token_address}_holders_GET.py
@@ -149,6 +149,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
         _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
         _account_address_1 = "0xb75c7545b9230FEe99b7af370D38eBd3DAD929f7"
         _account_address_2 = "0x3F198534Bbe3B2a197d3B317d41392F348EAC707"
+        _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         # prepare data
         account = Account()
@@ -196,6 +197,29 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
         idx_position_2.pending_transfer = 10
         db.add(idx_position_2)
 
+        idx_position_3 = IDXPosition()
+        idx_position_3.token_address = _token_address
+        idx_position_3.account_address = _account_address_3
+        idx_position_3.balance = 99
+        idx_position_3.exchange_balance = 99
+        idx_position_3.exchange_commitment = 99
+        idx_position_3.pending_transfer = 99
+        db.add(idx_position_3)
+
+        idx_personal_info_3 = IDXPersonalInfo()
+        idx_personal_info_3.account_address = _account_address_3
+        idx_personal_info_3.issuer_address = _issuer_address
+        idx_personal_info_3.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test3",
+            "postal_code": "postal_code_test3",
+            "address": "address_test3",
+            "email": "email_test3",
+            "birth": "birth_test3"
+            # PersonalInfo is partially registered.
+        }
+        db.add(idx_personal_info_3)
+
         # request target API
         resp = client.get(
             self.base_url.format(_token_address),
@@ -240,6 +264,23 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
                 "exchange_balance": 21,
                 "exchange_commitment": 22,
                 "pending_transfer": 10
+            },
+            {
+                "account_address": _account_address_3,
+                "personal_information": {
+                    "key_manager": "key_manager_test1",
+                    "name": "name_test3",
+                    "postal_code": "postal_code_test3",
+                    "address": "address_test3",
+                    "email": "email_test3",
+                    "birth": "birth_test3",
+                    "is_corporate": None,
+                    "tax_category": None
+                },
+                "balance": 99,
+                "exchange_balance": 99,
+                "exchange_commitment": 99,
+                "pending_transfer": 99
             }
         ]
 

--- a/tests/test_app_routers_bond_tokens_{token_address}_holders_{account_address}_GET.py
+++ b/tests/test_app_routers_bond_tokens_{token_address}_holders_{account_address}_GET.py
@@ -106,9 +106,9 @@ class TestAppRoutersBondTokensTokenAddressHoldersAccountAddressGET:
             "pending_transfer": 5
         }
 
-    # <Normal_2>
+    # <Normal_2_1>
     # PersonalInfo not registry
-    def test_normal_2(self, client, db):
+    def test_normal_2_1(self, client, db):
         user = config_eth_account("user1")
         _issuer_address = user["address"]
         _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
@@ -155,6 +155,78 @@ class TestAppRoutersBondTokensTokenAddressHoldersAccountAddressGET:
                 "address": None,
                 "email": None,
                 "birth": None,
+                "is_corporate": None,
+                "tax_category": None
+            },
+            "balance": 10,
+            "exchange_balance": 11,
+            "exchange_commitment": 12,
+            "pending_transfer": 5
+        }
+
+    # <Normal_2_2>
+    # PersonalInfo is partially registered
+    def test_normal_2_2(self, client, db):
+        user = config_eth_account("user1")
+        _issuer_address = user["address"]
+        _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
+        _account_address_1 = "0xb75c7545b9230FEe99b7af370D38eBd3DAD929f7"
+
+        # prepare data
+        account = Account()
+        account.issuer_address = _issuer_address
+        db.add(account)
+
+        token = Token()
+        token.type = TokenType.IBET_STRAIGHT_BOND.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        db.add(token)
+
+        idx_position_1 = IDXPosition()
+        idx_position_1.token_address = _token_address
+        idx_position_1.account_address = _account_address_1
+        idx_position_1.balance = 10
+        idx_position_1.exchange_balance = 11
+        idx_position_1.exchange_commitment = 12
+        idx_position_1.pending_transfer = 5
+        db.add(idx_position_1)
+
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = _account_address_1
+        idx_personal_info_1.issuer_address = _issuer_address
+        idx_personal_info_1.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1"
+            # PersonalInfo is partially registered.
+        }
+        db.add(idx_personal_info_1)
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address, _account_address_1),
+            headers={
+                "issuer-address": _issuer_address
+            }
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "account_address": _account_address_1,
+            "personal_information": {
+                "key_manager": "key_manager_test1",
+                "name": "name_test1",
+                "postal_code": "postal_code_test1",
+                "address": "address_test1",
+                "email": "email_test1",
+                "birth": "birth_test1",
                 "is_corporate": None,
                 "tax_category": None
             },

--- a/tests/test_app_routers_bond_tokens_{token_address}_holders_{account_address}_personal_info_POST.py
+++ b/tests/test_app_routers_bond_tokens_{token_address}_holders_{account_address}_personal_info_POST.py
@@ -114,7 +114,8 @@ class TestAppRoutersBondTokensTokenAddressHoldersAccountAddressPersonalInfoPOST:
             )
             PersonalInfoContract.modify_info.assert_called_with(
                 account_address=_test_account_address,
-                data=req_param
+                data=req_param,
+                default_value=None
             )
 
     # <Normal_2>
@@ -192,7 +193,8 @@ class TestAppRoutersBondTokensTokenAddressHoldersAccountAddressPersonalInfoPOST:
             )
             PersonalInfoContract.modify_info.assert_called_with(
                 account_address=_test_account_address,
-                data=req_param
+                data=req_param,
+                default_value=None
             )
 
     ###########################################################################

--- a/tests/test_app_routers_bond_tokens_{token_address}_personal_info_POST.py
+++ b/tests/test_app_routers_bond_tokens_{token_address}_personal_info_POST.py
@@ -115,7 +115,8 @@ class TestAppRoutersBondTokensTokenAddressPersonalInfoPOST:
             )
             PersonalInfoContract.register_info.assert_called_with(
                 account_address=_test_account_address,
-                data=req_param
+                data=req_param,
+                default_value=None
             )
 
     # <Normal_2>
@@ -194,7 +195,8 @@ class TestAppRoutersBondTokensTokenAddressPersonalInfoPOST:
             )
             PersonalInfoContract.register_info.assert_called_with(
                 account_address=_test_account_address,
-                data=req_param
+                data=req_param,
+                default_value=None
             )
 
     ###########################################################################

--- a/tests/test_app_routers_ledger_{token_address}_details_data_{data_id}_GET.py
+++ b/tests/test_app_routers_ledger_{token_address}_details_data_{data_id}_GET.py
@@ -189,6 +189,86 @@ class TestAppRoutersLedgerTokenAddressDetailsDataDataIdGET:
             },
         ]
 
+    # <Normal_2>
+    # set issuer-address
+    def test_normal_2(self, client, db):
+        user = config_eth_account("user1")
+        issuer_address = user["address"]
+        token_address = "0xABCdeF1234567890abcdEf123456789000000000"
+        data_id = "data_id_1"
+
+        # prepare data
+        _token = Token()
+        _token.type = TokenType.IBET_STRAIGHT_BOND.value
+        _token.tx_hash = ""
+        _token.issuer_address = issuer_address
+        _token.token_address = token_address
+        _token.abi = {}
+        db.add(_token)
+
+        _details_1_data_1 = LedgerDetailsData()
+        _details_1_data_1.token_address = token_address
+        _details_1_data_1.data_id = data_id
+        _details_1_data_1.name = "name_test_0"
+        _details_1_data_1.address = "address_test_0"
+        _details_1_data_1.amount = 0
+        _details_1_data_1.price = 1
+        _details_1_data_1.balance = 2
+        _details_1_data_1.acquisition_date = "2000/12/31"
+        db.add(_details_1_data_1)
+
+        _details_1_data_2 = LedgerDetailsData()
+        _details_1_data_2.token_address = token_address
+        _details_1_data_2.data_id = data_id
+        _details_1_data_2.name = "name_test_1"
+        _details_1_data_2.address = "address_test_1"
+        _details_1_data_2.amount = 3
+        _details_1_data_2.price = 4
+        _details_1_data_2.balance = 5
+        _details_1_data_2.acquisition_date = "2000/12/30"
+        db.add(_details_1_data_2)
+
+        # Not Target Data
+        _details_1_data_3 = LedgerDetailsData()
+        _details_1_data_3.token_address = token_address
+        _details_1_data_3.data_id = "not_target"
+        _details_1_data_3.name = "name_test_0"
+        _details_1_data_3.address = "address_test_0"
+        _details_1_data_3.amount = 0
+        _details_1_data_3.price = 1
+        _details_1_data_3.balance = 2
+        _details_1_data_3.acquisition_date = "2000/12/31"
+        db.add(_details_1_data_3)
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(token_address=token_address, data_id=data_id),
+            headers={
+                "issuer-address": issuer_address,
+            }
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == [
+            {
+                "name": "name_test_0",
+                "address": "address_test_0",
+                "amount": 0,
+                "price": 1,
+                "balance": 2,
+                "acquisition_date": "2000/12/31",
+            },
+            {
+                "name": "name_test_1",
+                "address": "address_test_1",
+                "amount": 3,
+                "price": 4,
+                "balance": 5,
+                "acquisition_date": "2000/12/30",
+            },
+        ]
+
     ###########################################################################
     # Error Case
     ###########################################################################

--- a/tests/test_app_routers_ledger_{token_address}_history_{ledger_id}_GET.py
+++ b/tests/test_app_routers_ledger_{token_address}_history_{ledger_id}_GET.py
@@ -765,7 +765,7 @@ class TestAppRoutersLedgerTokenAddressHistoryLedgerIdGET:
             # assertion
             token_get_mock_patch.assert_any_call(token_address)
             personal_get_info_mock_patch.assert_has_calls([
-                call(account_address=account_address_2, default_value="")
+                call(account_address=account_address_2, default_value=None)
             ])
 
         # assertion

--- a/tests/test_app_routers_ledger_{token_address}_history_{ledger_id}_GET.py
+++ b/tests/test_app_routers_ledger_{token_address}_history_{ledger_id}_GET.py
@@ -561,11 +561,11 @@ class TestAppRoutersLedgerTokenAddressHistoryLedgerIdGET:
             ],
         }
 
-    # <Normal_2>
+    # <Normal_2_1>
     # latest_flg = 1 (Get the latest personal info)
     #  address_1 has personal info in the DB
     #  address_2 has no personal info in the DB
-    def test_normal_2(self, client, db):
+    def test_normal_2_1(self, client, db):
         user_1 = config_eth_account("user1")
         issuer_address = user_1["address"]
         token_address = "0xABCdeF1234567890abcdEf123456789000000000"
@@ -801,6 +801,329 @@ class TestAppRoutersLedgerTokenAddressHistoryLedgerIdGET:
                             "account_address": account_address_1,
                             "name": "name_db_1",
                             "address": "address_db_1",
+                            "amount": 10,
+                            "price": 20,
+                            "balance": 30,
+                            "acquisition_date": "2022/12/02"
+                        },
+                        {
+                            "account_address": account_address_2,
+                            "name": "name_contract_2",
+                            "address": "address_contract_2",
+                            "amount": 100,
+                            "price": 200,
+                            "balance": 300,
+                            "acquisition_date": "2022/12/03"
+                        }
+                    ],
+                    "footers": [
+                        {
+                            "key": "aaa",
+                            "value": "aaa",
+                        },
+                        {
+                            "f-test1": "a",
+                            "f-test2": "b"
+                        }
+                    ],
+                },
+                {
+                    "token_detail_type": "権利_test_2",
+                    "headers": [
+                        {
+                            "key": "aaa",
+                            "value": "aaa",
+                        },
+                        {
+                            "test1-1": "a",
+                            "test2-1": "b"
+                        }
+                    ],
+                    "data": [
+                        {
+                            "account_address": None,
+                            "name": "name_test_1",
+                            "address": "address_test_1",
+                            "amount": 10,
+                            "price": 20,
+                            "balance": 200,
+                            "acquisition_date": "2020/01/01",
+                        },
+                        {
+                            "account_address": None,
+                            "name": "name_test_2",
+                            "address": "address_test_2",
+                            "amount": 20,
+                            "price": 30,
+                            "balance": 600,
+                            "acquisition_date": "2020/01/02",
+                        }
+                    ],
+                    "footers": [
+                        {
+                            "key": "aaa",
+                            "value": "aaa",
+                        },
+                        {
+                            "f-test1-1": "a",
+                            "f-test2-1": "b"
+                        }
+                    ],
+                },
+            ],
+            "footers": [
+                {
+                    "key": "aaa",
+                    "value": "aaa",
+                },
+                {
+                    "f-hoge": "aaaa",
+                    "f-fuga": "bbbb",
+                }
+            ],
+        }
+
+    # <Normal_2_2>
+    # latest_flg = 1 (Get the latest personal info)
+    #  address_1 has partial personal info in the DB
+    #  address_2 has no personal info in the DB
+    def test_normal_2_2(self, client, db):
+        user_1 = config_eth_account("user1")
+        issuer_address = user_1["address"]
+        token_address = "0xABCdeF1234567890abcdEf123456789000000000"
+        account_address_1 = "0xABCdeF1234567890abCDeF123456789000000001"
+        account_address_2 = "0xaBcdEF1234567890aBCDEF123456789000000002"
+        personal_info_contract_address = "0xabcDEF1234567890AbcDEf123456789000000003"
+
+        # prepare data
+        _token = Token()
+        _token.type = TokenType.IBET_STRAIGHT_BOND.value
+        _token.tx_hash = ""
+        _token.issuer_address = issuer_address
+        _token.token_address = token_address
+        _token.abi = {}
+        db.add(_token)
+
+        _ledger_1 = Ledger()
+        _ledger_1.token_address = token_address
+        _ledger_1.token_type = TokenType.IBET_STRAIGHT_BOND.value
+        _ledger_1.ledger = {
+            "created": "2022/12/01",
+            "token_name": "テスト原簿",
+            "headers": [
+                {
+                    "key": "aaa",
+                    "value": "aaa",
+                },
+                {
+                    "hoge": "aaaa",
+                    "fuga": "bbbb",
+                }
+            ],
+            "details": [
+                {
+                    "token_detail_type": "権利_test_1",
+                    "headers": [
+                        {
+                            "key": "aaa",
+                            "value": "aaa",
+                        },
+                        {
+                            "test1": "a",
+                            "test2": "b"
+                        }
+                    ],
+                    "data": [
+                        {
+                            "account_address": account_address_1,
+                            "name": "name_test_1",
+                            "address": "address_test_1",
+                            "amount": 10,
+                            "price": 20,
+                            "balance": 30,
+                            "acquisition_date": "2022/12/02"
+                        },
+                        {
+                            "account_address": account_address_2,
+                            "name": "name_test_2",
+                            "address": "address_test_2",
+                            "amount": 100,
+                            "price": 200,
+                            "balance": 300,
+                            "acquisition_date": "2022/12/03"
+                        }
+                    ],
+                    "footers": [
+                        {
+                            "key": "aaa",
+                            "value": "aaa",
+                        },
+                        {
+                            "f-test1": "a",
+                            "f-test2": "b"
+                        }
+                    ],
+                },
+                {
+                    "token_detail_type": "権利_test_2",
+                    "headers": [
+                        {
+                            "key": "aaa",
+                            "value": "aaa",
+                        },
+                        {
+                            "test1-1": "a",
+                            "test2-1": "b"
+                        }
+                    ],
+                    "data": [
+                        {
+                            "account_address": None,
+                            "name": "name_test_1",
+                            "address": "address_test_1",
+                            "amount": 10,
+                            "price": 20,
+                            "balance": 200,
+                            "acquisition_date": "2020/01/01",
+                        },
+                        {
+                            "account_address": None,
+                            "name": "name_test_2",
+                            "address": "address_test_2",
+                            "amount": 20,
+                            "price": 30,
+                            "balance": 600,
+                            "acquisition_date": "2020/01/02",
+                        }
+                    ],
+                    "footers": [
+                        {
+                            "key": "aaa",
+                            "value": "aaa",
+                        },
+                        {
+                            "f-test1-1": "a",
+                            "f-test2-1": "b"
+                        }
+                    ],
+                },
+            ],
+            "footers": [
+                {
+                    "key": "aaa",
+                    "value": "aaa",
+                },
+                {
+                    "f-hoge": "aaaa",
+                    "f-fuga": "bbbb",
+                }
+            ],
+        }
+        _ledger_1.ledger_created = datetime.strptime("2022/01/01 15:20:30", '%Y/%m/%d %H:%M:%S')  # JST 2022/01/02
+        db.add(_ledger_1)
+
+        _idx_personal_info_1 = IDXPersonalInfo()  # Note: account_address_1 has partial personal information in DB
+        _idx_personal_info_1.account_address = account_address_1
+        _idx_personal_info_1.issuer_address = issuer_address
+        _idx_personal_info_1.personal_info = {
+            "name": None,
+            "address": None
+        }
+        db.add(_idx_personal_info_1)
+
+        _details_1 = LedgerDetailsTemplate()
+        _details_1.token_address = token_address
+        _details_1.token_detail_type = "権利_test_1"
+        _details_1.headers = [
+            {
+                "key": "aaa",
+                "value": "aaa",
+            },
+            {
+                "test1": "a",
+                "test2": "b"
+            }
+        ]
+        _details_1.footers = [
+            {
+                "key": "aaa",
+                "value": "aaa",
+            },
+            {
+                "f-test1": "a",
+                "f-test2": "b"
+            }
+        ]
+        _details_1.data_type = LedgerDetailsDataType.IBET_FIN.value
+        _details_1.data_source = token_address
+        db.add(_details_1)
+
+        # Mock
+        token = IbetStraightBondContract()
+        token.personal_info_contract_address = personal_info_contract_address
+        token.issuer_address = issuer_address
+        token_get_mock = mock.patch("app.model.blockchain.IbetStraightBondContract.get", return_value=token)
+        personal_get_info_mock = mock.patch("app.model.blockchain.PersonalInfoContract.get_info")
+
+        # request target API
+        with token_get_mock as token_get_mock_patch, personal_get_info_mock as personal_get_info_mock_patch:
+            # Note:
+            # account_address_2 has no personal information in the DB
+            # and gets information from the contract
+            personal_get_info_mock_patch.side_effect = [{
+                "name": "name_contract_2",
+                "address": "address_contract_2",
+            }]
+
+            resp = client.get(
+                self.base_url.format(token_address=token_address, ledger_id=1),
+                params={
+                    "latest_flg": 1,
+                },
+                headers={
+                    "issuer-address": issuer_address,
+                }
+            )
+            # assertion
+            token_get_mock_patch.assert_any_call(token_address)
+            personal_get_info_mock_patch.assert_has_calls([
+                call(account_address=account_address_2, default_value=None)
+            ])
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "created": "2022/12/01",
+            "token_name": "テスト原簿",
+            "headers": [
+                {
+                    "key": "aaa",
+                    "value": "aaa",
+                },
+                {
+                    "hoge": "aaaa",
+                    "fuga": "bbbb",
+                }
+            ],
+            "details": [
+                {
+                    "token_detail_type": "権利_test_1",
+                    "headers": [
+                        {
+                            "key": "aaa",
+                            "value": "aaa",
+                        },
+                        {
+                            "test1": "a",
+                            "test2": "b"
+                        }
+                    ],
+                    "data": [
+                        {
+                            "account_address": account_address_1,
+                            # Value stored with None should be converted to empty string.
+                            "name": "",
+                            "address": "",
                             "amount": 10,
                             "price": 20,
                             "balance": 30,

--- a/tests/test_app_routers_share_tokens_{token_address}_holders_GET.py
+++ b/tests/test_app_routers_share_tokens_{token_address}_holders_GET.py
@@ -149,6 +149,7 @@ class TestAppRoutersShareTokensTokenAddressHoldersGET:
         _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
         _account_address_1 = "0xb75c7545b9230FEe99b7af370D38eBd3DAD929f7"
         _account_address_2 = "0x3F198534Bbe3B2a197d3B317d41392F348EAC707"
+        _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         # prepare data
         account = Account()
@@ -196,6 +197,29 @@ class TestAppRoutersShareTokensTokenAddressHoldersGET:
         idx_position_2.pending_transfer = 10
         db.add(idx_position_2)
 
+        idx_position_3 = IDXPosition()
+        idx_position_3.token_address = _token_address
+        idx_position_3.account_address = _account_address_3
+        idx_position_3.balance = 99
+        idx_position_3.exchange_balance = 99
+        idx_position_3.exchange_commitment = 99
+        idx_position_3.pending_transfer = 99
+        db.add(idx_position_3)
+
+        idx_personal_info_3 = IDXPersonalInfo()
+        idx_personal_info_3.account_address = _account_address_3
+        idx_personal_info_3.issuer_address = _issuer_address
+        idx_personal_info_3.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test3",
+            "postal_code": "postal_code_test3",
+            "address": "address_test3",
+            "email": "email_test3",
+            "birth": "birth_test3"
+            # PersonalInfo is partially registered.
+        }
+        db.add(idx_personal_info_3)
+
         # request target API
         resp = client.get(
             self.base_url.format(_token_address),
@@ -240,6 +264,23 @@ class TestAppRoutersShareTokensTokenAddressHoldersGET:
                 "exchange_balance": 21,
                 "exchange_commitment": 22,
                 "pending_transfer": 10
+            },
+            {
+                "account_address": _account_address_3,
+                "personal_information": {
+                    "key_manager": "key_manager_test1",
+                    "name": "name_test3",
+                    "postal_code": "postal_code_test3",
+                    "address": "address_test3",
+                    "email": "email_test3",
+                    "birth": "birth_test3",
+                    "is_corporate": None,
+                    "tax_category": None
+                },
+                "balance": 99,
+                "exchange_balance": 99,
+                "exchange_commitment": 99,
+                "pending_transfer": 99
             }
         ]
 

--- a/tests/test_app_routers_share_tokens_{token_address}_holders_{account_address}_GET.py
+++ b/tests/test_app_routers_share_tokens_{token_address}_holders_{account_address}_GET.py
@@ -106,9 +106,9 @@ class TestAppRoutersShareTokensTokenAddressHoldersAccountAddressGET:
             "pending_transfer": 5
         }
 
-    # <Normal_2>
+    # <Normal_2_1>
     # PersonalInfo not registry
-    def test_normal_2(self, client, db):
+    def test_normal_2_1(self, client, db):
         user = config_eth_account("user1")
         _issuer_address = user["address"]
         _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
@@ -155,6 +155,78 @@ class TestAppRoutersShareTokensTokenAddressHoldersAccountAddressGET:
                 "address": None,
                 "email": None,
                 "birth": None,
+                "is_corporate": None,
+                "tax_category": None
+            },
+            "balance": 10,
+            "exchange_balance": 11,
+            "exchange_commitment": 12,
+            "pending_transfer": 5
+        }
+
+    # <Normal_2_2>
+    # PersonalInfo is partially registered
+    def test_normal_2_2(self, client, db):
+        user = config_eth_account("user1")
+        _issuer_address = user["address"]
+        _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
+        _account_address_1 = "0xb75c7545b9230FEe99b7af370D38eBd3DAD929f7"
+
+        # prepare data
+        account = Account()
+        account.issuer_address = _issuer_address
+        db.add(account)
+
+        token = Token()
+        token.type = TokenType.IBET_SHARE.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        db.add(token)
+
+        idx_position_1 = IDXPosition()
+        idx_position_1.token_address = _token_address
+        idx_position_1.account_address = _account_address_1
+        idx_position_1.balance = 10
+        idx_position_1.exchange_balance = 11
+        idx_position_1.exchange_commitment = 12
+        idx_position_1.pending_transfer = 5
+        db.add(idx_position_1)
+
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = _account_address_1
+        idx_personal_info_1.issuer_address = _issuer_address
+        idx_personal_info_1.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1"
+            # PersonalInfo is partially registered.
+        }
+        db.add(idx_personal_info_1)
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address, _account_address_1),
+            headers={
+                "issuer-address": _issuer_address
+            }
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "account_address": _account_address_1,
+            "personal_information": {
+                "key_manager": "key_manager_test1",
+                "name": "name_test1",
+                "postal_code": "postal_code_test1",
+                "address": "address_test1",
+                "email": "email_test1",
+                "birth": "birth_test1",
                 "is_corporate": None,
                 "tax_category": None
             },

--- a/tests/test_app_routers_share_tokens_{token_address}_holders_{account_address}_personal_info_POST.py
+++ b/tests/test_app_routers_share_tokens_{token_address}_holders_{account_address}_personal_info_POST.py
@@ -114,7 +114,8 @@ class TestAppRoutersShareTokensTokenAddressHoldersAccountAddressPersonalInfoPOST
             )
             PersonalInfoContract.modify_info.assert_called_with(
                 account_address=_test_account_address,
-                data=req_param
+                data=req_param,
+                default_value=None
             )
 
     # <Normal_2>
@@ -192,7 +193,8 @@ class TestAppRoutersShareTokensTokenAddressHoldersAccountAddressPersonalInfoPOST
             )
             PersonalInfoContract.modify_info.assert_called_with(
                 account_address=_test_account_address,
-                data=req_param
+                data=req_param,
+                default_value=None
             )
 
     ###########################################################################

--- a/tests/test_app_routers_share_tokens_{token_address}_personal_info_POST.py
+++ b/tests/test_app_routers_share_tokens_{token_address}_personal_info_POST.py
@@ -115,7 +115,8 @@ class TestAppRoutersShareTokensTokenAddressPersonalInfoPOST:
             )
             PersonalInfoContract.register_info.assert_called_with(
                 account_address=_test_account_address,
-                data=req_param
+                data=req_param,
+                default_value=None
             )
 
     # <Normal_2>
@@ -194,7 +195,8 @@ class TestAppRoutersShareTokensTokenAddressPersonalInfoPOST:
             )
             PersonalInfoContract.register_info.assert_called_with(
                 account_address=_test_account_address,
-                data=req_param
+                data=req_param,
+                default_value=None
             )
 
     ###########################################################################


### PR DESCRIPTION
Close #335 

----
## Summary

PersonalInfo is transmitted through the following 3 channels.

1. ibet-Prime Outside(REST API) => ibet-Prime Inside(DB)
2. ibet-Prime Inside(DB) <=> ibet-Network
3. ibet-Prime Inside(DB) => ibet-Prime Outside(REST-API)

So I revised DB model/Contract util/REST-API.

### DB
I fixed DB model(not schema).
Now default_value is automatically set to personal_information.

https://github.com/BoostryJP/ibet-Prime/blob/1d7a9b889a8953bdab5aa633ede612673e93fa69/app/model/db/idx_personal_info.py#L52-L78

### Contract util
I added default_value argument as None explicitly to all Create/Update methods.

### REST-API
I checked following 5 endpoints and fixed 1 endpoint.
(This is referred to in Issue #355 .)
All but one is currently allowed to use null value in PersonalInfo.

```s
Checked
# GET: /bond/tokens/{token_address}/holders
# GET: /share/tokens/{token_address}/holders
# GET: /bond/tokens/{token_address}/holders/{account_address}
# GET: /share/tokens/{token_address}/holders/{account_address}

Fixed
# GET: /ledger/{token_address}/history/{ledger_id}
```

---

<details><pre><code>

1. DBモデルの修正
PersonalInfoをDBへ保存したり、読み出したりする際にデフォルト値がセットされるようDBモデルを拡張する形で修正を行いました。
スキーマは変更していません。

2. コントラクト関数の呼び出し箇所修正
デフォルト値を明示的にセットするよう各所を修正しました。

3. REST-APIの修正
PersonalInfoを取り扱うエンドポイント5つに関して、修正要否を検討し
#355 で言及されている箇所のみ修正を行いました。
</code></pre></details>