### PR TITLE
feat: Add token_address attribute to notification metainfo

### DIFF
--- a/app/model/schema/notification.py
+++ b/app/model/schema/notification.py
@@ -21,7 +21,8 @@ from typing import (
     List,
     Dict,
     Any,
-    Union
+    Union,
+    Optional
 )
 
 from pydantic import BaseModel, conint
@@ -34,26 +35,28 @@ from app.model.db import (
 )
 
 
-class IssueErrorMetainfo(BaseModel):
+class IssueErrorMetaInfo(BaseModel):
     token_address: str
     token_type: TokenType
     arguments: dict
 
 
-class BulkTransferErrorMetainfo(BaseModel):
+class BulkTransferErrorMetaInfo(BaseModel):
     upload_id: str
     token_type: TokenType
     error_transfer_id: list[int]
 
 
-class ScheduleEventErrorMetainfo(BaseModel):
-    scheduled_event_id: int
+class ScheduleEventErrorMetaInfo(BaseModel):
+    scheduled_event_id: str
+    token_address: Optional[str]
     token_type: TokenType
 
 
 class TransferApprovalInfoMetaInfo(BaseModel):
     id: int
     token_address: str
+    token_type: Optional[TokenType]
 
 
 class CreateLedgerInfoMetaInfo(BaseModel):
@@ -62,15 +65,17 @@ class CreateLedgerInfoMetaInfo(BaseModel):
     ledger_id: int
 
 
-class BatchRegisterPersonalInfoErrorMetainfo(BaseModel):
+class BatchRegisterPersonalInfoErrorMetaInfo(BaseModel):
     upload_id: str
     error_registration_id: list[int]
 
 
-class BatchIssueRedeemProcessedMetainfo(BaseModel):
+class BatchIssueRedeemProcessedMetaInfo(BaseModel):
     category: BatchIssueRedeemProcessingCategory
     upload_id: str
     error_data_id: list[int]
+    token_address: str
+    token_type: TokenType
 
 
 class Notification(BaseModel):
@@ -84,7 +89,7 @@ class Notification(BaseModel):
 class IssueErrorNotification(Notification):
     notice_type: str = NotificationType.ISSUE_ERROR
     notice_code: conint(ge=0, le=2)
-    metainfo: IssueErrorMetainfo
+    metainfo: IssueErrorMetaInfo
 
     class Config:
         @staticmethod
@@ -98,7 +103,7 @@ class IssueErrorNotification(Notification):
 class BulkTransferErrorNotification(Notification):
     notice_type: str = NotificationType.BULK_TRANSFER_ERROR
     notice_code: conint(ge=0, le=2)
-    metainfo: BulkTransferErrorMetainfo
+    metainfo: BulkTransferErrorMetaInfo
 
     class Config:
         @staticmethod
@@ -113,7 +118,7 @@ class BulkTransferErrorNotification(Notification):
 class ScheduleEventErrorNotification(Notification):
     notice_type: str = NotificationType.SCHEDULE_EVENT_ERROR
     notice_code: conint(ge=0, le=2)
-    metainfo: ScheduleEventErrorMetainfo
+    metainfo: ScheduleEventErrorMetaInfo
 
     class Config:
         @staticmethod
@@ -155,28 +160,26 @@ class CreateLedgerInfoNotification(Notification):
 class BatchRegisterPersonalInfoErrorNotification(Notification):
     notice_type: str = NotificationType.BATCH_REGISTER_PERSONAL_INFO_ERROR
     notice_code: conint(ge=0, le=1)
-    metainfo: BatchRegisterPersonalInfoErrorMetainfo
+    metainfo: BatchRegisterPersonalInfoErrorMetaInfo
 
     class Config:
         @staticmethod
         def schema_extra(schema: Dict[str, Any], _) -> None:
             notice_code_schema = schema["properties"]["notice_code"]
-            notice_code_schema["description"] = "notice_type: BatchRegisterPersonalInfoError\n" \
-                                                " - 0: Issuer does not exist\n" \
+            notice_code_schema["description"] = " - 0: Issuer does not exist\n" \
                                                 " - 1: Failed to send transaction\n"
 
 
 class BatchIssueRedeemProcessedNotification(Notification):
     notice_type: str = NotificationType.BATCH_ISSUE_REDEEM_PROCESSED
     notice_code: conint(ge=0, le=3)
