### PR TITLE
feat: Add new APIs - list personal info batch registration uploads

### DIFF
--- a/app/model/db/batch_register_personal_info.py
+++ b/app/model/db/batch_register_personal_info.py
@@ -36,7 +36,7 @@ class BatchRegisterPersonalInfoUpload(Base):
     upload_id = Column(String(36), primary_key=True)
     # issuer address
     issuer_address = Column(String(42), nullable=False, index=True)
-    # processing status (pending:0, succeeded:1, failed:2)
+    # processing status (BatchRegisterPersonalInfoUploadStatus)
     status = Column(String, nullable=False, index=True)
 
 

--- a/app/model/schema/batch_issue_redeem.py
+++ b/app/model/schema/batch_issue_redeem.py
@@ -17,7 +17,10 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 from typing import List
-from pydantic import BaseModel
+from pydantic import (
+    BaseModel,
+    Field
+)
 
 from .types import ResultSet
 from app.model.db import TokenType
@@ -29,12 +32,19 @@ from app.model.db import TokenType
 
 class BatchIssueRedeemUpload(BaseModel):
     """Batch issue/redeem Upload"""
-    upload_id: str
+    batch_id: str = Field(description="UUID v4 required")
     issuer_address: str
     token_type: TokenType
     token_address: str
     processed: bool
     created: str
+
+    class Config:
+        schema_extra = {
+            "example": {
+                "batch_id": "cfd83622-34dc-4efe-a68b-2cc275d3d824"
+            }
+        }
 
 
 class ListBatchIssueRedeemUploadResponse(BaseModel):

--- a/app/model/schema/personal_info.py
+++ b/app/model/schema/personal_info.py
@@ -19,9 +19,11 @@ SPDX-License-Identifier: Apache-2.0
 from typing import Optional, List
 from pydantic import (
     BaseModel,
-    validator, Field
+    validator,
+    Field
 )
 from web3 import Web3
+
 from app.model.db import BatchRegisterPersonalInfoUploadStatus
 from app.model.schema.types import ResultSet
 

--- a/app/routers/share.py
+++ b/app/routers/share.py
@@ -84,6 +84,7 @@ from app.model.schema.batch_issue_redeem import (
 )
 from app.model.schema.personal_info import (
     BatchRegisterPersonalInfoUploadResponse,
+    ListBatchRegisterPersonalInfoUploadResponse,
     GetBatchRegisterPersonalInfoResponse,
     BatchRegisterPersonalInfoResult
 )
