### PR TITLE
feat: add query param to position API for retrieving former holders

### DIFF
--- a/app/routers/bond.py
+++ b/app/routers/bond.py
@@ -909,6 +909,7 @@ def delete_scheduled_event(
 )
 def list_all_holders(
         token_address: str,
+        include_former_holder: bool = False,
         issuer_address: str = Header(...),
         db: Session = Depends(db_session)):
     """List all bond token holders"""
@@ -935,15 +936,17 @@ def list_all_holders(
     if _token.token_status == 0:
         raise InvalidParameterError("this token is temporarily unavailable")
 
-    # Get Holders
-    _holders = db.query(IDXPosition). \
-        filter(IDXPosition.token_address == token_address). \
-        filter(or_(
+    query = db.query(IDXPosition). \
+        filter(IDXPosition.token_address == token_address)
+    if not include_former_holder:
+        # Get Holders
+        query = query.filter(or_(
             IDXPosition.balance != 0,
             IDXPosition.exchange_balance != 0,
             IDXPosition.pending_transfer != 0,
             IDXPosition.exchange_commitment != 0
-        )).order_by(IDXPosition.id).all()
+        ))
+    _holders = query.order_by(IDXPosition.id).all()
 
     # Get personal information
     _personal_info_list = db.query(IDXPersonalInfo). \

--- a/app/routers/share.py
+++ b/app/routers/share.py
@@ -897,6 +897,7 @@ def delete_scheduled_event(
 )
 def list_all_holders(
         token_address: str,
+        include_former_holder: bool = False,
         issuer_address: str = Header(...),
         db: Session = Depends(db_session)):
     """List all share token holders"""
@@ -924,14 +925,17 @@ def list_all_holders(
         raise InvalidParameterError("this token is temporarily unavailable")
 
     # Get Holders
-    _holders = db.query(IDXPosition). \
-        filter(IDXPosition.token_address == token_address). \
-        filter(or_(
+    query = db.query(IDXPosition). \
+        filter(IDXPosition.token_address == token_address)
+    if not include_former_holder:
+        # Get Holders
+        query = query.filter(or_(
             IDXPosition.balance != 0,
             IDXPosition.exchange_balance != 0,
             IDXPosition.pending_transfer != 0,
             IDXPosition.exchange_commitment != 0
-        )).order_by(IDXPosition.id).all()
+        ))
+    _holders = query.order_by(IDXPosition.id).all()
 
     # Get personal information
     _personal_info_list = db.query(IDXPersonalInfo). \

--- a/app/utils/contract_utils.py
+++ b/app/utils/contract_utils.py
@@ -220,10 +220,10 @@ class ContractUtils:
 
         # build a new transaction to replay:
         replay_tx = {
-            'to': tx['to'],
-            'from': tx['from'],
-            'value': tx['value'],
-            'data': tx['input'],
+            "to": tx.get("to"),
+            "from": tx.get("from"),
+            "value": tx.get("value"),
+            "data": tx.get("input"),
         }
 
         # replay the transaction locally:

--- a/tests/test_app_routers_bond_tokens_{token_address}_holders_GET.py
+++ b/tests/test_app_routers_bond_tokens_{token_address}_holders_GET.py
@@ -286,6 +286,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
 
     # <Normal_3_2>
     # Multi record (Including former holder)
+    # Query param: including_former_holder=None
     def test_normal_3_2(self, client, db):
         user = config_eth_account("user1")
         _issuer_address = user["address"]
@@ -406,6 +407,154 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
                 },
                 "balance": 20,
                 "exchange_balance": 21,
+                "exchange_commitment": 0,
+                "pending_transfer": 0
+            }
+        ]
+
+    # <Normal_3_3>
+    # Multi record (Including former holder)
+    # Query param: including_former_holder=True
+    def test_normal_3_3(self, client, db):
+        user = config_eth_account("user1")
+        _issuer_address = user["address"]
+        _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
+        _account_address_1 = "0xb75c7545b9230FEe99b7af370D38eBd3DAD929f7"
+        _account_address_2 = "0x3F198534Bbe3B2a197d3B317d41392F348EAC707"
+        _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
+
+        # prepare data
+        account = Account()
+        account.issuer_address = _issuer_address
+        db.add(account)
+
+        token = Token()
+        token.type = TokenType.IBET_STRAIGHT_BOND.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        db.add(token)
+
+        idx_position_1 = IDXPosition()
+        idx_position_1.token_address = _token_address
+        idx_position_1.account_address = _account_address_1
+        idx_position_1.balance = 0
+        idx_position_1.exchange_balance = 0
+        idx_position_1.exchange_commitment = 12
+        idx_position_1.pending_transfer = 5
+        db.add(idx_position_1)
+
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = _account_address_1
+        idx_personal_info_1.issuer_address = _issuer_address
+        idx_personal_info_1.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10
+        }
+        db.add(idx_personal_info_1)
+
+        idx_position_2 = IDXPosition()
+        idx_position_2.token_address = _token_address
+        idx_position_2.account_address = _account_address_2
+        idx_position_2.balance = 20
+        idx_position_2.exchange_balance = 21
+        idx_position_2.exchange_commitment = 0
+        idx_position_2.pending_transfer = 0
+        db.add(idx_position_2)
+
+        idx_position_3 = IDXPosition()
+        idx_position_3.token_address = _token_address
+        idx_position_3.account_address = _account_address_3
+        idx_position_3.balance = 0
+        idx_position_3.exchange_balance = 0
+        idx_position_3.exchange_commitment = 0
+        idx_position_3.pending_transfer = 0
+        db.add(idx_position_3)
+
+        idx_personal_info_3 = IDXPersonalInfo()
+        idx_personal_info_3.account_address = _account_address_3
+        idx_personal_info_3.issuer_address = _issuer_address
+        idx_personal_info_3.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test3",
+            "postal_code": "postal_code_test3",
+            "address": "address_test3",
+            "email": "email_test3",
+            "birth": "birth_test3"
+            # PersonalInfo is partially registered.
+        }
+        db.add(idx_personal_info_3)
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address),
+            headers={
+                "issuer-address": _issuer_address
+            },
+            params={
+                "include_former_holder": "true"
+            }
+        )
+
+        # assertion
+        # former holder who has currently no balance is not listed
+        assert resp.status_code == 200
+        assert resp.json() == [
+            {
+                "account_address": _account_address_1,
+                "personal_information": {
+                    "key_manager": "key_manager_test1",
+                    "name": "name_test1",
+                    "postal_code": "postal_code_test1",
+                    "address": "address_test1",
+                    "email": "email_test1",
+                    "birth": "birth_test1",
+                    "is_corporate": False,
+                    "tax_category": 10
+                },
+                "balance": 0,
+                "exchange_balance": 0,
+                "exchange_commitment": 12,
+                "pending_transfer": 5
+            },
+            {
+                "account_address": _account_address_2,
+                "personal_information": {
+                    "key_manager": None,
+                    "name": None,
+                    "postal_code": None,
+                    "address": None,
+                    "email": None,
+                    "birth": None,
+                    "is_corporate": None,
+                    "tax_category": None
+                },
+                "balance": 20,
+                "exchange_balance": 21,
+                "exchange_commitment": 0,
+                "pending_transfer": 0
+            },
+            {
+                "account_address": _account_address_3,
+                "personal_information": {
+                    "key_manager": "key_manager_test1",
+                    "name": "name_test3",
+                    "postal_code": "postal_code_test3",
+                    "address": "address_test3",
+                    "email": "email_test3",
+                    "birth": "birth_test3",
+                    "is_corporate": None,
+                    "tax_category": None
+                },
+                "balance": 0,
+                "exchange_balance": 0,
                 "exchange_commitment": 0,
                 "pending_transfer": 0
             }

--- a/tests/test_app_routers_positions_{account_address}_GET.py
+++ b/tests/test_app_routers_positions_{account_address}_GET.py
@@ -693,6 +693,163 @@ class TestAppRoutersPositionsAccountAddressGET:
             ]
         }
 