-    metainfo: BatchIssueRedeemProcessedMetainfo
+    metainfo: BatchIssueRedeemProcessedMetaInfo
 
     class Config:
         @staticmethod
         def schema_extra(schema: Dict[str, Any], _) -> None:
             notice_code_schema = schema["properties"]["notice_code"]
-            notice_code_schema["description"] = "notice_type: BatchIssueRedeemProcessed\n" \
-                                                " - 0: All records successfully processed\n" \
+            notice_code_schema["description"] = " - 0: All records successfully processed\n" \
                                                 " - 1: Issuer does not exist\n" \
                                                 " - 2: Failed to decode keyfile\n" \
                                                 " - 3: Some records are failed to send transaction"

--- a/batch/indexer_transfer_approval.py
+++ b/batch/indexer_transfer_approval.py
@@ -466,7 +466,7 @@ class Processor:
             first()
         if transfer_approval is not None:
             # Get issuer address
-            token = db_session.query(Token). \
+            token: Token | None = db_session.query(Token). \
                 filter(Token.token_address == token_address). \
                 first()
             sender = web3.eth.get_transaction(transaction_hash)["from"]
@@ -478,6 +478,7 @@ class Processor:
                             issuer_address=token.issuer_address,
                             code=notice_code,
                             token_address=token_address,
+                            token_type=token.type,
                             id=transfer_approval.id
                         )
                     elif notice_code == 1 or notice_code == 3:  # CancelTransfer or EscrowFinished
@@ -486,6 +487,7 @@ class Processor:
                             issuer_address=token.issuer_address,
                             code=notice_code,
                             token_address=token_address,
+                            token_type=token.type,
                             id=transfer_approval.id
                         )
                 else:  # Operate from issuer
@@ -495,6 +497,7 @@ class Processor:
                             issuer_address=token.issuer_address,
                             code=notice_code,
                             token_address=token_address,
+                            token_type=token.type,
                             id=transfer_approval.id
                         )
 
@@ -582,6 +585,7 @@ class Processor:
                                     issuer_address: str,
                                     code: int,
                                     token_address: str,
+                                    token_type: str,
                                     id: int):
         notification = Notification()
         notification.notice_id = uuid.uuid4()
@@ -591,6 +595,7 @@ class Processor:
         notification.code = code
         notification.metainfo = {
             "token_address": token_address,
+            "token_type": token_type,
             "id": id
         }
         db_session.add(notification)

--- a/batch/processor_batch_issue_redeem.py
+++ b/batch/processor_batch_issue_redeem.py
@@ -81,6 +81,8 @@ class Processor:
                     self.__sink_on_notification(
                         db_session=db_session,
                         issuer_address=upload.issuer_address,
+                        token_address=upload.token_address,
+                        token_type=upload.token_type,
                         code=1,
                         upload_category=upload.category,
                         upload_id=upload.upload_id,
@@ -100,6 +102,8 @@ class Processor:
                     self.__sink_on_notification(
                         db_session=db_session,
                         issuer_address=upload.issuer_address,
+                        token_address=upload.token_address,
+                        token_type=upload.token_type,
                         code=2,
                         upload_category=upload.category,
                         upload_id=upload.upload_id,
@@ -182,6 +186,8 @@ class Processor:
                 self.__sink_on_notification(
                     db_session=db_session,
                     issuer_address=upload.issuer_address,
+                    token_address=upload.token_address,
+                    token_type=upload.token_type,
                     code=code,
                     upload_category=upload.category,
                     upload_id=upload.upload_id,
@@ -196,6 +202,8 @@ class Processor:
     @staticmethod
     def __sink_on_notification(db_session: Session,
                                issuer_address: str,
+                               token_address: str,
+                               token_type: str,
                                upload_category: str,
                                code: int,
                                upload_id: str,
@@ -209,7 +217,9 @@ class Processor:
         notification.metainfo = {
             "category": upload_category,
             "upload_id": upload_id,
-            "error_data_id": error_data_id_list
+            "error_data_id": error_data_id_list,
+            "token_address": token_address,
+            "token_type": token_type
         }
         db_session.add(notification)
 

--- a/batch/processor_scheduled_events.py
+++ b/batch/processor_scheduled_events.py
@@ -147,7 +147,10 @@ class Processor:
                     self.__sink_on_error_notification(
                         db_session=db_session,
                         issuer_address=_event.issuer_address, code=0,
-                        scheduled_event_id=_event.event_id, token_type=_event.token_type)
+                        scheduled_event_id=_event.event_id,
+                        token_type=_event.token_type,
+                        token_address=_event.token_address
+                    )
                     db_session.commit()
                     continue
                 keyfile_json = _account.keyfile
@@ -166,7 +169,10 @@ class Processor:
                 self.__sink_on_error_notification(
                     db_session=db_session,
                     issuer_address=_event.issuer_address, code=1,
-                    scheduled_event_id=_event.event_id, token_type=_event.token_type)
+                    scheduled_event_id=_event.event_id,
+                    token_type=_event.token_type,
+                    token_address=_event.token_address
+                )
                 db_session.commit()
                 continue
 
@@ -210,7 +216,8 @@ class Processor:
                     issuer_address=_event.issuer_address,
                     code=2,
                     scheduled_event_id=_event.event_id,
-                    token_type=_event.token_type
+                    token_type=_event.token_type,
+                    token_address=_event.token_address
                 )
             except SendTransactionError:
                 LOG.warning(f"Failed to send transaction: id=<{_event.id}>")
@@ -224,7 +231,8 @@ class Processor:
                     issuer_address=_event.issuer_address,
                     code=2,
                     scheduled_event_id=_event.event_id,
-                    token_type=_event.token_type
+                    token_type=_event.token_type,
+                    token_address=_event.token_address
                 )
             db_session.commit()
 