@@ -483,7 +484,7 @@ def additional_issue(
 @router.get(
     "/tokens/{token_address}/additional_issue/batch",
     response_model=ListBatchIssueRedeemUploadResponse,
-    responses=get_routers_responses()
+    responses=get_routers_responses(422)
 )
 def list_all_additional_issue_upload(
     token_address: str,
@@ -528,7 +529,7 @@ def list_all_additional_issue_upload(
     for _upload in _upload_list:
         created_utc = timezone("UTC").localize(_upload.created)
         uploads.append({
-            "upload_id": _upload.upload_id,
+            "batch_id": _upload.upload_id,
             "issuer_address": _upload.issuer_address,
             "token_type": _upload.token_type,
             "token_address": _upload.token_address,
@@ -735,7 +736,7 @@ def redeem_token(
 @router.get(
     "/tokens/{token_address}/redeem/batch",
     response_model=ListBatchIssueRedeemUploadResponse,
-    responses=get_routers_responses()
+    responses=get_routers_responses(422)
 )
 def list_all_redeem_upload(
     token_address: str,
@@ -780,7 +781,7 @@ def list_all_redeem_upload(
     for _upload in _upload_list:
         created_utc = timezone("UTC").localize(_upload.created)
         uploads.append({
-            "upload_id": _upload.upload_id,
+            "batch_id": _upload.upload_id,
             "issuer_address": _upload.issuer_address,
             "token_type": _upload.token_type,
             "token_address": _upload.token_address,
@@ -1403,6 +1404,80 @@ def modify_holder_personal_info(
         raise SendTransactionError("failed to modify personal information")
 
     return
+
+
+# GET: /share/tokens/{token_address}/personal_info/batch
+@router.get(
+    "/tokens/{token_address}/personal_info/batch",
+    response_model=ListBatchRegisterPersonalInfoUploadResponse,
+    responses=get_routers_responses(422, 404, InvalidParameterError)
+)
+def list_all_personal_info_batch_registration_uploads(
+        token_address: str,
+        issuer_address: str = Header(...),
+        status: Optional[str] = Query(None),
+        sort_order: int = Query(1, ge=0, le=1, description="0:asc, 1:desc (created)"),
+        offset: Optional[int] = Query(None),
+        limit: Optional[int] = Query(None),
+        db: Session = Depends(db_session)):
+    """List all personal information batch registration uploads"""
+
+    # Verify that the token is issued by the issuer_address
+    _token = db.query(Token). \
+        filter(Token.type == TokenType.IBET_SHARE.value). \
+        filter(Token.issuer_address == issuer_address). \
+        filter(Token.token_address == token_address). \
+        filter(Token.token_status != 2). \
+        first()
+    if _token is None:
+        raise HTTPException(status_code=404, detail="token not found")
+    if _token.token_status == 0:
+        raise InvalidParameterError("this token is temporarily unavailable")
+
+    # Get a list of uploads
+    query = db.query(BatchRegisterPersonalInfoUpload). \
+        filter(BatchRegisterPersonalInfoUpload.issuer_address == issuer_address)
+
+    total = query.count()
+
+    if status is not None:
+        query = query.filter(BatchRegisterPersonalInfoUpload.status == status)
+
+    count = query.count()
+
+    # Sort
+    if sort_order == 0:  # ASC
+        query = query.order_by(BatchRegisterPersonalInfoUpload.created)
+    else:  # DESC
+        query = query.order_by(desc(BatchRegisterPersonalInfoUpload.created))
+
+    # Pagination
+    if limit is not None:
+        query = query.limit(limit)
+    if offset is not None:
+        query = query.offset(offset)
+
+    _upload_list: list[BatchRegisterPersonalInfoUpload] = query.all()
+
+    uploads = []
+    for _upload in _upload_list:
+        created_utc = timezone("UTC").localize(_upload.created)
+        uploads.append({
+            "batch_id": _upload.upload_id,
+            "issuer_address": _upload.issuer_address,
+            "status": _upload.status,
+            "created": created_utc.astimezone(local_tz).isoformat()
+        })
+
+    return ListBatchRegisterPersonalInfoUploadResponse(
+        result_set={
+            "count": count,
+            "offset": offset,
+            "limit": limit,
+            "total": total
+        },
+        uploads=uploads
+    )
 
 
 # POST: /share/tokens/{token_address}/personal_info

--- a/tests/test_app_routers_bond_tokens_{token_address}_additional_issue_batch_GET.py
+++ b/tests/test_app_routers_bond_tokens_{token_address}_additional_issue_batch_GET.py
@@ -17,20 +17,18 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 import uuid
-import pytz
 from unittest import mock
-from unittest.mock import call
 
-from app.model.blockchain import IbetStraightBondContract
 from app.model.db import (
     Token,
-    TokenType, BatchIssueRedeem, BatchIssueRedeemUpload, BatchIssueRedeemProcessingCategory
+    TokenType,
+    BatchIssueRedeemUpload,
+    BatchIssueRedeemProcessingCategory
 )
-from config import TZ
 from tests.account_config import config_eth_account
 
 
-class TestAppRoutersBondTokensTokenAddressAdditionalIssueGET:
+class TestAppRoutersBondTokensTokenAddressAdditionalIssueBatchGET:
     # target API endpoint
     base_url = "/bond/tokens/{}/additional_issue/batch"
 
@@ -117,7 +115,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueGET:
                     "processed": False,
                     "token_address": "token_address_test",
                     "token_type": "IbetStraightBond",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 }
             ]
@@ -205,7 +203,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueGET:
                     "processed": False,
                     "token_address": "token_address_test",
                     "token_type": "IbetStraightBond",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 },
                 {
@@ -213,7 +211,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueGET:
                     "processed": False,
                     "token_address": "token_address_test",
                     "token_type": "IbetStraightBond",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 },
                 {
@@ -221,7 +219,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueGET:
                     "processed": False,
                     "token_address": "token_address_test",
                     "token_type": "IbetStraightBond",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 },
                 {
@@ -229,7 +227,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueGET:
                     "processed": True,
                     "token_address": "token_address_test",
                     "token_type": "IbetStraightBond",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 }
             ]
@@ -319,7 +317,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueGET:
                     "processed": False,
                     "token_address": "token_address_test",
                     "token_type": "IbetStraightBond",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 },
                 {
@@ -327,7 +325,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueGET:
                     "processed": True,
                     "token_address": "token_address_test",
                     "token_type": "IbetStraightBond",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 }
             ]
@@ -419,7 +417,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueGET:
                     "processed": False,
                     "token_address": "token_address_test",
                     "token_type": "IbetStraightBond",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 },
                 {
@@ -427,7 +425,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueGET:
                     "processed": False,
                     "token_address": "token_address_test",
                     "token_type": "IbetStraightBond",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 },
                 {
@@ -435,7 +433,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueGET:
                     "processed": False,
                     "token_address": "token_address_test",
                     "token_type": "IbetStraightBond",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 }
             ]
@@ -527,7 +525,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueGET:
                     "processed": False,
                     "token_address": "token_address_test",
                     "token_type": "IbetStraightBond",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 },
                 {
@@ -535,7 +533,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueGET:
                     "processed": True,
                     "token_address": "token_address_test",
                     "token_type": "IbetStraightBond",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 }
             ]
@@ -626,7 +624,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueGET:
                     "processed": True,
                     "token_address": "token_address_test",
                     "token_type": "IbetStraightBond",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 },
                 {
@@ -634,7 +632,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueGET:
                     "processed": False,
                     "token_address": "token_address_test",
                     "token_type": "IbetStraightBond",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 },
                 {
@@ -642,7 +640,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueGET:
                     "processed": True,
                     "token_address": "token_address_test",
                     "token_type": "IbetStraightBond",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 },
                 {
@@ -650,7 +648,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueGET:
                     "processed": False,
                     "token_address": "token_address_test",
                     "token_type": "IbetStraightBond",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 }
             ]

