### PR TITLE
fix: An error occurs in the ledger API when personal information is null (Response Schema)

### DIFF
--- a/app/model/schema/ledger.py
+++ b/app/model/schema/ledger.py
@@ -106,8 +106,8 @@ class ListAllLedgerHistoryResponse(BaseModel):
 class RetrieveLedgerDetailsDataHistoryResponse(BaseModel):
     """Retrieve Ledger Details Data History schema (Response)"""
     account_address: Optional[str]
-    name: str
-    address: str
+    name: Optional[str]
+    address: Optional[str]
     amount: int
     price: int
     balance: int
@@ -173,8 +173,8 @@ class LedgerDetailsDataResponse(BaseModel):
 
 class RetrieveLedgerDetailsDataResponse(BaseModel):
     """Retrieve Ledger Details Data schema (Response)"""
-    name: str
-    address: str
+    name: Optional[str]
+    address: Optional[str]
     amount: int
     price: int
     balance: int

--- a/app/routers/ledger.py
+++ b/app/routers/ledger.py
@@ -215,8 +215,8 @@ def retrieve_ledger_history(
                         db=db
                     )
                     if personal_info is not None:
-                        data["name"] = personal_info.get("name", None) or ""
-                        data["address"] = personal_info.get("address", None) or ""
+                        data["name"] = personal_info.get("name", None)
+                        data["address"] = personal_info.get("address", None)
 
     return resp
 