@@ -241,8 +249,9 @@ class Processor:
     def __sink_on_error_notification(db_session: Session,
                                      issuer_address: str,
                                      code: int,
-                                     scheduled_event_id: int,
-                                     token_type: str):
+                                     scheduled_event_id: str,
+                                     token_type: str,
+                                     token_address: str):
         notification = Notification()
         notification.notice_id = uuid.uuid4()
         notification.issuer_address = issuer_address
@@ -251,7 +260,8 @@ class Processor:
         notification.code = code
         notification.metainfo = {
             "scheduled_event_id": scheduled_event_id,
-            "token_type": token_type
+            "token_type": token_type,
+            "token_address": token_address
         }
         db_session.add(notification)
 

--- a/tests/test_app_routers_docs_GET.py
+++ b/tests/test_app_routers_docs_GET.py
@@ -1,0 +1,37 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+from fastapi.testclient import TestClient
+
+
+class TestOpenAPIDoc:
+    # テスト対象API
+    apiurl_base = '/openapi.json'
+
+    ###########################################################################
+    # Normal
+    ###########################################################################
+
+    # <Normal_1>
+    def test_normal_1(self, client: TestClient):
+        apiurl = self.apiurl_base
+        resp = client.get(apiurl)
+
+        assert resp.status_code == 200
+        assert resp.json()["openapi"] == "3.0.2"
+        assert resp.json()["info"]["title"] == "ibet Prime"

--- a/tests/test_app_routers_notifications_GET.py
+++ b/tests/test_app_routers_notifications_GET.py
@@ -67,7 +67,8 @@ class TestAppRoutersNotificationsGET:
         _notification_2.type = NotificationType.SCHEDULE_EVENT_ERROR
         _notification_2.code = 2
         _notification_2.metainfo = {
-            "scheduled_event_id": 1,
+            "scheduled_event_id": "1",
+            "token_address": "0x0000000000000000000000000000000000000000",
             "token_type": TokenType.IBET_STRAIGHT_BOND.value
         }
         _notification_2.created = datetime.strptime("2022/01/02 00:20:30", '%Y/%m/%d %H:%M:%S')  # JST 2022/01/02
@@ -95,7 +96,8 @@ class TestAppRoutersNotificationsGET:
         _notification_4.code = 3
         _notification_4.metainfo = {
             "id": 1,
-            "token_address": "0x0000000000000000000000000000000000000000"
+            "token_address": "0x0000000000000000000000000000000000000000",
+            "token_type": TokenType.IBET_STRAIGHT_BOND.value
         }
         _notification_4.created = datetime.strptime("2022/01/03 00:20:30", '%Y/%m/%d %H:%M:%S')  # JST 2022/01/03
         db.add(_notification_4)
@@ -139,6 +141,8 @@ class TestAppRoutersNotificationsGET:
             "category": BatchIssueRedeemProcessingCategory.ISSUE.value,
             "upload_id": str(uuid.uuid4()),
             "error_data_id": [1, 2, 3],