--- a/tests/test_app_routers_bond_tokens_{token_address}_personal_info_batch_GET.py
+++ b/tests/test_app_routers_bond_tokens_{token_address}_personal_info_batch_GET.py
@@ -1,0 +1,414 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+from unittest import mock
+
+from app.model.db import (
+    TokenType,
+    Token,
+    BatchRegisterPersonalInfoUpload,
+    BatchRegisterPersonalInfoUploadStatus
+)
+from tests.account_config import config_eth_account
+
+
+class TestAppRoutersBondTokensTokenAddressPersonalInfoBatchGET:
+    # target API endpoint
+    base_url = "/bond/tokens/{}/personal_info/batch"
+
+    upload_id_list = [
+        "0c961f7d-e1ad-40e5-988b-cca3d6009643",
+        "0e778f46-864e-4ec0-b566-21bd31cf63ff",
+        "0f33d48f-9e6e-4a36-a55e-5bbcbda69c80",
+        "1c961f7d-e1ad-40e5-988b-cca3d6009643",
+        "1e778f46-864e-4ec0-b566-21bd31cf63ff",
+        "1f33d48f-9e6e-4a36-a55e-5bbcbda69c80"
+    ]
+
+    ###########################################################################
+    # Normal Case
+    ###########################################################################
+
+    # Normal_1
+    # 0 record
+    def test_normal_1(self, client, db):
+        _issuer_account = config_eth_account("user1")
+        _issuer_address = _issuer_account["address"]
+
+        _token_address = "0xd9F55747DE740297ff1eEe537aBE0f8d73B7D783"
+
+        # prepare data: token issued by issuer_address
+        token = Token()
+        token.type = TokenType.IBET_STRAIGHT_BOND.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        db.add(token)
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address, self.upload_id_list[0]),
+            headers={
+                "issuer-address": _issuer_address
+            }
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            'result_set': {
+                'count': 0,
+                'offset': None,
+                'limit': None,
+                'total': 0
+            },
+            'uploads': []
+        }
+
+    # Normal_2
+    # multi records
+    def test_normal_2(self, client, db):
+        _issuer_account = config_eth_account("user1")
+        _issuer_address = _issuer_account["address"]
+
+        _token_address = "0xd9F55747DE740297ff1eEe537aBE0f8d73B7D783"
+
+        # prepare data: token issued by issuer_address
+        token = Token()
+        token.type = TokenType.IBET_STRAIGHT_BOND.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        db.add(token)
+
+        # Prepare data : BatchRegisterPersonalInfoUpload
+        batch_register_upload = BatchRegisterPersonalInfoUpload()
+        batch_register_upload.issuer_address = _issuer_address
+        batch_register_upload.upload_id = self.upload_id_list[0]
+        batch_register_upload.status = BatchRegisterPersonalInfoUploadStatus.DONE.value
+        db.add(batch_register_upload)
+
+        batch_register_upload = BatchRegisterPersonalInfoUpload()
+        batch_register_upload.issuer_address = _issuer_address
+        batch_register_upload.upload_id = self.upload_id_list[1]
+        batch_register_upload.status = BatchRegisterPersonalInfoUploadStatus.PENDING.value
+        db.add(batch_register_upload)
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address, self.upload_id_list[0]),
+            headers={
+                "issuer-address": _issuer_address
+            }
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            'result_set': {
+                'count': 2,
+                'offset': None,
+                'limit': None,
+                'total': 2
+            },
+            'uploads': [
+                {
+                    'batch_id': self.upload_id_list[1],
+                    'status': BatchRegisterPersonalInfoUploadStatus.PENDING.value,
+                    'created': mock.ANY
+                }, {
+                    'batch_id': self.upload_id_list[0],
+                    'status': BatchRegisterPersonalInfoUploadStatus.DONE.value,
+                    'created': mock.ANY
+                }
+            ]
+        }
+
+    # Normal_3
+    # filter by status
+    def test_normal_3(self, client, db):
+        _issuer_account = config_eth_account("user1")
+        _issuer_address = _issuer_account["address"]
+
+        _token_address = "0xd9F55747DE740297ff1eEe537aBE0f8d73B7D783"
+
+        # prepare data: token issued by issuer_address
+        token = Token()
+        token.type = TokenType.IBET_STRAIGHT_BOND.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        db.add(token)
+
+        # Prepare data : BatchRegisterPersonalInfoUpload
+        batch_register_upload = BatchRegisterPersonalInfoUpload()
+        batch_register_upload.issuer_address = _issuer_address
+        batch_register_upload.upload_id = self.upload_id_list[0]
+        batch_register_upload.status = BatchRegisterPersonalInfoUploadStatus.DONE.value
+        db.add(batch_register_upload)
+
+        batch_register_upload = BatchRegisterPersonalInfoUpload()
+        batch_register_upload.issuer_address = _issuer_address
+        batch_register_upload.upload_id = self.upload_id_list[1]
+        batch_register_upload.status = BatchRegisterPersonalInfoUploadStatus.PENDING.value
+        db.add(batch_register_upload)
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address, self.upload_id_list[0]),
+            headers={
+                "issuer-address": _issuer_address
+            },
+            params={
+                "status": BatchRegisterPersonalInfoUploadStatus.DONE.value
+            }
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            'result_set': {
+                'count': 1,
+                'offset': None,
+                'limit': None,
+                'total': 2
+            },
+            'uploads': [
+                {
+                    'batch_id': self.upload_id_list[0],
+                    'status': BatchRegisterPersonalInfoUploadStatus.DONE.value,
+                    'created': mock.ANY
+                }
+            ]
+        }
+
+    # Normal_4
+    # pagination
+    def test_normal_4(self, client, db):
+        _issuer_account = config_eth_account("user1")
+        _issuer_address = _issuer_account["address"]
+
+        _token_address = "0xd9F55747DE740297ff1eEe537aBE0f8d73B7D783"
+
+        # prepare data: token issued by issuer_address
+        token = Token()
+        token.type = TokenType.IBET_STRAIGHT_BOND.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        db.add(token)
+
+        # Prepare data : BatchRegisterPersonalInfoUpload
+        batch_register_upload = BatchRegisterPersonalInfoUpload()
+        batch_register_upload.issuer_address = _issuer_address
+        batch_register_upload.upload_id = self.upload_id_list[0]
+        batch_register_upload.status = BatchRegisterPersonalInfoUploadStatus.DONE.value
+        db.add(batch_register_upload)
+
+        batch_register_upload = BatchRegisterPersonalInfoUpload()
+        batch_register_upload.issuer_address = _issuer_address
+        batch_register_upload.upload_id = self.upload_id_list[1]
+        batch_register_upload.status = BatchRegisterPersonalInfoUploadStatus.PENDING.value
+        db.add(batch_register_upload)
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address, self.upload_id_list[0]),
+            headers={
+                "issuer-address": _issuer_address
+            },
+            params={
+                "offset": 0,
+                "limit": 1
+            }
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            'result_set': {
+                'count': 2,
+                'offset': 0,
+                'limit': 1,
+                'total': 2
+            },
+            'uploads': [
+                {
+                    'batch_id': self.upload_id_list[1],
+                    'status': BatchRegisterPersonalInfoUploadStatus.PENDING.value,
+                    'created': mock.ANY
+                }
+            ]
+        }
+
+    # Normal_5
+    # sort
+    def test_normal_5(self, client, db):
+        _issuer_account = config_eth_account("user1")
+        _issuer_address = _issuer_account["address"]
+
+        _token_address = "0xd9F55747DE740297ff1eEe537aBE0f8d73B7D783"
+
+        # prepare data: token issued by issuer_address
+        token = Token()
+        token.type = TokenType.IBET_STRAIGHT_BOND.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        db.add(token)
+
+        # Prepare data : BatchRegisterPersonalInfoUpload
+        batch_register_upload = BatchRegisterPersonalInfoUpload()
+        batch_register_upload.issuer_address = _issuer_address
+        batch_register_upload.upload_id = self.upload_id_list[0]
+        batch_register_upload.status = BatchRegisterPersonalInfoUploadStatus.DONE.value
+        db.add(batch_register_upload)
+
+        batch_register_upload = BatchRegisterPersonalInfoUpload()
+        batch_register_upload.issuer_address = _issuer_address
+        batch_register_upload.upload_id = self.upload_id_list[1]
+        batch_register_upload.status = BatchRegisterPersonalInfoUploadStatus.PENDING.value
+        db.add(batch_register_upload)
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address, self.upload_id_list[0]),
+            headers={
+                "issuer-address": _issuer_address
+            },
+            params={
+                "sort_order": 0
+            }
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            'result_set': {
+                'count': 2,
+                'offset': None,
+                'limit': None,
+                'total': 2
+            },
+            'uploads': [
+                {
+                    'batch_id': self.upload_id_list[0],
+                    'status': BatchRegisterPersonalInfoUploadStatus.DONE.value,
+                    'created': mock.ANY
+                },
+                {
+                    'batch_id': self.upload_id_list[1],
+                    'status': BatchRegisterPersonalInfoUploadStatus.PENDING.value,
+                    'created': mock.ANY
+                }
+            ]
+        }
+
+    #########################################################################
+    # Error Case
+    ###########################################################################
+
+    # Error_1
+    # RequestValidationError: issuer_address
+    def test_error_1(self, client, db):
+        _issuer_account = config_eth_account("user1")
+        _issuer_address = _issuer_account["address"]
+
+        _token_address = "0xd9F55747DE740297ff1eEe537aBE0f8d73B7D783"
+
+        # prepare data: token issued by issuer_address
+        token = Token()
+        token.type = TokenType.IBET_STRAIGHT_BOND.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        db.add(token)
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address, self.upload_id_list[0]),
+            headers={}
+        )
+
+        # assertion
+        assert resp.status_code == 422
+        assert resp.json() == {
+            'meta': {
+                'code': 1,
+                'title': 'RequestValidationError'
+            },
+            'detail': [
+                {
+                    'loc': ['header', 'issuer-address'],
+                    'msg': 'field required',
+                    'type': 'value_error.missing'
+                }
+            ]
+        }
+
+    # Error_2
+    # NotFound
+    # token not found
+    def test_error_2(self, client, db):
+        _issuer_account_1 = config_eth_account("user1")
+        _issuer_address_1 = _issuer_account_1["address"]
+
+        _issuer_account_2 = config_eth_account("user2")
+        _issuer_address_2 = _issuer_account_2["address"]
+
+        _token_address = "0xd9F55747DE740297ff1eEe537aBE0f8d73B7D783"
+
+        # prepare data: token issued by issuer_address_2
+        token = Token()
+        token.type = TokenType.IBET_STRAIGHT_BOND.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address_2
+        token.token_address = _token_address
+        token.abi = ""
+        db.add(token)
+
+        # Prepare data : BatchRegisterPersonalInfoUpload
+        batch_register_upload = BatchRegisterPersonalInfoUpload()
+        batch_register_upload.issuer_address = _issuer_address_2
+        batch_register_upload.upload_id = self.upload_id_list[0]
+        batch_register_upload.status = BatchRegisterPersonalInfoUploadStatus.DONE.value
+        db.add(batch_register_upload)
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address, self.upload_id_list[0]),
+            headers={
+                "issuer-address": _issuer_address_1
+            }
+        )
+
+        # assertion
+        assert resp.status_code == 404
+        assert resp.json() == {
+            'meta': {
+                'code': 1,
+                'title': 'NotFound'
+            },
+            'detail': 'token not found'
+        }