--- a/app/utils/ledger_utils.py
+++ b/app/utils/ledger_utils.py
@@ -189,8 +189,8 @@ def __get_details_data_list_from_ibetfin(token_address: str, token_type: str, db
         for date_ymd, amount in date_ymd_amount.items():
             details_data = {
                 "account_address": account_address,
-                "name": "",
-                "address": "",
+                "name": None,
+                "address": None,
                 "amount": amount,
                 "price": price,
                 "balance": price * amount,
@@ -199,8 +199,8 @@ def __get_details_data_list_from_ibetfin(token_address: str, token_type: str, db
 
             # Update PersonalInfo
             personal_info = __get_personal_info(account_address, issuer_address, personal_info_contract, db)
-            details_data["name"] = personal_info.get("name", "")
-            details_data["address"] = personal_info.get("address", "")
+            details_data["name"] = personal_info.get("name", None)
+            details_data["address"] = personal_info.get("address", None)
 
             data_list.append(details_data)
 

--- a/tests/test_app_routers_ledger_{token_address}_details_data_{data_id}_GET.py
+++ b/tests/test_app_routers_ledger_{token_address}_details_data_{data_id}_GET.py
@@ -210,7 +210,7 @@ class TestAppRoutersLedgerTokenAddressDetailsDataDataIdGET:
         _details_1_data_1.token_address = token_address
         _details_1_data_1.data_id = data_id
         _details_1_data_1.name = "name_test_0"
-        _details_1_data_1.address = "address_test_0"
+        _details_1_data_1.address = None
         _details_1_data_1.amount = 0
         _details_1_data_1.price = 1
         _details_1_data_1.balance = 2
@@ -253,7 +253,7 @@ class TestAppRoutersLedgerTokenAddressDetailsDataDataIdGET:
         assert resp.json() == [
             {
                 "name": "name_test_0",
-                "address": "address_test_0",
+                "address": None,
                 "amount": 0,
                 "price": 1,
                 "balance": 2,

--- a/tests/test_app_routers_ledger_{token_address}_history_{ledger_id}_GET.py
+++ b/tests/test_app_routers_ledger_{token_address}_history_{ledger_id}_GET.py
@@ -1122,8 +1122,8 @@ class TestAppRoutersLedgerTokenAddressHistoryLedgerIdGET:
                         {
                             "account_address": account_address_1,
                             # Value stored with None should be converted to empty string.
-                            "name": "",
-                            "address": "",
+                            "name": None,
+                            "address": None,
                             "amount": 10,
                             "price": 20,
                             "balance": 30,
@@ -1133,6 +1133,303 @@ class TestAppRoutersLedgerTokenAddressHistoryLedgerIdGET:
                             "account_address": account_address_2,
                             "name": "name_contract_2",
                             "address": "address_contract_2",
+                            "amount": 100,
+                            "price": 200,
+                            "balance": 300,
+                            "acquisition_date": "2022/12/03"
+                        }
+                    ],
+                    "footers": [
+                        {
+                            "key": "aaa",
+                            "value": "aaa",
+                        },
+                        {
+                            "f-test1": "a",
+                            "f-test2": "b"
+                        }
+                    ],
+                },
+                {
+                    "token_detail_type": "権利_test_2",
+                    "headers": [
+                        {
+                            "key": "aaa",
+                            "value": "aaa",
+                        },
+                        {
+                            "test1-1": "a",
+                            "test2-1": "b"
+                        }
+                    ],
+                    "data": [
+                        {
+                            "account_address": None,
+                            "name": "name_test_1",
+                            "address": "address_test_1",
+                            "amount": 10,
+                            "price": 20,
+                            "balance": 200,
+                            "acquisition_date": "2020/01/01",
+                        },
+                        {
+                            "account_address": None,
+                            "name": "name_test_2",
+                            "address": "address_test_2",
+                            "amount": 20,
+                            "price": 30,
+                            "balance": 600,
+                            "acquisition_date": "2020/01/02",
+                        }
+                    ],
+                    "footers": [
+                        {
+                            "key": "aaa",
+                            "value": "aaa",
+                        },
+                        {
+                            "f-test1-1": "a",
+                            "f-test2-1": "b"
+                        }
+                    ],
+                },
+            ],
+            "footers": [
+                {
+                    "key": "aaa",
+                    "value": "aaa",
+                },
+                {
+                    "f-hoge": "aaaa",
+                    "f-fuga": "bbbb",
+                }
+            ],
+        }
+
+    # <Normal_3>
+    # latest_flg = 0 (Get the latest personal info)
+    #  ledger detail contains None value in "name" and "value"
+    def test_normal_3(self, client, db):
+        user_1 = config_eth_account("user1")
+        issuer_address = user_1["address"]
+        token_address = "0xABCdeF1234567890abcdEf123456789000000000"
+        account_address_1 = "0xABCdeF1234567890abCDeF123456789000000001"
+        account_address_2 = "0xaBcdEF1234567890aBCDEF123456789000000002"
+        personal_info_contract_address = "0xabcDEF1234567890AbcDEf123456789000000003"
+
+        # prepare data
+        _token = Token()
+        _token.type = TokenType.IBET_STRAIGHT_BOND.value
+        _token.tx_hash = ""
+        _token.issuer_address = issuer_address
+        _token.token_address = token_address
+        _token.abi = {}
+        db.add(_token)
+
+        _ledger_1 = Ledger()
+        _ledger_1.token_address = token_address
+        _ledger_1.token_type = TokenType.IBET_STRAIGHT_BOND.value
+        _ledger_1.ledger = {
+            "created": "2022/12/01",
+            "token_name": "テスト原簿",
+            "headers": [
+                {
+                    "key": "aaa",
+                    "value": "aaa",
+                },
+                {
+                    "hoge": "aaaa",
+                    "fuga": "bbbb",
+                }
+            ],
+            "details": [
+                {
+                    "token_detail_type": "権利_test_1",
+                    "headers": [
+                        {
+                            "key": "aaa",
+                            "value": "aaa",
+                        },
+                        {
+                            "test1": "a",
+                            "test2": "b"
+                        }
+                    ],
+                    "data": [
+                        {
+                            "account_address": account_address_1,
+                            "name": None,
+                            "address": None,
+                            "amount": 10,
+                            "price": 20,
+                            "balance": 30,
+                            "acquisition_date": "2022/12/02"
+                        },
+                        {
+                            "account_address": account_address_2,
+                            "name": "name_test_2",
+                            "address": "address_test_2",
+                            "amount": 100,
+                            "price": 200,
+                            "balance": 300,
+                            "acquisition_date": "2022/12/03"
+                        }
+                    ],
+                    "footers": [
+                        {
+                            "key": "aaa",
+                            "value": "aaa",
+                        },
+                        {
+                            "f-test1": "a",
+                            "f-test2": "b"
+                        }
+                    ],
+                },
+                {
+                    "token_detail_type": "権利_test_2",
+                    "headers": [
+                        {
+                            "key": "aaa",
+                            "value": "aaa",
+                        },
+                        {
+                            "test1-1": "a",
+                            "test2-1": "b"
+                        }
+                    ],
+                    "data": [
+                        {
+                            "account_address": None,
+                            "name": "name_test_1",
+                            "address": "address_test_1",
+                            "amount": 10,
+                            "price": 20,
+                            "balance": 200,
+                            "acquisition_date": "2020/01/01",
+                        },
+                        {
+                            "account_address": None,
+                            "name": "name_test_2",
+                            "address": "address_test_2",
+                            "amount": 20,
+                            "price": 30,
+                            "balance": 600,
+                            "acquisition_date": "2020/01/02",
+                        }
+                    ],
+                    "footers": [
+                        {
+                            "key": "aaa",
+                            "value": "aaa",
+                        },
+                        {
+                            "f-test1-1": "a",
+                            "f-test2-1": "b"
+                        }
+                    ],
+                },
+            ],
+            "footers": [
+                {
+                    "key": "aaa",
+                    "value": "aaa",
+                },
+                {
+                    "f-hoge": "aaaa",
+                    "f-fuga": "bbbb",
+                }
+            ],
+        }
+        _ledger_1.ledger_created = datetime.strptime("2022/01/01 15:20:30", '%Y/%m/%d %H:%M:%S')  # JST 2022/01/02
+        db.add(_ledger_1)
+
+        _details_1 = LedgerDetailsTemplate()
+        _details_1.token_address = token_address
+        _details_1.token_detail_type = "権利_test_1"
+        _details_1.headers = [
+            {
+                "key": "aaa",
+                "value": "aaa",
+            },
+            {
+                "test1": "a",
+                "test2": "b"
+            }
+        ]
+        _details_1.footers = [
+            {
+                "key": "aaa",
+                "value": "aaa",
+            },
+            {
+                "f-test1": "a",
+                "f-test2": "b"
+            }
+        ]
+        _details_1.data_type = LedgerDetailsDataType.IBET_FIN.value
+        _details_1.data_source = token_address
+        db.add(_details_1)
+
+        # Mock
+        token = IbetStraightBondContract()
+        token.personal_info_contract_address = personal_info_contract_address
+        token.issuer_address = issuer_address
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(token_address=token_address, ledger_id=1),
+            params={
+                "latest_flg": 0,
+            },
+            headers={
+                "issuer-address": issuer_address,
+            }
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "created": "2022/12/01",
+            "token_name": "テスト原簿",
+            "headers": [
+                {
+                    "key": "aaa",
+                    "value": "aaa",
+                },
+                {
+                    "hoge": "aaaa",
+                    "fuga": "bbbb",
+                }
+            ],
+            "details": [
+                {
+                    "token_detail_type": "権利_test_1",
+                    "headers": [
+                        {
+                            "key": "aaa",
+                            "value": "aaa",
+                        },
+                        {
+                            "test1": "a",
+                            "test2": "b"
+                        }
+                    ],
+                    "data": [
+                        {
+                            "account_address": account_address_1,
+                            # Value stored with None should be converted to empty string.
+                            "name": None,
+                            "address": None,
+                            "amount": 10,
+                            "price": 20,
+                            "balance": 30,
+                            "acquisition_date": "2022/12/02"
+                        },
+                        {
+                            "account_address": account_address_2,
+                            "name": "name_test_2",
+                            "address": "address_test_2",
                             "amount": 100,
                             "price": 200,
                             "balance": 300,


### PR DESCRIPTION
Close #335 
----

Following schema fixed.

```s
# GET: /ledger/{token_address}/history/{ledger_id}
# GET: /ledger/{token_address}/details_data/{data_id}
```

https://github.com/BoostryJP/ibet-Prime/blob/03c84b377155f1e290f3422ff69e8530dfd7ee07/app/model/schema/ledger.py#L106-L114

https://github.com/BoostryJP/ibet-Prime/blob/03c84b377155f1e290f3422ff69e8530dfd7ee07/app/model/schema/ledger.py#L174-L181