### PR TITLE
feat: avoid to fetch ABI data from DB in indexer batch every cycle

### DIFF
--- a/batch/indexer_issue_redeem.py
+++ b/batch/indexer_issue_redeem.py
@@ -92,12 +92,7 @@ class Processor:
             ]
         )
         loaded_token_address_list: tuple[str, ...] = tuple(self.token_list.keys())
-
-        load_required_address_list: list[str] = []
-        # List addresses of tokens that need to be newly loaded
-        for issued_token_address in issued_token_address_list:
-            if issued_token_address not in loaded_token_address_list:
-                load_required_address_list.append(issued_token_address)
+        load_required_address_list = list(set(issued_token_address_list) ^ set(loaded_token_address_list))
 
         if not load_required_address_list:
             # If there are no tokens to load newly, skip process

--- a/batch/indexer_issue_redeem.py
+++ b/batch/indexer_issue_redeem.py
@@ -24,6 +24,7 @@ from eth_utils import to_checksum_address
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import SQLAlchemyError
+from web3.eth import Contract
 
 path = os.path.join(os.path.dirname(__file__), "../")
 sys.path.append(path)
@@ -54,7 +55,7 @@ db_engine = create_engine(DATABASE_URL, echo=False, pool_pre_ping=True)
 class Processor:
     def __init__(self):
         self.latest_block = web3.eth.block_number
-        self.token_list = []
+        self.token_list: dict[str, Contract] = {}
 
     def sync_new_logs(self):
         db_session = Session(autocommit=False, autoflush=True, bind=db_engine)
@@ -83,14 +84,36 @@ class Processor:
             db_session.close()
 
     def __get_token_list(self, db_session: Session):
-        self.token_list = []
-        issued_token_list = db_session.query(Token).filter(Token.token_status == 1).all()
-        for issued_token in issued_token_list:
+        issued_token_address_list: tuple[str, ...] = tuple(
+            [
+                record[0] for record in (
+                    db_session.query(Token.token_address).filter(Token.token_status == 1).all()
+                )
+            ]
+        )
+        loaded_token_address_list: tuple[str, ...] = tuple(self.token_list.keys())
+
+        load_required_address_list: list[str] = []
+        # List addresses of tokens that need to be newly loaded
+        for issued_token_address in issued_token_address_list:
+            if issued_token_address not in loaded_token_address_list:
+                load_required_address_list.append(issued_token_address)
+
+        if not load_required_address_list:
+            # If there are no tokens to load newly, skip process
+            return
+
+        load_required_token_list: list[Token] = (
+            db_session.query(Token).
+            filter(Token.token_status == 1).
+            filter(Token.token_address.in_(load_required_address_list)).all()
+        )
+        for load_required_token in load_required_token_list:
             token_contract = web3.eth.contract(
-                address=issued_token.token_address,
-                abi=issued_token.abi
+                address=load_required_token.token_address,
+                abi=load_required_token.abi
             )
-            self.token_list.append(token_contract)
+            self.token_list[load_required_token.token_address] = token_contract
 
     def __get_idx_issue_redeem_block_number(self, db_session: Session):
         _idx_transfer_block_number = db_session.query(IDXIssueRedeemBlockNumber). \
@@ -122,7 +145,7 @@ class Processor:
         :param block_to: to block number
         :return: None
         """
-        for token in self.token_list:
+        for token in self.token_list.values():
             try:
                 events = ContractUtils.get_event_logs(
                     contract=token,
@@ -158,7 +181,7 @@ class Processor:
         :param block_to: to block number
         :return: None
         """
-        for token in self.token_list:
+        for token in self.token_list.values():
             try:
                 events = ContractUtils.get_event_logs(
                     contract=token,

--- a/batch/indexer_position_bond.py
+++ b/batch/indexer_position_bond.py
@@ -101,12 +101,7 @@ class Processor:
             ]
         )
         loaded_token_address_list: tuple[str, ...] = tuple(self.token_list.keys())