--- a/tests/test_app_routers_bond_tokens_{token_address}_personal_info_batch_{batch_id}_GET.py
+++ b/tests/test_app_routers_bond_tokens_{token_address}_personal_info_batch_{batch_id}_GET.py
@@ -171,7 +171,7 @@ class TestAppRoutersBondTokensTokenAddressPersonalInfoBatchBatchIdGET:
     ###########################################################################
 
     # <Error_1>
-    # Batch not found
+    # RequestValidationError: issuer_address
     def test_error_1(self, client, db):
         test_account = config_eth_account("user2")
         _issuer_address = test_account["address"]
@@ -179,7 +179,37 @@ class TestAppRoutersBondTokensTokenAddressPersonalInfoBatchBatchIdGET:
 
         # request target API
         resp = client.get(
-            self.base_url.format(_token_address, "test_event_id"),
+            self.base_url.format(_token_address, "test_batch_id"),
+            headers={
+            }
+        )
+
+        # assertion
+        assert resp.status_code == 422
+        assert resp.json() == {
+            'meta': {
+                'code': 1,
+                'title': 'RequestValidationError'
+            },
+            'detail': [
+                {
+                    'loc': ['header', 'issuer-address'],
+                    'msg': 'field required',
+                    'type': 'value_error.missing'
+                }
+            ]
+        }
+
+    # <Error_2>
+    # Batch not found
+    def test_error_2(self, client, db):
+        test_account = config_eth_account("user2")
+        _issuer_address = test_account["address"]
+        _token_address = "token_address_test"
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address, "test_batch_id"),
             headers={
                 "issuer-address": _issuer_address,
             }

--- a/tests/test_app_routers_bond_tokens_{token_address}_redeem_batch_GET.py
+++ b/tests/test_app_routers_bond_tokens_{token_address}_redeem_batch_GET.py
@@ -17,20 +17,18 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 import uuid
-import pytz
 from unittest import mock
-from unittest.mock import call
 