+            "token_address": "0x0000000000000000000000000000000000000000",
+            "token_type": TokenType.IBET_STRAIGHT_BOND.value
         }
         _notification_7.created = datetime.strptime("2022/01/07 00:20:30", '%Y/%m/%d %H:%M:%S')  # JST 2022/01/03
         db.add(_notification_7)
@@ -178,7 +182,8 @@ class TestAppRoutersNotificationsGET:
                     "notice_type": NotificationType.SCHEDULE_EVENT_ERROR,
                     "notice_code": 2,
                     "metainfo": {
-                        "scheduled_event_id": 1,
+                        "scheduled_event_id": "1",
+                        "token_address": "0x0000000000000000000000000000000000000000",
                         "token_type": TokenType.IBET_STRAIGHT_BOND.value
                     },
                     "created": "2022-01-02T09:20:30+09:00"
@@ -204,7 +209,8 @@ class TestAppRoutersNotificationsGET:
                     "notice_code": 3,
                     "metainfo": {
                         "id": 1,
-                        "token_address": "0x0000000000000000000000000000000000000000"
+                        "token_address": "0x0000000000000000000000000000000000000000",
+                        "token_type": TokenType.IBET_STRAIGHT_BOND
                     },
                     "created": "2022-01-03T09:20:30+09:00"
                 },
@@ -242,7 +248,9 @@ class TestAppRoutersNotificationsGET:
                     "metainfo": {
                         "category": BatchIssueRedeemProcessingCategory.ISSUE.value,
                         "upload_id": ANY,
-                        "error_data_id": [1, 2, 3]
+                        "error_data_id": [1, 2, 3],
+                        "token_address": "0x0000000000000000000000000000000000000000",
+                        "token_type": TokenType.IBET_STRAIGHT_BOND
                     },
                     "created": "2022-01-07T09:20:30+09:00"
                 },
@@ -279,7 +287,7 @@ class TestAppRoutersNotificationsGET:
         _notification_2.type = NotificationType.SCHEDULE_EVENT_ERROR
         _notification_2.code = 1
         _notification_2.metainfo = {
-            "scheduled_event_id": 1,
+            "scheduled_event_id": "1",
             "token_type": TokenType.IBET_STRAIGHT_BOND.value
         }
         _notification_2.created = datetime.strptime("2022/01/02 00:20:30", '%Y/%m/%d %H:%M:%S')  # JST 2022/01/02
@@ -306,7 +314,7 @@ class TestAppRoutersNotificationsGET:
         _notification_4.type = NotificationType.SCHEDULE_EVENT_ERROR
         _notification_4.code = 3
         _notification_4.metainfo = {
-            "scheduled_event_id": 1,
+            "scheduled_event_id": "1",
             "token_type": TokenType.IBET_STRAIGHT_BOND.value
         }
         _notification_4.created = datetime.strptime("2022/01/03 00:20:30", '%Y/%m/%d %H:%M:%S')  # JST 2022/01/03
@@ -340,8 +348,9 @@ class TestAppRoutersNotificationsGET:
                     "notice_type": NotificationType.SCHEDULE_EVENT_ERROR,
                     "notice_code": 1,
                     "metainfo": {
-                        "scheduled_event_id": 1,
-                        "token_type": TokenType.IBET_STRAIGHT_BOND.value
+                        "scheduled_event_id": "1",
+                        "token_type": TokenType.IBET_STRAIGHT_BOND.value,
+                        "token_address": None
                     },
                     "created": "2022-01-02T09:20:30+09:00"
                 },
@@ -378,7 +387,7 @@ class TestAppRoutersNotificationsGET:
         _notification_2.type = NotificationType.SCHEDULE_EVENT_ERROR
         _notification_2.code = 1
         _notification_2.metainfo = {
-            "scheduled_event_id": 1,
+            "scheduled_event_id": "1",
             "token_type": TokenType.IBET_STRAIGHT_BOND.value
         }
         _notification_2.created = datetime.strptime("2022/01/02 00:20:30", '%Y/%m/%d %H:%M:%S')  # JST 2022/01/02
@@ -388,12 +397,12 @@ class TestAppRoutersNotificationsGET:
         _notification_3.notice_id = "notice_id_3"
         _notification_3.issuer_address = issuer_address_2
         _notification_3.priority = 2