+    # <Normal_5_3>
+    # Search Filter
+    # including_former_position
+    @mock.patch("app.model.blockchain.token.IbetShareContract.get")
+    @mock.patch("app.model.blockchain.token.IbetStraightBondContract.get")
+    def test_normal_5_3(self, mock_IbetStraightBondContract_get, mock_IbetShareContract_get, client, db):
+        account_address = "0x1234567890123456789012345678900000000000"
+
+        # prepare data: Token
+        _token = Token()
+        _token.token_address = "0x1234567890123456789012345678900000000010"
+        _token.issuer_address = "0x1234567890123456789012345678900000000100"
+        _token.type = TokenType.IBET_STRAIGHT_BOND.value
+        _token.tx_hash = ""
+        _token.abi = ""
+        db.add(_token)
+
+        # prepare data: Position
+        _position = IDXPosition()
+        _position.token_address = "0x1234567890123456789012345678900000000010"
+        _position.account_address = account_address
+        _position.balance = 10
+        _position.exchange_balance = 11
+        _position.exchange_commitment = 12
+        _position.pending_transfer = 13
+        db.add(_position)
+
+        # prepare data: Token
+        _token = Token()
+        _token.token_address = "0x1234567890123456789012345678900000000011"
+        _token.issuer_address = "0x1234567890123456789012345678900000000101"
+        _token.type = TokenType.IBET_STRAIGHT_BOND.value
+        _token.tx_hash = ""
+        _token.abi = ""
+        db.add(_token)
+
+        # prepare data: Position
+        _position = IDXPosition()
+        _position.token_address = "0x1234567890123456789012345678900000000011"
+        _position.account_address = account_address
+        _position.balance = 0
+        _position.exchange_balance = 0
+        _position.exchange_commitment = 0
+        _position.pending_transfer = 0
+        db.add(_position)
+
+        # prepare data: Token
+        _token = Token()
+        _token.token_address = "0x1234567890123456789012345678900000000012"
+        _token.issuer_address = "0x1234567890123456789012345678900000000100"
+        _token.type = TokenType.IBET_SHARE.value
+        _token.tx_hash = ""
+        _token.abi = ""
+        db.add(_token)
+
+        # prepare data: Position
+        _position = IDXPosition()
+        _position.token_address = "0x1234567890123456789012345678900000000012"
+        _position.account_address = account_address
+        _position.balance = 30
+        _position.exchange_balance = 20
+        _position.exchange_commitment = 10
+        _position.pending_transfer = 1
+        db.add(_position)
+
+        # prepare data: Token
+        _token = Token()
+        _token.token_address = "0x1234567890123456789012345678900000000013"
+        _token.issuer_address = "0x1234567890123456789012345678900000000101"
+        _token.type = TokenType.IBET_SHARE.value
+        _token.tx_hash = ""
+        _token.abi = ""
+        db.add(_token)
+
+        # prepare data: Position
+        _position = IDXPosition()
+        _position.token_address = "0x1234567890123456789012345678900000000013"
+        _position.account_address = account_address
+        _position.balance = 0
+        _position.exchange_balance = 0
+        _position.exchange_commitment = 0
+        _position.pending_transfer = 0
+        db.add(_position)
+
+        # mock
+        bond_1 = IbetStraightBondContract()
+        bond_1.name = "test_bond_1"
+        bond_2 = IbetStraightBondContract()
+        bond_2.name = "test_bond_2"
+        mock_IbetStraightBondContract_get.side_effect = [bond_1, bond_2]
+        share_1 = IbetShareContract()
+        share_1.name = "test_share_1"
+        share_2 = IbetShareContract()
+        share_2.name = "test_share_2"
+        mock_IbetShareContract_get.side_effect = [share_1, share_2]
+
+        # request target api
+        resp = client.get(
+            self.base_url.format(account_address=account_address),
+            params={
+                "include_former_position": "true"
+            }
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "result_set": {
+                "count": 4,
+                "offset": None,
+                "limit": None,
+                "total": 4,
+            },
+            "positions": [
+                {
+                    "issuer_address": "0x1234567890123456789012345678900000000100",
+                    "token_address": "0x1234567890123456789012345678900000000010",
+                    "token_type": TokenType.IBET_STRAIGHT_BOND.value,
+                    "token_name": "test_bond_1",
+                    "balance": 10,
+                    "exchange_balance": 11,
+                    "exchange_commitment": 12,
+                    "pending_transfer": 13,
+                },
+                {
+                    "issuer_address": "0x1234567890123456789012345678900000000101",
+                    "token_address": "0x1234567890123456789012345678900000000011",
+                    "token_type": TokenType.IBET_STRAIGHT_BOND.value,
+                    "token_name": "test_bond_2",
+                    "balance": 0,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 0,
+                    "pending_transfer": 0,
+                },
+                {
+                    "issuer_address": "0x1234567890123456789012345678900000000100",
+                    "token_address": "0x1234567890123456789012345678900000000012",
+                    "token_type": TokenType.IBET_SHARE.value,
+                    "token_name": "test_share_1",
+                    "balance": 30,
+                    "exchange_balance": 20,
+                    "exchange_commitment": 10,
+                    "pending_transfer": 1,
+                },
+                {
+                    "issuer_address": "0x1234567890123456789012345678900000000101",
+                    "token_address": "0x1234567890123456789012345678900000000013",
+                    "token_type": TokenType.IBET_SHARE.value,
+                    "token_name": "test_share_2",
+                    "balance": 0,
+                    "exchange_balance": 0,
+                    "exchange_commitment": 0,
+                    "pending_transfer": 0,
+                }
+            ]
+        }
+
     # <Normal_6>
     # Pagination
     @mock.patch("app.model.blockchain.token.IbetShareContract.get")