-from app.model.blockchain import IbetStraightBondContract
 from app.model.db import (
     Token,
-    TokenType, BatchIssueRedeem, BatchIssueRedeemUpload, BatchIssueRedeemProcessingCategory
+    TokenType,
+    BatchIssueRedeemUpload,
+    BatchIssueRedeemProcessingCategory
 )
-from config import TZ
 from tests.account_config import config_eth_account
 
 
-class TestAppRoutersBondTokensTokenAddressRedeemGET:
+class TestAppRoutersBondTokensTokenAddressRedeemBatchGET:
     # target API endpoint
     base_url = "/bond/tokens/{}/redeem/batch"
 
@@ -117,7 +115,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemGET:
                     "processed": False,
                     "token_address": "token_address_test",
                     "token_type": "IbetStraightBond",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 }
             ]
@@ -205,7 +203,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemGET:
                     "processed": False,
                     "token_address": "token_address_test",
                     "token_type": "IbetStraightBond",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 },
                 {
@@ -213,7 +211,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemGET:
                     "processed": False,
                     "token_address": "token_address_test",
                     "token_type": "IbetStraightBond",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 },
                 {
@@ -221,7 +219,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemGET:
                     "processed": False,
                     "token_address": "token_address_test",
                     "token_type": "IbetStraightBond",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 },
                 {
@@ -229,7 +227,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemGET:
                     "processed": True,
                     "token_address": "token_address_test",
                     "token_type": "IbetStraightBond",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 }
             ]
@@ -319,7 +317,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemGET:
                     "processed": False,
                     "token_address": "token_address_test",
                     "token_type": "IbetStraightBond",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 },
                 {
@@ -327,7 +325,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemGET:
                     "processed": True,
                     "token_address": "token_address_test",
                     "token_type": "IbetStraightBond",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 }
             ]
@@ -419,7 +417,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemGET:
                     "processed": False,
                     "token_address": "token_address_test",
                     "token_type": "IbetStraightBond",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 },
                 {
@@ -427,7 +425,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemGET:
                     "processed": False,
                     "token_address": "token_address_test",
                     "token_type": "IbetStraightBond",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 },
                 {
@@ -435,7 +433,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemGET:
                     "processed": False,
                     "token_address": "token_address_test",
                     "token_type": "IbetStraightBond",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 }
             ]
@@ -527,7 +525,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemGET:
                     "processed": False,
                     "token_address": "token_address_test",
                     "token_type": "IbetStraightBond",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 },
                 {
@@ -535,7 +533,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemGET:
                     "processed": True,
                     "token_address": "token_address_test",
                     "token_type": "IbetStraightBond",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 }
             ]
@@ -626,7 +624,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemGET:
                     "processed": True,
                     "token_address": "token_address_test",
                     "token_type": "IbetStraightBond",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 },
                 {
@@ -634,7 +632,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemGET:
                     "processed": False,
                     "token_address": "token_address_test",
                     "token_type": "IbetStraightBond",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 },
                 {
@@ -642,7 +640,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemGET:
                     "processed": True,
                     "token_address": "token_address_test",
                     "token_type": "IbetStraightBond",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 },
                 {
@@ -650,7 +648,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemGET:
                     "processed": False,
                     "token_address": "token_address_test",
                     "token_type": "IbetStraightBond",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 }
             ]

--- a/tests/test_app_routers_share_tokens_{token_address}_additional_issue_batch_GET.py
+++ b/tests/test_app_routers_share_tokens_{token_address}_additional_issue_batch_GET.py
@@ -17,20 +17,18 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 import uuid
-import pytz
 from unittest import mock
-from unittest.mock import call
 
-from app.model.blockchain import IbetShareContract
 from app.model.db import (
     Token,
-    TokenType, BatchIssueRedeem, BatchIssueRedeemUpload, BatchIssueRedeemProcessingCategory
+    TokenType,
+    BatchIssueRedeemUpload,
+    BatchIssueRedeemProcessingCategory
 )
-from config import TZ
 from tests.account_config import config_eth_account
 
 
-class TestAppRoutersShareTokensTokenAddressAdditionalIssueGET:
+class TestAppRoutersShareTokensTokenAddressAdditionalIssueBatchGET:
     # target API endpoint
     base_url = "/share/tokens/{}/additional_issue/batch"
 
@@ -117,7 +115,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueGET:
                     "processed": False,
                     "token_address": "token_address_test",
                     "token_type": "IbetShare",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 }
             ]
@@ -205,7 +203,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueGET:
                     "processed": False,
                     "token_address": "token_address_test",
                     "token_type": "IbetShare",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 },
                 {
@@ -213,7 +211,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueGET:
                     "processed": False,
                     "token_address": "token_address_test",
                     "token_type": "IbetShare",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 },
                 {
@@ -221,7 +219,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueGET:
                     "processed": False,
                     "token_address": "token_address_test",
                     "token_type": "IbetShare",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 },
                 {
@@ -229,7 +227,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueGET:
                     "processed": True,
                     "token_address": "token_address_test",
                     "token_type": "IbetShare",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 }
             ]
@@ -319,7 +317,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueGET:
                     "processed": False,
                     "token_address": "token_address_test",
                     "token_type": "IbetShare",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 },
                 {
@@ -327,7 +325,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueGET:
                     "processed": True,
                     "token_address": "token_address_test",
                     "token_type": "IbetShare",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 }
             ]
@@ -419,7 +417,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueGET:
                     "processed": False,
                     "token_address": "token_address_test",
                     "token_type": "IbetShare",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 },
                 {
@@ -427,7 +425,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueGET:
                     "processed": False,
                     "token_address": "token_address_test",
                     "token_type": "IbetShare",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 },
                 {
@@ -435,7 +433,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueGET:
                     "processed": False,
                     "token_address": "token_address_test",
                     "token_type": "IbetShare",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 }
             ]
@@ -527,7 +525,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueGET:
                     "processed": False,
                     "token_address": "token_address_test",
                     "token_type": "IbetShare",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 },
                 {
@@ -535,7 +533,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueGET:
                     "processed": True,
                     "token_address": "token_address_test",
                     "token_type": "IbetShare",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 }
             ]