-        _notification_3.type = NotificationType.BULK_TRANSFER_ERROR
+        _notification_3.type = NotificationType.TRANSFER_APPROVAL_INFO
         _notification_3.code = 2
         _notification_3.metainfo = {
-            "upload_id": str(uuid.uuid4()),
+            "id": 1,
             "token_type": TokenType.IBET_STRAIGHT_BOND.value,
-            "error_transfer_id": []
+            "token_address": "0x0000000000000000000000000000000000000000"
         }
         _notification_3.created = datetime.strptime("2022/01/02 15:20:30", '%Y/%m/%d %H:%M:%S')  # JST 2022/01/03
         db.add(_notification_3)
@@ -405,7 +414,7 @@ class TestAppRoutersNotificationsGET:
         _notification_4.type = NotificationType.SCHEDULE_EVENT_ERROR
         _notification_4.code = 3
         _notification_4.metainfo = {
-            "scheduled_event_id": 1,
+            "scheduled_event_id": "1",
             "token_type": TokenType.IBET_STRAIGHT_BOND.value
         }
         _notification_4.created = datetime.strptime("2022/01/03 00:20:30", '%Y/%m/%d %H:%M:%S')  # JST 2022/01/03
@@ -437,8 +446,9 @@ class TestAppRoutersNotificationsGET:
                     "notice_type": NotificationType.SCHEDULE_EVENT_ERROR,
                     "notice_code": 1,
                     "metainfo": {
-                        "scheduled_event_id": 1,
-                        "token_type": TokenType.IBET_STRAIGHT_BOND.value
+                        "scheduled_event_id": "1",
+                        "token_type": TokenType.IBET_STRAIGHT_BOND.value,
+                        "token_address": None
                     },
                     "created": "2022-01-02T09:20:30+09:00"
                 },
@@ -446,12 +456,12 @@ class TestAppRoutersNotificationsGET:
                     "notice_id": "notice_id_3",
                     "issuer_address": issuer_address_2,
                     "priority": 2,
-                    "notice_type": NotificationType.BULK_TRANSFER_ERROR,
+                    "notice_type": NotificationType.TRANSFER_APPROVAL_INFO,
                     "notice_code": 2,
                     "metainfo": {
-                        "upload_id": ANY,
+                        "id": 1,
                         "token_type": TokenType.IBET_STRAIGHT_BOND.value,
-                        "error_transfer_id": []
+                        "token_address": "0x0000000000000000000000000000000000000000"
                     },
                     "created": "2022-01-03T00:20:30+09:00"
                 },

--- a/tests/test_batch_indexer_transfer_approval.py
+++ b/tests/test_batch_indexer_transfer_approval.py
@@ -340,6 +340,7 @@ class TestProcessor:
         assert _notification.type == NotificationType.TRANSFER_APPROVAL_INFO
         assert _notification.code == 0
         assert _notification.metainfo == {
+            "token_type": token_1.type,
             "token_address": token_address_1,
             "id": 1
         }
@@ -461,6 +462,7 @@ class TestProcessor:
         assert _notification.type == NotificationType.TRANSFER_APPROVAL_INFO
         assert _notification.code == 0
         assert _notification.metainfo == {
+            "token_type": token_1.type,
             "token_address": token_address_1,
             "id": 1
         }
@@ -582,6 +584,7 @@ class TestProcessor:
         assert _notification.type == NotificationType.TRANSFER_APPROVAL_INFO
         assert _notification.code == 1
         assert _notification.metainfo == {
+            "token_type": token_1.type,
             "token_address": token_address_1,
             "id": 1
         }
@@ -703,6 +706,7 @@ class TestProcessor:
         assert _notification.type == NotificationType.TRANSFER_APPROVAL_INFO
         assert _notification.code == 2
         assert _notification.metainfo == {
+            "token_type": token_1.type,
             "token_address": token_address_1,
             "id": 1
         }
@@ -827,6 +831,7 @@ class TestProcessor:
         assert _notification.type == NotificationType.TRANSFER_APPROVAL_INFO
         assert _notification.code == 0
         assert _notification.metainfo == {
+            "token_type": token_1.type,
             "token_address": token_address_1,
             "id": 1
         }