--- a/tests/test_app_routers_share_tokens_{token_address}_holders_GET.py
+++ b/tests/test_app_routers_share_tokens_{token_address}_holders_GET.py
@@ -286,6 +286,7 @@ class TestAppRoutersShareTokensTokenAddressHoldersGET:
 
     # <Normal_3_2>
     # Multi record (Including former holder)
+    # Query param: including_former_holder=None
     def test_normal_3_2(self, client, db):
         user = config_eth_account("user1")
         _issuer_address = user["address"]
@@ -406,6 +407,154 @@ class TestAppRoutersShareTokensTokenAddressHoldersGET:
                 },
                 "balance": 20,
                 "exchange_balance": 21,
+                "exchange_commitment": 0,
+                "pending_transfer": 0
+            }
+        ]
+
+    # <Normal_3_3>
+    # Multi record (Including former holder)
+    # Query param: including_former_holder=True
+    def test_normal_3_3(self, client, db):
+        user = config_eth_account("user1")
+        _issuer_address = user["address"]
+        _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
+        _account_address_1 = "0xb75c7545b9230FEe99b7af370D38eBd3DAD929f7"
+        _account_address_2 = "0x3F198534Bbe3B2a197d3B317d41392F348EAC707"
+        _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
+
+        # prepare data
+        account = Account()
+        account.issuer_address = _issuer_address
+        db.add(account)
+
+        token = Token()
+        token.type = TokenType.IBET_SHARE.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        db.add(token)
+
+        idx_position_1 = IDXPosition()
+        idx_position_1.token_address = _token_address
+        idx_position_1.account_address = _account_address_1
+        idx_position_1.balance = 0
+        idx_position_1.exchange_balance = 0
+        idx_position_1.exchange_commitment = 12
+        idx_position_1.pending_transfer = 5
+        db.add(idx_position_1)
+
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = _account_address_1
+        idx_personal_info_1.issuer_address = _issuer_address
+        idx_personal_info_1.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10
+        }
+        db.add(idx_personal_info_1)
+
+        idx_position_2 = IDXPosition()
+        idx_position_2.token_address = _token_address
+        idx_position_2.account_address = _account_address_2
+        idx_position_2.balance = 20
+        idx_position_2.exchange_balance = 21
+        idx_position_2.exchange_commitment = 0
+        idx_position_2.pending_transfer = 0
+        db.add(idx_position_2)
+
+        idx_position_3 = IDXPosition()
+        idx_position_3.token_address = _token_address
+        idx_position_3.account_address = _account_address_3
+        idx_position_3.balance = 0
+        idx_position_3.exchange_balance = 0
+        idx_position_3.exchange_commitment = 0
+        idx_position_3.pending_transfer = 0
+        db.add(idx_position_3)
+
+        idx_personal_info_3 = IDXPersonalInfo()
+        idx_personal_info_3.account_address = _account_address_3
+        idx_personal_info_3.issuer_address = _issuer_address
+        idx_personal_info_3.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test3",
+            "postal_code": "postal_code_test3",
+            "address": "address_test3",
+            "email": "email_test3",
+            "birth": "birth_test3"
+            # PersonalInfo is partially registered.
+        }
+        db.add(idx_personal_info_3)
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address),
+            headers={
+                "issuer-address": _issuer_address
+            },
+            params={
+                "include_former_holder": "true"
+            }
+        )
+
+        # assertion
+        # former holder who has currently no balance is not listed
+        assert resp.status_code == 200
+        assert resp.json() == [
+            {
+                "account_address": _account_address_1,
+                "personal_information": {
+                    "key_manager": "key_manager_test1",
+                    "name": "name_test1",
+                    "postal_code": "postal_code_test1",
+                    "address": "address_test1",
+                    "email": "email_test1",
+                    "birth": "birth_test1",
+                    "is_corporate": False,
+                    "tax_category": 10
+                },
+                "balance": 0,
+                "exchange_balance": 0,
+                "exchange_commitment": 12,
+                "pending_transfer": 5
+            },
+            {
+                "account_address": _account_address_2,
+                "personal_information": {
+                    "key_manager": None,
+                    "name": None,
+                    "postal_code": None,
+                    "address": None,
+                    "email": None,
+                    "birth": None,
+                    "is_corporate": None,
+                    "tax_category": None
+                },
+                "balance": 20,
+                "exchange_balance": 21,
+                "exchange_commitment": 0,
+                "pending_transfer": 0
+            },
+            {
+                "account_address": _account_address_3,
+                "personal_information": {
+                    "key_manager": "key_manager_test1",
+                    "name": "name_test3",
+                    "postal_code": "postal_code_test3",
+                    "address": "address_test3",
+                    "email": "email_test3",
+                    "birth": "birth_test3",
+                    "is_corporate": None,
+                    "tax_category": None
+                },
+                "balance": 0,
+                "exchange_balance": 0,
                 "exchange_commitment": 0,
                 "pending_transfer": 0
             }


### PR DESCRIPTION
Close #369 

## Changes

### Behavior Changed API

- Added query param so as to retrieve former holders.

GET: `/bond/tokens/{token_address}/holders`
GET: `/share/tokens/{token_address}/holders`
  - added `include_former_holder` param.

GET: `/positions/{account_address}`
  - added `include_former_position` param.

### OpenAPI Doc

following GET: `/bond/tokens/{token_address}/holders` example.

<img width="1431" alt="スクリーンショット 2022-08-15 17 02 04" src="https://user-images.githubusercontent.com/15183665/184600338-c2060efa-94a0-42d0-9c83-881c1ec60ffb.png">