@@ -626,7 +624,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueGET:
                     "processed": True,
                     "token_address": "token_address_test",
                     "token_type": "IbetShare",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 },
                 {
@@ -634,7 +632,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueGET:
                     "processed": False,
                     "token_address": "token_address_test",
                     "token_type": "IbetShare",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 },
                 {
@@ -642,7 +640,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueGET:
                     "processed": True,
                     "token_address": "token_address_test",
                     "token_type": "IbetShare",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 },
                 {
@@ -650,7 +648,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueGET:
                     "processed": False,
                     "token_address": "token_address_test",
                     "token_type": "IbetShare",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 }
             ]

--- a/tests/test_app_routers_share_tokens_{token_address}_personal_info_batch_GET.py
+++ b/tests/test_app_routers_share_tokens_{token_address}_personal_info_batch_GET.py
@@ -1,0 +1,414 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+from unittest import mock
+
+from app.model.db import (
+    TokenType,
+    Token,
+    BatchRegisterPersonalInfoUpload,
+    BatchRegisterPersonalInfoUploadStatus
+)
+from tests.account_config import config_eth_account
+
+
+class TestAppRoutersShareTokensTokenAddressPersonalInfoBatchGET:
+    # target API endpoint
+    base_url = "/share/tokens/{}/personal_info/batch"
+
+    upload_id_list = [
+        "0c961f7d-e1ad-40e5-988b-cca3d6009643",
+        "0e778f46-864e-4ec0-b566-21bd31cf63ff",
+        "0f33d48f-9e6e-4a36-a55e-5bbcbda69c80",
+        "1c961f7d-e1ad-40e5-988b-cca3d6009643",
+        "1e778f46-864e-4ec0-b566-21bd31cf63ff",
+        "1f33d48f-9e6e-4a36-a55e-5bbcbda69c80"
+    ]
+
+    ###########################################################################
+    # Normal Case
+    ###########################################################################
+
+    # Normal_1
+    # 0 record
+    def test_normal_1(self, client, db):
+        _issuer_account = config_eth_account("user1")
+        _issuer_address = _issuer_account["address"]
+
+        _token_address = "0xd9F55747DE740297ff1eEe537aBE0f8d73B7D783"
+
+        # prepare data: token issued by issuer_address
+        token = Token()
+        token.type = TokenType.IBET_SHARE.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        db.add(token)
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address, self.upload_id_list[0]),
+            headers={
+                "issuer-address": _issuer_address
+            }
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            'result_set': {
+                'count': 0,
+                'offset': None,
+                'limit': None,
+                'total': 0
+            },
+            'uploads': []
+        }
+
+    # Normal_2
+    # multi records
+    def test_normal_2(self, client, db):
+        _issuer_account = config_eth_account("user1")
+        _issuer_address = _issuer_account["address"]
+
+        _token_address = "0xd9F55747DE740297ff1eEe537aBE0f8d73B7D783"
+
+        # prepare data: token issued by issuer_address
+        token = Token()
+        token.type = TokenType.IBET_SHARE.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        db.add(token)
+
+        # Prepare data : BatchRegisterPersonalInfoUpload
+        batch_register_upload = BatchRegisterPersonalInfoUpload()
+        batch_register_upload.issuer_address = _issuer_address
+        batch_register_upload.upload_id = self.upload_id_list[0]
+        batch_register_upload.status = BatchRegisterPersonalInfoUploadStatus.DONE.value
+        db.add(batch_register_upload)
+
+        batch_register_upload = BatchRegisterPersonalInfoUpload()
+        batch_register_upload.issuer_address = _issuer_address
+        batch_register_upload.upload_id = self.upload_id_list[1]
+        batch_register_upload.status = BatchRegisterPersonalInfoUploadStatus.PENDING.value
+        db.add(batch_register_upload)
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address, self.upload_id_list[0]),
+            headers={
+                "issuer-address": _issuer_address
+            }
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            'result_set': {
+                'count': 2,
+                'offset': None,
+                'limit': None,
+                'total': 2
+            },
+            'uploads': [
+                {
+                    'batch_id': self.upload_id_list[1],
+                    'status': BatchRegisterPersonalInfoUploadStatus.PENDING.value,
+                    'created': mock.ANY
+                }, {
+                    'batch_id': self.upload_id_list[0],
+                    'status': BatchRegisterPersonalInfoUploadStatus.DONE.value,
+                    'created': mock.ANY
+                }
+            ]
+        }
+
+    # Normal_3
+    # filter by status
+    def test_normal_3(self, client, db):
+        _issuer_account = config_eth_account("user1")
+        _issuer_address = _issuer_account["address"]
+
+        _token_address = "0xd9F55747DE740297ff1eEe537aBE0f8d73B7D783"
+
+        # prepare data: token issued by issuer_address
+        token = Token()
+        token.type = TokenType.IBET_SHARE.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        db.add(token)
+
+        # Prepare data : BatchRegisterPersonalInfoUpload
+        batch_register_upload = BatchRegisterPersonalInfoUpload()
+        batch_register_upload.issuer_address = _issuer_address
+        batch_register_upload.upload_id = self.upload_id_list[0]
+        batch_register_upload.status = BatchRegisterPersonalInfoUploadStatus.DONE.value
+        db.add(batch_register_upload)
+
+        batch_register_upload = BatchRegisterPersonalInfoUpload()
+        batch_register_upload.issuer_address = _issuer_address
+        batch_register_upload.upload_id = self.upload_id_list[1]
+        batch_register_upload.status = BatchRegisterPersonalInfoUploadStatus.PENDING.value
+        db.add(batch_register_upload)
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address, self.upload_id_list[0]),
+            headers={
+                "issuer-address": _issuer_address
+            },
+            params={
+                "status": BatchRegisterPersonalInfoUploadStatus.DONE.value
+            }
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            'result_set': {
+                'count': 1,
+                'offset': None,
+                'limit': None,
+                'total': 2
+            },
+            'uploads': [
+                {
+                    'batch_id': self.upload_id_list[0],
+                    'status': BatchRegisterPersonalInfoUploadStatus.DONE.value,
+                    'created': mock.ANY
+                }
+            ]
+        }
+
+    # Normal_4
+    # pagination
+    def test_normal_4(self, client, db):
+        _issuer_account = config_eth_account("user1")
+        _issuer_address = _issuer_account["address"]
+
+        _token_address = "0xd9F55747DE740297ff1eEe537aBE0f8d73B7D783"
+
+        # prepare data: token issued by issuer_address
+        token = Token()
+        token.type = TokenType.IBET_SHARE.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        db.add(token)
+
+        # Prepare data : BatchRegisterPersonalInfoUpload
+        batch_register_upload = BatchRegisterPersonalInfoUpload()
+        batch_register_upload.issuer_address = _issuer_address
+        batch_register_upload.upload_id = self.upload_id_list[0]
+        batch_register_upload.status = BatchRegisterPersonalInfoUploadStatus.DONE.value
+        db.add(batch_register_upload)
+
+        batch_register_upload = BatchRegisterPersonalInfoUpload()
+        batch_register_upload.issuer_address = _issuer_address
+        batch_register_upload.upload_id = self.upload_id_list[1]
+        batch_register_upload.status = BatchRegisterPersonalInfoUploadStatus.PENDING.value
+        db.add(batch_register_upload)
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address, self.upload_id_list[0]),
+            headers={
+                "issuer-address": _issuer_address
+            },
+            params={
+                "offset": 0,
+                "limit": 1
+            }
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            'result_set': {
+                'count': 2,
+                'offset': 0,
+                'limit': 1,
+                'total': 2
+            },
+            'uploads': [
+                {
+                    'batch_id': self.upload_id_list[1],
+                    'status': BatchRegisterPersonalInfoUploadStatus.PENDING.value,
+                    'created': mock.ANY
+                }
+            ]
+        }
+
+    # Normal_5
+    # sort
+    def test_normal_5(self, client, db):
+        _issuer_account = config_eth_account("user1")
+        _issuer_address = _issuer_account["address"]
+
+        _token_address = "0xd9F55747DE740297ff1eEe537aBE0f8d73B7D783"
+
+        # prepare data: token issued by issuer_address
+        token = Token()
+        token.type = TokenType.IBET_SHARE.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        db.add(token)
+
+        # Prepare data : BatchRegisterPersonalInfoUpload
+        batch_register_upload = BatchRegisterPersonalInfoUpload()
+        batch_register_upload.issuer_address = _issuer_address
+        batch_register_upload.upload_id = self.upload_id_list[0]
+        batch_register_upload.status = BatchRegisterPersonalInfoUploadStatus.DONE.value
+        db.add(batch_register_upload)
+
+        batch_register_upload = BatchRegisterPersonalInfoUpload()
+        batch_register_upload.issuer_address = _issuer_address
+        batch_register_upload.upload_id = self.upload_id_list[1]
+        batch_register_upload.status = BatchRegisterPersonalInfoUploadStatus.PENDING.value
+        db.add(batch_register_upload)
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address, self.upload_id_list[0]),
+            headers={
+                "issuer-address": _issuer_address
+            },
+            params={
+                "sort_order": 0
+            }
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            'result_set': {
+                'count': 2,
+                'offset': None,
+                'limit': None,
+                'total': 2
+            },
+            'uploads': [
+                {
+                    'batch_id': self.upload_id_list[0],
+                    'status': BatchRegisterPersonalInfoUploadStatus.DONE.value,
+                    'created': mock.ANY
+                },
+                {
+                    'batch_id': self.upload_id_list[1],
+                    'status': BatchRegisterPersonalInfoUploadStatus.PENDING.value,
+                    'created': mock.ANY
+                }
+            ]
+        }
+
+    #########################################################################
+    # Error Case
+    ###########################################################################
+
+    # Error_1
+    # RequestValidationError: issuer_address
+    def test_error_1(self, client, db):
+        _issuer_account = config_eth_account("user1")
+        _issuer_address = _issuer_account["address"]
+
+        _token_address = "0xd9F55747DE740297ff1eEe537aBE0f8d73B7D783"
+
+        # prepare data: token issued by issuer_address
+        token = Token()
+        token.type = TokenType.IBET_SHARE.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        db.add(token)
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address, self.upload_id_list[0]),
+            headers={}
+        )
+
+        # assertion
+        assert resp.status_code == 422
+        assert resp.json() == {
+            'meta': {
+                'code': 1,
+                'title': 'RequestValidationError'
+            },
+            'detail': [
+                {
+                    'loc': ['header', 'issuer-address'],
+                    'msg': 'field required',
+                    'type': 'value_error.missing'
+                }
+            ]
+        }
+
+    # Error_2
+    # NotFound
+    # token not found
+    def test_error_2(self, client, db):
+        _issuer_account_1 = config_eth_account("user1")
+        _issuer_address_1 = _issuer_account_1["address"]
+
+        _issuer_account_2 = config_eth_account("user2")
+        _issuer_address_2 = _issuer_account_2["address"]
+
+        _token_address = "0xd9F55747DE740297ff1eEe537aBE0f8d73B7D783"
+
+        # prepare data: token issued by issuer_address_2
+        token = Token()
+        token.type = TokenType.IBET_SHARE.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address_2
+        token.token_address = _token_address
+        token.abi = ""
+        db.add(token)
+
+        # Prepare data : BatchRegisterPersonalInfoUpload
+        batch_register_upload = BatchRegisterPersonalInfoUpload()
+        batch_register_upload.issuer_address = _issuer_address_2
+        batch_register_upload.upload_id = self.upload_id_list[0]
+        batch_register_upload.status = BatchRegisterPersonalInfoUploadStatus.DONE.value
+        db.add(batch_register_upload)
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address, self.upload_id_list[0]),
+            headers={
+                "issuer-address": _issuer_address_1
+            }
+        )
+
+        # assertion
+        assert resp.status_code == 404
+        assert resp.json() == {
+            'meta': {
+                'code': 1,
+                'title': 'NotFound'
+            },
+            'detail': 'token not found'
+        }