-
-        load_required_address_list: list[str] = []
-        # List addresses of tokens that need to be newly loaded
-        for issued_token_address in issued_token_address_list:
-            if issued_token_address not in loaded_token_address_list:
-                load_required_address_list.append(issued_token_address)
+        load_required_address_list = list(set(issued_token_address_list) ^ set(loaded_token_address_list))
 
         load_required_token_list: list[Token] = (
             db_session.query(Token).

--- a/batch/indexer_position_bond.py
+++ b/batch/indexer_position_bond.py
@@ -26,6 +26,7 @@ from eth_utils import to_checksum_address
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import SQLAlchemyError
+from web3.eth import Contract
 
 path = os.path.join(os.path.dirname(__file__), "../")
 sys.path.append(path)
@@ -58,8 +59,8 @@ db_engine = create_engine(DATABASE_URL, echo=False, pool_pre_ping=True)
 class Processor:
     def __init__(self):
         self.latest_block = web3.eth.block_number
-        self.token_list = []
-        self.exchange_address_list = []
+        self.token_list: dict[str, Contract] = {}
+        self.exchange_address_list: list[str] = []
 
     def sync_new_logs(self):
         db_session = Session(autocommit=False, autoflush=True, bind=db_engine)
@@ -88,21 +89,41 @@ class Processor:
             db_session.close()
 
     def __get_contract_list(self, db_session: Session):
-        self.token_list = []
         self.exchange_address_list = []
 
-        issued_token_list = db_session.query(Token). \
-            filter(Token.type == TokenType.IBET_STRAIGHT_BOND.value). \
-            filter(Token.token_status == 1). \
-            all()
-        _exchange_list_tmp = []
-        for issued_token in issued_token_list:
-            token_contract = web3.eth.contract(
-                address=issued_token.token_address,
-                abi=issued_token.abi
-            )
-            self.token_list.append(token_contract)
+        issued_token_address_list: tuple[str, ...] = tuple(
+            [
+                record[0] for record in (
+                    db_session.query(Token.token_address).
+                    filter(Token.type == TokenType.IBET_STRAIGHT_BOND.value).
+                    filter(Token.token_status == 1).all()
+                )
+            ]
+        )
+        loaded_token_address_list: tuple[str, ...] = tuple(self.token_list.keys())
 
+        load_required_address_list: list[str] = []
+        # List addresses of tokens that need to be newly loaded
+        for issued_token_address in issued_token_address_list:
+            if issued_token_address not in loaded_token_address_list:
+                load_required_address_list.append(issued_token_address)
+
+        load_required_token_list: list[Token] = (
+            db_session.query(Token).
+            filter(Token.type == TokenType.IBET_STRAIGHT_BOND.value).
+            filter(Token.token_status == 1).
+            filter(Token.token_address.in_(load_required_address_list)).
+            all()
+        )
+        for load_required_token in load_required_token_list:
+            token_contract = web3.eth.contract(
+                address=load_required_token.token_address,
+                abi=load_required_token.abi
+            )
+            self.token_list[load_required_token.token_address] = token_contract
+
+        _exchange_list_tmp = []
+        for token_contract in self.token_list.values():
             tradable_exchange_address = ContractUtils.call_function(
                 contract=token_contract,
                 function_name="tradableExchange",
@@ -148,7 +169,7 @@ class Processor:
 
     def __sync_issuer(self, db_session: Session):
         """Synchronize issuer position"""
-        for token in self.token_list:
+        for token in self.token_list.values():
             try:
                 issuer_address = ContractUtils.call_function(
                     contract=token,
@@ -175,7 +196,7 @@ class Processor:
         :param block_to: to block number
         :return: None
         """
-        for token in self.token_list:
+        for token in self.token_list.values():
             try:
                 events = ContractUtils.get_event_logs(
                     contract=token,
@@ -205,7 +226,7 @@ class Processor:
         :param block_to: to block number
         :return: None
         """
-        for token in self.token_list:
+        for token in self.token_list.values():
             try:
                 # Get "Transfer" events from token contract
                 events = ContractUtils.get_event_logs(
@@ -240,7 +261,7 @@ class Processor:
         :param block_to: to block number
         :return: None
         """
-        for token in self.token_list:
+        for token in self.token_list.values():
             try:
                 events = ContractUtils.get_event_logs(
                     contract=token,
@@ -270,7 +291,7 @@ class Processor:
         :param block_to: to block number
         :return: None
         """
-        for token in self.token_list:
+        for token in self.token_list.values():
             try:
                 events = ContractUtils.get_event_logs(
                     contract=token,
@@ -300,7 +321,7 @@ class Processor:
         :param block_to: to block number
         :return: None
         """
-        for token in self.token_list:
+        for token in self.token_list.values():
             try:
                 events = ContractUtils.get_event_logs(
                     contract=token,
@@ -330,7 +351,7 @@ class Processor:
         :param block_to: To block
         :return: None
         """
-        for token in self.token_list:
+        for token in self.token_list.values():
             try:
                 events = ContractUtils.get_event_logs(
                     contract=token,
@@ -360,7 +381,7 @@ class Processor:
         :param block_to: To block
         :return: None
         """
-        for token in self.token_list:
+        for token in self.token_list.values():
             try:
                 events = ContractUtils.get_event_logs(
                     contract=token,
@@ -390,7 +411,7 @@ class Processor:
         :param block_to: To block
         :return: None
         """
-        for token in self.token_list:
+        for token in self.token_list.values():
             try:
                 events = ContractUtils.get_event_logs(
                     contract=token,

--- a/batch/indexer_position_share.py
+++ b/batch/indexer_position_share.py
@@ -26,6 +26,7 @@ from eth_utils import to_checksum_address
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import SQLAlchemyError
+from web3.eth import Contract
 
 path = os.path.join(os.path.dirname(__file__), "../")
 sys.path.append(path)
@@ -58,8 +59,8 @@ db_engine = create_engine(DATABASE_URL, echo=False, pool_pre_ping=True)
 class Processor:
     def __init__(self):
         self.latest_block = web3.eth.block_number
-        self.token_list = []
-        self.exchange_address_list = []
+        self.token_list: dict[str, Contract] = {}
+        self.exchange_address_list: list[str] = []
 
     def sync_new_logs(self):
         db_session = Session(autocommit=False, autoflush=True, bind=db_engine)
@@ -88,21 +89,42 @@ class Processor:
             db_session.close()
 
     def __get_contract_list(self, db_session: Session):
-        self.token_list = []
         self.exchange_address_list = []
 
-        issued_token_list = db_session.query(Token). \
-            filter(Token.type == TokenType.IBET_SHARE.value). \
-            filter(Token.token_status == 1). \
-            all()
-        _exchange_list_tmp = []
-        for issued_token in issued_token_list:
-            token_contract = web3.eth.contract(
-                address=issued_token.token_address,
-                abi=issued_token.abi
-            )
-            self.token_list.append(token_contract)
+        issued_token_address_list: tuple[str, ...] = tuple(
+            [
+                record[0] for record in (
+                    db_session.query(Token.token_address).
+                    filter(Token.type == TokenType.IBET_SHARE.value).
+                    filter(Token.token_status == 1).all()
+                )
+            ]
+        )
+        loaded_token_address_list: tuple[str, ...] = tuple(self.token_list.keys())
 
+        load_required_address_list: list[str] = []
+        # List addresses of tokens that need to be newly loaded
+        for issued_token_address in issued_token_address_list:
+            if issued_token_address not in loaded_token_address_list:
+                load_required_address_list.append(issued_token_address)
+
+        load_required_token_list: list[Token] = (
+            db_session.query(Token).
+            filter(Token.type == TokenType.IBET_SHARE.value).
+            filter(Token.token_status == 1).
+            filter(Token.token_address.in_(load_required_address_list)).
+            all()
+        )
+
+        for load_required_token in load_required_token_list:
+            token_contract = web3.eth.contract(
+                address=load_required_token.token_address,
+                abi=load_required_token.abi
+            )
+            self.token_list[load_required_token.token_address] = token_contract
+
+        _exchange_list_tmp = []
+        for token_contract in self.token_list.values():
             tradable_exchange_address = ContractUtils.call_function(
                 contract=token_contract,
                 function_name="tradableExchange",
@@ -148,7 +170,7 @@ class Processor:
 
     def __sync_issuer(self, db_session: Session):
         """Synchronize issuer position"""
-        for token in self.token_list:
+        for token in self.token_list.values():
             try:
                 issuer_address = ContractUtils.call_function(
                     contract=token,
@@ -175,7 +197,7 @@ class Processor:
         :param block_to: to block number
         :return: None
         """
-        for token in self.token_list:
+        for token in self.token_list.values():
             try:
                 events = ContractUtils.get_event_logs(
                     contract=token,
@@ -205,7 +227,7 @@ class Processor:
         :param block_to: to block number
         :return: None
         """
-        for token in self.token_list:
+        for token in self.token_list.values():
             try:
                 # Get "Transfer" events from token contract
                 events = ContractUtils.get_event_logs(
@@ -240,7 +262,7 @@ class Processor:
         :param block_to: to block number
         :return: None
         """
-        for token in self.token_list:
+        for token in self.token_list.values():
             try:
                 events = ContractUtils.get_event_logs(
                     contract=token,
@@ -270,7 +292,7 @@ class Processor:
         :param block_to: to block number
         :return: None
         """
-        for token in self.token_list:
+        for token in self.token_list.values():
             try:
                 events = ContractUtils.get_event_logs(
                     contract=token,
@@ -300,7 +322,7 @@ class Processor:
         :param block_to: to block number
         :return: None
         """
-        for token in self.token_list:
+        for token in self.token_list.values():
             try:
                 events = ContractUtils.get_event_logs(
                     contract=token,
@@ -330,7 +352,7 @@ class Processor:
         :param block_to: To block
         :return: None
         """
-        for token in self.token_list:
+        for token in self.token_list.values():
             try:
                 events = ContractUtils.get_event_logs(
                     contract=token,
@@ -360,7 +382,7 @@ class Processor:
         :param block_to: To block
         :return: None
         """
-        for token in self.token_list:
+        for token in self.token_list.values():
             try:
                 events = ContractUtils.get_event_logs(
                     contract=token,
@@ -390,7 +412,7 @@ class Processor:
         :param block_to: To block
         :return: None
         """
-        for token in self.token_list:
+        for token in self.token_list.values():
             try:
                 events = ContractUtils.get_event_logs(
                     contract=token,

--- a/batch/indexer_position_share.py
+++ b/batch/indexer_position_share.py
@@ -101,12 +101,7 @@ class Processor:
             ]
         )
         loaded_token_address_list: tuple[str, ...] = tuple(self.token_list.keys())
-
-        load_required_address_list: list[str] = []
-        # List addresses of tokens that need to be newly loaded
-        for issued_token_address in issued_token_address_list:
-            if issued_token_address not in loaded_token_address_list:
-                load_required_address_list.append(issued_token_address)
+        load_required_address_list = list(set(issued_token_address_list) ^ set(loaded_token_address_list))
 
         load_required_token_list: list[Token] = (
             db_session.query(Token).

--- a/batch/indexer_transfer.py
+++ b/batch/indexer_transfer.py
@@ -24,6 +24,7 @@ from eth_utils import to_checksum_address
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import SQLAlchemyError
+from web3.eth import Contract
 
 path = os.path.join(os.path.dirname(__file__), "../")
 sys.path.append(path)
@@ -53,7 +54,7 @@ db_engine = create_engine(DATABASE_URL, echo=False, pool_pre_ping=True)
 class Processor:
     def __init__(self):
         self.latest_block = web3.eth.block_number
-        self.token_list = []
+        self.token_list: dict[str, Contract] = {}
 
     def sync_new_logs(self):
         db_session = Session(autocommit=False, autoflush=True, bind=db_engine)
@@ -82,14 +83,36 @@ class Processor:
             db_session.close()
 
     def __get_token_list(self, db_session: Session):
-        self.token_list = []
-        issued_token_list = db_session.query(Token).filter(Token.token_status == 1).all()
-        for issued_token in issued_token_list:
+        issued_token_address_list: tuple[str, ...] = tuple(
+            [
+                record[0] for record in (
+                    db_session.query(Token.token_address).filter(Token.token_status == 1).all()
+                )
+            ]
+        )
+        loaded_token_address_list: tuple[str, ...] = tuple(self.token_list.keys())
+
+        load_required_address_list: list[str] = []
+        # List addresses of tokens that need to be newly loaded
+        for issued_token_address in issued_token_address_list:
+            if issued_token_address not in loaded_token_address_list:
+                load_required_address_list.append(issued_token_address)
+
+        if not load_required_address_list:
+            # If there are no additional tokens to load, skip process
+            return
+
+        load_required_token_list: list[Token] = (
+            db_session.query(Token).
+            filter(Token.token_status == 1).
+            filter(Token.token_address.in_(load_required_address_list)).all()
+        )
+        for load_required_token in load_required_token_list:
             token_contract = web3.eth.contract(
-                address=issued_token.token_address,
-                abi=issued_token.abi
+                address=load_required_token.token_address,
+                abi=load_required_token.abi
             )
-            self.token_list.append(token_contract)
+            self.token_list[load_required_token.token_address] = token_contract
 
     def __get_idx_transfer_block_number(self, db_session: Session):
         _idx_transfer_block_number = db_session.query(IDXTransferBlockNumber). \
@@ -120,7 +143,7 @@ class Processor:
         :param block_to: to block number
         :return: None
         """
-        for token in self.token_list:
+        for token in self.token_list.values():
             try:
                 events = ContractUtils.get_event_logs(
                     contract=token,

--- a/batch/indexer_transfer.py
+++ b/batch/indexer_transfer.py
@@ -91,12 +91,7 @@ class Processor:
             ]
         )
         loaded_token_address_list: tuple[str, ...] = tuple(self.token_list.keys())
-
-        load_required_address_list: list[str] = []
-        # List addresses of tokens that need to be newly loaded
-        for issued_token_address in issued_token_address_list:
-            if issued_token_address not in loaded_token_address_list:
-                load_required_address_list.append(issued_token_address)
+        load_required_address_list = list(set(issued_token_address_list) ^ set(loaded_token_address_list))
 
         if not load_required_address_list:
             # If there are no additional tokens to load, skip process

--- a/batch/indexer_transfer_approval.py
+++ b/batch/indexer_transfer_approval.py
@@ -28,6 +28,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import SQLAlchemyError
 from typing import Optional
+from web3.eth import Contract
 
 path = os.path.join(os.path.dirname(__file__), "../")
 sys.path.append(path)
@@ -77,7 +78,8 @@ ibetSecurityTokenEscrow
 class Processor:
     def __init__(self):
         self.latest_block = web3.eth.block_number
-        self.token_list = []
+        self.token_list: dict[str, Contract] = {}
+        self.exchange_list: list[Contract] = []
 
     def sync_new_logs(self):
         db_session = Session(autocommit=False, autoflush=True, bind=db_engine)
@@ -106,19 +108,39 @@ class Processor:
             db_session.close()
 
     def __get_contract_list(self, db_session: Session):
-        self.token_list = []
         self.exchange_list = []
-        _exchange_list_tmp = []
-        issued_token_list = db_session.query(Token). \
-            filter(Token.type.in_([TokenType.IBET_STRAIGHT_BOND.value, TokenType.IBET_SHARE.value])). \
-            filter(Token.token_status == 1). \
+
+        issued_token_address_list: tuple[str, ...] = tuple(
+            [
+                record[0] for record in (
+                    db_session.query(Token.token_address).
+                    filter(Token.token_status == 1).all()
+                )
+            ]
+        )
+        loaded_token_address_list: tuple[str, ...] = tuple(self.token_list.keys())
+
+        load_required_address_list: list[str] = []
+        # List addresses of tokens that need to be newly loaded
+        for issued_token_address in issued_token_address_list:
+            if issued_token_address not in loaded_token_address_list:
+                load_required_address_list.append(issued_token_address)
+
+        load_required_token_list: list[Token] = (
+            db_session.query(Token).
+            filter(Token.token_status == 1).
+            filter(Token.token_address.in_(load_required_address_list)).
             all()
-        for issued_token in issued_token_list:
+        )
+        for load_required_token in load_required_token_list:
             token_contract = web3.eth.contract(
-                address=issued_token.token_address,
-                abi=issued_token.abi
+                address=load_required_token.token_address,
+                abi=load_required_token.abi
             )
-            self.token_list.append(token_contract)
+            self.token_list[load_required_token.token_address] = token_contract
+
+        _exchange_list_tmp = []
+        for token_contract in self.token_list.values():
             tradable_exchange_address = ContractUtils.call_function(
                 contract=token_contract,
                 function_name="tradableExchange",
@@ -171,7 +193,7 @@ class Processor:
         :param block_to: To Block
         :return: None
         """
-        for token in self.token_list:
+        for token in self.token_list.values():
             try:
                 events = ContractUtils.get_event_logs(
                     contract=token,
@@ -217,7 +239,7 @@ class Processor:
         :param block_to: To Block
         :return: None
         """
-        for token in self.token_list:
+        for token in self.token_list.values():
             try:
                 events = ContractUtils.get_event_logs(
                     contract=token,
@@ -255,7 +277,7 @@ class Processor:
         :param block_to: To Block
         :return: None
         """
-        for token in self.token_list:
+        for token in self.token_list.values():
             try:
                 events = ContractUtils.get_event_logs(
                     contract=token,

--- a/batch/indexer_transfer_approval.py
+++ b/batch/indexer_transfer_approval.py
@@ -119,12 +119,7 @@ class Processor:
             ]
         )
         loaded_token_address_list: tuple[str, ...] = tuple(self.token_list.keys())
-
-        load_required_address_list: list[str] = []
-        # List addresses of tokens that need to be newly loaded
-        for issued_token_address in issued_token_address_list:
-            if issued_token_address not in loaded_token_address_list:
-                load_required_address_list.append(issued_token_address)
+        load_required_address_list = list(set(issued_token_address_list) ^ set(loaded_token_address_list))
 
         load_required_token_list: list[Token] = (
             db_session.query(Token).

--- a/tests/test_batch_indexer_position_share.py
+++ b/tests/test_batch_indexer_position_share.py
@@ -2635,6 +2635,71 @@ class TestProcessor:
         # Error occurs in Transfer and Escrow events.
         assert 2 == caplog.record_tuples.count((LOG.name, logging.ERROR, "An exception occurred during event synchronization"))
 
+    # <Normal_8>
+    # Newly tokens added
+    def test_normal_8(self, processor: Processor, db: Session, personal_info_contract, ibet_security_token_escrow_contract):
+        escrow_contract = ibet_security_token_escrow_contract
+        user_1 = config_eth_account("user1")
+        issuer_address = user_1["address"]
+        issuer_private_key = decode_keyfile_json(raw_keyfile_json=user_1["keyfile_json"], password="password".encode("utf-8"))
+
+        # Issuer issues bond token.
+        token_contract1 = deploy_share_token_contract(
+            issuer_address,
+            issuer_private_key,
+            personal_info_contract.address,
+            tradable_exchange_contract_address=escrow_contract.address,
+            transfer_approval_required=False,
+        )
+        token_address_1 = token_contract1.address
+        token_1 = Token()
+        token_1.type = TokenType.IBET_SHARE.value
+        token_1.token_address = token_address_1
+        token_1.issuer_address = issuer_address
+        token_1.abi = token_contract1.abi
+        token_1.tx_hash = "tx_hash"
+        db.add(token_1)
+
+        db.commit()
+
+        # Run target process
+        processor.sync_new_logs()
+
+        # Assertion
+        assert len(processor.token_list.keys()) == 1
+        assert len(processor.exchange_address_list) == 1
+
+        # Prepare additional token
+        token_contract2 = deploy_share_token_contract(
+            issuer_address,
+            issuer_private_key,
+            personal_info_contract.address,
+            tradable_exchange_contract_address=escrow_contract.address,
+            transfer_approval_required=False,
+        )
+        token_address_2 = token_contract2.address
+        token_2 = Token()
+        token_2.type = TokenType.IBET_SHARE.value
+        token_2.token_address = token_address_2
+        token_2.issuer_address = issuer_address
+        token_2.abi = token_contract2.abi
+        token_2.tx_hash = "tx_hash"
+        db.add(token_2)
+
+        db.commit()
+
+        # Run target process
+        processor.sync_new_logs()
+
+        # Assertion
+        # newly issued token is loaded properly
+        assert len(processor.token_list.keys()) == 2
+        assert len(processor.exchange_address_list) == 1
+
+    ###########################################################################
+    # Error Case
+    ###########################################################################
+
     # <Error_1>
     # If exception occures out of Processor except-catch, batch outputs logs in mainloop.
     def test_error_1(self, main_func, db :Session, personal_info_contract, caplog: pytest.LogCaptureFixture):

--- a/tests/test_batch_indexer_transfer.py
+++ b/tests/test_batch_indexer_transfer.py
@@ -659,6 +659,69 @@ class TestProcessor:
         processor.sync_new_logs()
         assert 1 == caplog.record_tuples.count((LOG.name, logging.DEBUG, "skip process"))
 
+    # <Normal_7>
+    # Newly tokens added
+    def test_normal_7(self, processor: Processor, db: Session, personal_info_contract, ibet_security_token_escrow_contract):
+        escrow_contract = ibet_security_token_escrow_contract
+        user_1 = config_eth_account("user1")
+        issuer_address = user_1["address"]
+        issuer_private_key = decode_keyfile_json(raw_keyfile_json=user_1["keyfile_json"], password="password".encode("utf-8"))
+
+        # Issuer issues bond token.
+        token_contract1 = deploy_bond_token_contract(
+            issuer_address,
+            issuer_private_key,
+            personal_info_contract.address,
+            tradable_exchange_contract_address=escrow_contract.address,
+            transfer_approval_required=False,
+        )
+        token_address_1 = token_contract1.address
+        token_1 = Token()
+        token_1.type = TokenType.IBET_STRAIGHT_BOND.value
+        token_1.token_address = token_address_1
+        token_1.issuer_address = issuer_address
+        token_1.abi = token_contract1.abi
+        token_1.tx_hash = "tx_hash"
+        db.add(token_1)
+
+        db.commit()
+
+        # Run target process
+        processor.sync_new_logs()
+
+        # Assertion
+        assert len(processor.token_list.keys()) == 1
+
+        # Prepare additional token
+        token_contract2 = deploy_share_token_contract(
+            issuer_address,
+            issuer_private_key,
+            personal_info_contract.address,
+            tradable_exchange_contract_address=escrow_contract.address,
+            transfer_approval_required=False,
+        )
+        token_address_2 = token_contract2.address
+        token_2 = Token()
+        token_2.type = TokenType.IBET_SHARE.value
+        token_2.token_address = token_address_2
+        token_2.issuer_address = issuer_address
+        token_2.abi = token_contract2.abi
+        token_2.tx_hash = "tx_hash"
+        db.add(token_2)
+
+        db.commit()
+
+        # Run target process
+        processor.sync_new_logs()
+
+        # Assertion
+        # newly issued token is loaded properly
+        assert len(processor.token_list.keys()) == 2
+
+    ###########################################################################
+    # Error Case
+    ###########################################################################
+
     # <Error_1>
     # If each error occurs, batch will output logs and continue next sync.
     def test_error_1(self, main_func, db:Session, personal_info_contract, caplog: pytest.LogCaptureFixture):

--- a/tests/test_batch_indexer_transfer_approval.py
+++ b/tests/test_batch_indexer_transfer_approval.py
@@ -1347,6 +1347,67 @@ class TestProcessor:
         # Error occurs in events with exception of Escrow.
         assert caplog.record_tuples.count((LOG.name, logging.ERROR, "An exception occurred during event synchronization")) == 3
 
+    # <Normal_5>
+    # Newly tokens added
+    def test_normal_5(self, processor: Processor, db: Session, personal_info_contract, ibet_security_token_escrow_contract):
+        escrow_contract = ibet_security_token_escrow_contract
+        user_1 = config_eth_account("user1")
+        issuer_address = user_1["address"]
+        issuer_private_key = decode_keyfile_json(raw_keyfile_json=user_1["keyfile_json"], password="password".encode("utf-8"))
+
+        # Issuer issues bond token.
+        token_contract1 = deploy_bond_token_contract(
+            issuer_address,
+            issuer_private_key,
+            personal_info_contract.address,
+            tradable_exchange_contract_address=escrow_contract.address,
+            transfer_approval_required=False,
+        )
+        token_address_1 = token_contract1.address
+        token_1 = Token()
+        token_1.type = TokenType.IBET_STRAIGHT_BOND.value
+        token_1.token_address = token_address_1
+        token_1.issuer_address = issuer_address
+        token_1.abi = token_contract1.abi
+        token_1.tx_hash = "tx_hash"
+        db.add(token_1)
+
+        db.commit()
+
+        # Run target process
+        processor.sync_new_logs()
+
+        # Assertion
+        assert len(processor.token_list.keys()) == 1
+        assert len(processor.exchange_list) == 1
+
+        # Prepare additional token
+        token_contract2 = deploy_share_token_contract(
+            issuer_address,
+            issuer_private_key,
+            personal_info_contract.address,
+            tradable_exchange_contract_address=escrow_contract.address,
+            transfer_approval_required=False,
+        )
+        token_address_2 = token_contract2.address
+        token_2 = Token()
+        token_2.type = TokenType.IBET_SHARE.value
+        token_2.token_address = token_address_2
+        token_2.issuer_address = issuer_address
+        token_2.abi = token_contract2.abi
+        token_2.tx_hash = "tx_hash"
+        db.add(token_2)
+
+        db.commit()
+
+        # Run target process
+        processor.sync_new_logs()
+
+        # Assertion
+        # newly issued token is loaded properly
+        assert len(processor.token_list.keys()) == 2
+        assert len(processor.exchange_list) == 1
+
     ###########################################################################
     # Error Case
     ###########################################################################


### PR DESCRIPTION
Close #388

- Changed indexer batch logics to keep ABI data in memory and not to fetch ABI data from DB each time.
- Added Unit tests.

> ABIデータをメモリ内に保持し毎回ABIデータをDBから取得しないようにindexerバッチのロジックを変更しました。
> ユニットテストを追加しました。