@@ -969,6 +974,7 @@ class TestProcessor:
         assert _notification.type == NotificationType.TRANSFER_APPROVAL_INFO
         assert _notification.code == 1
         assert _notification.metainfo == {
+            "token_type": token_1.type,
             "token_address": token_address_1,
             "id": 1
         }
@@ -1102,6 +1108,7 @@ class TestProcessor:
         assert _notification.type == NotificationType.TRANSFER_APPROVAL_INFO
         assert _notification.code == 3
         assert _notification.metainfo == {
+            "token_type": token_1.type,
             "token_address": token_address_1,
             "id": 1
         }
@@ -1247,6 +1254,7 @@ class TestProcessor:
         assert _notification.type == NotificationType.TRANSFER_APPROVAL_INFO
         assert _notification.code == 2
         assert _notification.metainfo == {
+            "token_type": token_1.type,
             "token_address": token_address_1,
             "id": 1
         }
@@ -1255,11 +1263,11 @@ class TestProcessor:
         assert _idx_transfer_approval_block_number.id == 1
         assert _idx_transfer_approval_block_number.latest_block_number == block_number
 
-    # <Normal_6>
+    # <Normal_3>
     # If block number processed in batch is equal or greater than current block number,
     # batch will output a log "skip process".
     @mock.patch("web3.eth.Eth.block_number", 100)
-    def test_normal_6(self, processor: Processor, db: Session, caplog: pytest.LogCaptureFixture):
+    def test_normal_3(self, processor: Processor, db: Session, caplog: pytest.LogCaptureFixture):
         _idx_transfer_approval_block_number = IDXTransferApprovalBlockNumber()
         _idx_transfer_approval_block_number.id = 1
         _idx_transfer_approval_block_number.latest_block_number = 1000
@@ -1269,9 +1277,9 @@ class TestProcessor:
         processor.sync_new_logs()
         assert caplog.record_tuples.count((LOG.name, logging.DEBUG, "skip process")) == 1
 
-    # <Normal_7>
+    # <Normal_4>
     # If DB session fails in sinking phase each event, batch outputs a log "exception occurred".
-    def test_normal_7(self, processor, db, personal_info_contract, ibet_security_token_escrow_contract, caplog: pytest.LogCaptureFixture):
+    def test_normal_4(self, processor, db, personal_info_contract, ibet_security_token_escrow_contract, caplog: pytest.LogCaptureFixture):
         user_1 = config_eth_account("user1")
         issuer_address = user_1["address"]
         issuer_private_key = decode_keyfile_json(raw_keyfile_json=user_1["keyfile_json"], password="password".encode("utf-8"))

--- a/tests/test_batch_processor_batch_issue_redeem.py
+++ b/tests/test_batch_processor_batch_issue_redeem.py
@@ -158,7 +158,9 @@ class TestProcessor:
             assert _notification.metainfo == {
                 "category": BatchIssueRedeemProcessingCategory.ISSUE.value,
                 "upload_id": upload_id,
-                "error_data_id": []
+                "error_data_id": [],
+                "token_address": token_address,
+                "token_type": TokenType.IBET_STRAIGHT_BOND
             }
 
     # Normal_2
@@ -255,7 +257,9 @@ class TestProcessor:
             assert _notification.metainfo == {
                 "category": BatchIssueRedeemProcessingCategory.REDEEM.value,
                 "upload_id": upload_id,
-                "error_data_id": []
+                "error_data_id": [],
+                "token_address": token_address,
+                "token_type": TokenType.IBET_STRAIGHT_BOND
             }
 
     # Normal_3
@@ -352,7 +356,9 @@ class TestProcessor:
             assert _notification.metainfo == {
                 "category": BatchIssueRedeemProcessingCategory.ISSUE.value,
                 "upload_id": upload_id,
-                "error_data_id": []
+                "error_data_id": [],
+                "token_address": token_address,
+                "token_type": TokenType.IBET_SHARE
             }
 
     # Normal_4
@@ -449,7 +455,9 @@ class TestProcessor:
             assert _notification.metainfo == {
                 "category": BatchIssueRedeemProcessingCategory.REDEEM.value,
                 "upload_id": upload_id,
-                "error_data_id": []
+                "error_data_id": [],
+                "token_address": token_address,
+                "token_type": TokenType.IBET_SHARE
             }
 
     ###########################################################################