--- a/tests/test_app_routers_share_tokens_{token_address}_personal_info_batch_{batch_id}_GET.py
+++ b/tests/test_app_routers_share_tokens_{token_address}_personal_info_batch_{batch_id}_GET.py
@@ -66,7 +66,6 @@ class TestAppRoutersShareTokensTokenAddressPersonalInfoBatchBatchIdGET:
     ###########################################################################
 
     # <Normal_1>
-    # With issuer_address(header)
     def test_normal_1(self, client, db):
         _issuer_account = config_eth_account("user1")
         _issuer_address = _issuer_account["address"]
@@ -171,7 +170,7 @@ class TestAppRoutersShareTokensTokenAddressPersonalInfoBatchBatchIdGET:
     ###########################################################################
 
     # <Error_1>
-    # Batch not found
+    # RequestValidationError: issuer_address
     def test_error_1(self, client, db):
         test_account = config_eth_account("user2")
         _issuer_address = test_account["address"]
@@ -179,7 +178,37 @@ class TestAppRoutersShareTokensTokenAddressPersonalInfoBatchBatchIdGET:
 
         # request target API
         resp = client.get(
-            self.base_url.format(_token_address, "test_event_id"),
+            self.base_url.format(_token_address, "test_batch_id"),
+            headers={
+            }
+        )
+
+        # assertion
+        assert resp.status_code == 422
+        assert resp.json() == {
+            'meta': {
+                'code': 1,
+                'title': 'RequestValidationError'
+            },
+            'detail': [
+                {
+                    'loc': ['header', 'issuer-address'],
+                    'msg': 'field required',
+                    'type': 'value_error.missing'
+                }
+            ]
+        }
+
+    # <Error_2>
+    # Batch not found
+    def test_error_2(self, client, db):
+        test_account = config_eth_account("user2")
+        _issuer_address = test_account["address"]
+        _token_address = "token_address_test"
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address, "test_batch_id"),
             headers={
                 "issuer-address": _issuer_address,
             }

