### PR TITLE
feat: upgrade python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,8 +49,8 @@ RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~apl/.bash_profile \
 # install python
 USER apl
 RUN . ~/.bash_profile \
- && pyenv install 3.8.13 \
- && pyenv global 3.8.13 \
+ && pyenv install 3.10.4 \
+ && pyenv global 3.10.4 \
  && pip install --upgrade pip
 
 # install python packages

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 ## Dependencies
 
-- [python3](https://www.python.org/downloads/release/python-3811/) version 3.8 or greater
+- [python3](https://www.python.org/downloads/release/python-3811/) version 3.10 or later
 - [PostgreSQL](https://www.postgresql.org/) - Version 13
 - [GoQuorum](https://github.com/ConsenSys/quorum)
   - We support the official GoQuorum node of [ibet-Network](https://github.com/BoostryJP/ibet-Network).

--- a/requirements.lock
+++ b/requirements.lock
@@ -11,7 +11,7 @@ bitarray==2.5.1
 boto3==1.17.12
 botocore==1.20.112
 certifi==2022.6.15
-cffi==1.15.0
+cffi==1.15.1
 chardet==4.0.0
 charset-normalizer==2.1.0
 click==8.1.3
@@ -19,7 +19,7 @@ coincurve==14.0.0
 cytoolz==0.11.2
 eth-abi==2.1.1
 eth-account==0.5.8
-eth-hash==0.3.2
+eth-hash==0.3.3
 eth-keyfile==0.5.1
 eth-keys==0.3.4
 eth-rlp==0.2.1
@@ -27,6 +27,7 @@ eth-typing==2.3.0
 eth-utils==1.10.0
 fastapi==0.75.2
 frozenlist==1.3.0
+greenlet==1.1.2
 gunicorn==20.1.0
 h11==0.13.0
 hexbytes==0.2.2
@@ -35,14 +36,14 @@ ipfshttpclient==0.7.0
 jmespath==0.10.0
 jsonschema==3.2.0
 lru-dict==1.1.7
-Mako==1.2.0
+Mako==1.2.1
 MarkupSafe==2.1.1
 multiaddr==0.0.9
 multidict==6.0.2
 netaddr==0.8.0
 parsimonious==0.8.1
 protobuf==3.20.1
-psycopg2-binary==2.8.6
+psycopg2-binary==2.9.3
 pycparser==2.21
 pycryptodome==3.15.0
 pydantic==1.8.2
@@ -58,10 +59,10 @@ s3transfer==0.3.7
 shared-memory-dict==0.5.0
 six==1.16.0
 sniffio==1.2.0
-SQLAlchemy==1.3.22
+SQLAlchemy==1.4.39
 starlette==0.17.1
 toolz==0.11.2
-typing_extensions==4.2.0
+typing_extensions==4.3.0
 urllib3==1.26.9
 uvicorn==0.17.6
 varint==1.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-SQLAlchemy==1.3.22
-psycopg2-binary==2.8.6
+SQLAlchemy>=1.4,<1.5
+psycopg2-binary==2.9.3
 web3==5.20.1
 eth-keyfile==0.5.1
 pysha3==1.0.2

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -49,8 +49,8 @@ RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~apl/.bash_profile \
 # install python
 USER apl
 RUN . ~/.bash_profile \
- && pyenv install 3.8.13 \
- && pyenv global 3.8.13 \
+ && pyenv install 3.10.4 \
+ && pyenv global 3.10.4 \
  && pip install --upgrade pip
 
 # install python packages

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
-pytest==6.2.2
-pytest-cov==2.11.1
+pytest==7.1.2
+pytest-cov==3.0.0
 PyYAML==5.4.1
 pytest-freezegun==0.4.2


### PR DESCRIPTION
Upgrade python from 3.8 to 3.10 latest.

As part of this upgrade, we are upgrading the following modules to the latest versions

- psycopg2-binary
- pytest

Also, currently, the version of SQLAlchemy was not fixed, so it was fixed.