### PR TITLE
fix: openapi document

### DIFF
--- a/app/model/schema/batch_issue_redeem.py
+++ b/app/model/schema/batch_issue_redeem.py
@@ -42,7 +42,12 @@ class BatchIssueRedeemUpload(BaseModel):
     class Config:
         schema_extra = {
             "example": {
-                "batch_id": "cfd83622-34dc-4efe-a68b-2cc275d3d824"
+                "batch_id": "cfd83622-34dc-4efe-a68b-2cc275d3d824",
+                "issuer_address": "0x0000000000000000000000000000000000000000",
+                "token_type": "Bond",
+                "token_address": "0x0000000000000000000000000000000000000000",
+                "processed": True,
+                "created": "2022-09-02T19:49:33.370874+09:00"
             }
         }
 

--- a/app/model/schema/personal_info.py
+++ b/app/model/schema/personal_info.py
@@ -76,6 +76,7 @@ class BatchRegisterPersonalInfoUploadResponse(BaseModel):
             "example": {
                 "batch_id": "cfd83622-34dc-4efe-a68b-2cc275d3d824",
                 "status": "pending",
+                "created": "2022-09-02T19:49:33.370874+09:00"
             }
         }
 

--- a/app/routers/bond.py
+++ b/app/routers/bond.py
@@ -1502,7 +1502,8 @@ def retrieve_holder(
 @router.post(
     "/tokens/{token_address}/holders/{account_address}/personal_info",
     response_model=None,
-    responses=get_routers_responses(422, 401, 404, AuthorizationError, InvalidParameterError, SendTransactionError, ContractRevertError)
+    responses=get_routers_responses(422, 401, 404, AuthorizationError, InvalidParameterError, SendTransactionError, ContractRevertError),
+    deprecated=True
 )
 def modify_holder_personal_info(
         request: Request,

--- a/app/routers/share.py
+++ b/app/routers/share.py
@@ -1490,7 +1490,8 @@ def retrieve_holder(
 @router.post(
     "/tokens/{token_address}/holders/{account_address}/personal_info",
     response_model=None,
-    responses=get_routers_responses(422, 401, 404, AuthorizationError, InvalidParameterError, SendTransactionError, ContractRevertError)
+    responses=get_routers_responses(422, 401, 404, AuthorizationError, InvalidParameterError, SendTransactionError, ContractRevertError),
+    deprecated=True
 )
 def modify_holder_personal_info(
         request: Request,


### PR DESCRIPTION
**Fixed only docs**

- Add example value for `BatchRegisterPersonalInfoUploadResponse` / `BatchIssueRedeemUpload` .
- Set deprecated flag True to modify_holder_personal_info endpoint which has been already deprecated.

e.g.)
- Before
  - ![スクリーンショット 2022-09-14 9 30 51](https://user-images.githubusercontent.com/15183665/190033408-a18af198-f0c0-4f16-a830-36887d1ede0c.png)
  - ![スクリーンショット 2022-09-14 9 32 21](https://user-images.githubusercontent.com/15183665/190033443-ae62ffeb-2190-464f-a384-0017ccb44c16.png)
- After
  - "Deprecated" added
  ![スクリーンショット 2022-09-14 9 38 22](https://user-images.githubusercontent.com/15183665/190033476-0e853d38-6b1b-4ba6-9367-437d0fff206b.png)
  - Response example added
  ![スクリーンショット 2022-09-14 9 37 25](https://user-images.githubusercontent.com/15183665/190033460-e584e270-16f1-4b7f-8af1-ec3553ff0850.png)