--- a/tests/test_app_routers_share_tokens_{token_address}_redeem_batch_GET.py
+++ b/tests/test_app_routers_share_tokens_{token_address}_redeem_batch_GET.py
@@ -17,20 +17,18 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 import uuid
-import pytz
 from unittest import mock
-from unittest.mock import call
 
-from app.model.blockchain import IbetShareContract
 from app.model.db import (
     Token,
-    TokenType, BatchIssueRedeem, BatchIssueRedeemUpload, BatchIssueRedeemProcessingCategory
+    TokenType,
+    BatchIssueRedeemUpload,
+    BatchIssueRedeemProcessingCategory
 )
-from config import TZ
 from tests.account_config import config_eth_account
 
 
-class TestAppRoutersShareTokensTokenAddressRedeemGET:
+class TestAppRoutersShareTokensTokenAddressRedeemBatchGET:
     # target API endpoint
     base_url = "/share/tokens/{}/redeem/batch"
 
@@ -117,7 +115,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemGET:
                     "processed": False,
                     "token_address": "token_address_test",
                     "token_type": "IbetShare",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 }
             ]
@@ -205,7 +203,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemGET:
                     "processed": False,
                     "token_address": "token_address_test",
                     "token_type": "IbetShare",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 },
                 {
@@ -213,7 +211,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemGET:
                     "processed": False,
                     "token_address": "token_address_test",
                     "token_type": "IbetShare",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 },
                 {
@@ -221,7 +219,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemGET:
                     "processed": False,
                     "token_address": "token_address_test",
                     "token_type": "IbetShare",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 },
                 {
@@ -229,7 +227,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemGET:
                     "processed": True,
                     "token_address": "token_address_test",
                     "token_type": "IbetShare",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 }
             ]
@@ -319,7 +317,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemGET:
                     "processed": False,
                     "token_address": "token_address_test",
                     "token_type": "IbetShare",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 },
                 {
@@ -327,7 +325,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemGET:
                     "processed": True,
                     "token_address": "token_address_test",
                     "token_type": "IbetShare",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 }
             ]
@@ -419,7 +417,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemGET:
                     "processed": False,
                     "token_address": "token_address_test",
                     "token_type": "IbetShare",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 },
                 {
@@ -427,7 +425,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemGET:
                     "processed": False,
                     "token_address": "token_address_test",
                     "token_type": "IbetShare",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 },
                 {
@@ -435,7 +433,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemGET:
                     "processed": False,
                     "token_address": "token_address_test",
                     "token_type": "IbetShare",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 }
             ]
@@ -527,7 +525,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemGET:
                     "processed": False,
                     "token_address": "token_address_test",
                     "token_type": "IbetShare",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 },
                 {
@@ -535,7 +533,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemGET:
                     "processed": True,
                     "token_address": "token_address_test",
                     "token_type": "IbetShare",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 }
             ]
@@ -626,7 +624,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemGET:
                     "processed": True,
                     "token_address": "token_address_test",
                     "token_type": "IbetShare",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 },
                 {
@@ -634,7 +632,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemGET:
                     "processed": False,
                     "token_address": "token_address_test",
                     "token_type": "IbetShare",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 },
                 {
@@ -642,7 +640,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemGET:
                     "processed": True,
                     "token_address": "token_address_test",
                     "token_type": "IbetShare",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 },
                 {
@@ -650,7 +648,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemGET:
                     "processed": False,
                     "token_address": "token_address_test",
                     "token_type": "IbetShare",
-                    "upload_id": mock.ANY,
+                    "batch_id": mock.ANY,
                     "created": mock.ANY
                 }
             ]


### PR DESCRIPTION
Add new APIs: List personal information batch registration uploads

- GET: /bond/tokens/{token_address}/personal_info/batch
- GET: /share/tokens/{token_address}/personal_info/batch

In addition, various improvements were made to related functions.