@@ -528,7 +536,9 @@ class TestProcessor:
             assert _notification.metainfo == {
                 "category": BatchIssueRedeemProcessingCategory.ISSUE.value,
                 "upload_id": upload_id,
-                "error_data_id": []
+                "error_data_id": [],
+                "token_address": token_address,
+                "token_type": TokenType.IBET_STRAIGHT_BOND
             }
 
     # Error_2
@@ -612,7 +622,9 @@ class TestProcessor:
             assert _notification.metainfo == {
                 "category": BatchIssueRedeemProcessingCategory.ISSUE.value,
                 "upload_id": upload_id,
-                "error_data_id": []
+                "error_data_id": [],
+                "token_address": token_address,
+                "token_type": TokenType.IBET_STRAIGHT_BOND
             }
 
     # Error_3
@@ -701,7 +713,9 @@ class TestProcessor:
             assert _notification.metainfo == {
                 "category": BatchIssueRedeemProcessingCategory.ISSUE.value,
                 "upload_id": upload_id,
-                "error_data_id": ANY
+                "error_data_id": ANY,
+                "token_address": token_address,
+                "token_type": TokenType.IBET_STRAIGHT_BOND
             }
             assert len(_notification.metainfo["error_data_id"]) == 2
 
@@ -823,7 +837,9 @@ class TestProcessor:
         assert _notification_list[0].metainfo == {
             "category": BatchIssueRedeemProcessingCategory.ISSUE.value,
             "upload_id": upload_1_id,
-            "error_data_id": ANY
+            "error_data_id": ANY,
+            "token_address": token_address,
+            "token_type": TokenType.IBET_STRAIGHT_BOND
         }
         assert len(_notification_list[0].metainfo["error_data_id"]) == 1
 
@@ -835,6 +851,8 @@ class TestProcessor:
         assert _notification_list[1].metainfo == {
             "category": BatchIssueRedeemProcessingCategory.ISSUE.value,
             "upload_id": upload_2_id,
-            "error_data_id": ANY
+            "error_data_id": ANY,
+            "token_address": token_address,
+            "token_type": TokenType.IBET_SHARE
         }
         assert len(_notification_list[1].metainfo["error_data_id"]) == 1

--- a/tests/test_batch_processor_scheduled_events.py
+++ b/tests/test_batch_processor_scheduled_events.py
@@ -527,6 +527,7 @@ class TestProcessor:
         assert _notification.metainfo == {
             "scheduled_event_id": "event_id_1",
             "token_type": TokenType.IBET_STRAIGHT_BOND.value,
+            "token_address": _token_address
         }
 
     # <Error_2>
@@ -579,6 +580,7 @@ class TestProcessor:
         assert _notification.metainfo == {
             "scheduled_event_id": "event_id_1",
             "token_type": TokenType.IBET_SHARE.value,
+            "token_address": _token_address
         }
 
     # <Error_3>
@@ -641,6 +643,7 @@ class TestProcessor:
         assert _notification.metainfo == {
             "scheduled_event_id": "event_id_1",
             "token_type": TokenType.IBET_STRAIGHT_BOND.value,
+            "token_address": _token_address
         }
 
     # <Error_4>
@@ -704,6 +707,7 @@ class TestProcessor:
         assert _notification.metainfo == {
             "scheduled_event_id": "event_id_1",
             "token_type": TokenType.IBET_SHARE.value,
+            "token_address": _token_address
         }
 
     # <Error_5>
@@ -766,6 +770,7 @@ class TestProcessor:
         assert _notification.metainfo == {
             "scheduled_event_id": "event_id_1",
             "token_type": TokenType.IBET_STRAIGHT_BOND.value,
+            "token_address": _token_address
         }
         assert caplog.record_tuples.count((
             LOG.name,
@@ -834,6 +839,7 @@ class TestProcessor:
         assert _notification.metainfo == {
             "scheduled_event_id": "event_id_1",
             "token_type": TokenType.IBET_SHARE.value,
+            "token_address": _token_address
         }
 
         assert caplog.record_tuples.count((


### PR DESCRIPTION
Close #382 

### Changes

- Added "token_address" attribute to notification metainfo which specific token is related to.
  - Added `optional` to notification types which is introduced before v22.6.
- Renamed schema models from Metainfo to Meta**I**nfo.

> - トークン軸の通知に"token_address"属性を追加しました。
>   - v22.6以前に存在した通知タイプへは`optional`を追加しました。
> - MetainfoからMeta**I**nfoにリネームしました。