### PR TITLE
feat: Suppress unique constraint errors

### DIFF
--- a/app/model/blockchain/token.py
+++ b/app/model/blockchain/token.py
@@ -136,7 +136,7 @@ class IbetStandardTokenInterface:
         token_cache.attributes = self.__dict__
         token_cache.cached_datetime = datetime.utcnow()
         token_cache.expiration_datetime = datetime.utcnow() + timedelta(seconds=TOKEN_CACHE_TTL)
-        db_session.add(token_cache)
+        db_session.merge(token_cache)
 
     @staticmethod
     def delete_cache(db_session: Session, contract_address: str):
@@ -373,7 +373,7 @@ class IbetStraightBondContract(IbetSecurityTokenInterface):
                 token_cache.attributes = bond_token.__dict__
                 token_cache.cached_datetime = datetime.utcnow()
                 token_cache.expiration_datetime = datetime.utcnow() + timedelta(seconds=TOKEN_CACHE_TTL)
-                db_session.add(token_cache)
+                db_session.merge(token_cache)
                 db_session.commit()
             except SAIntegrityError:
                 db_session.rollback()
@@ -939,7 +939,7 @@ class IbetShareContract(IbetSecurityTokenInterface):
                 token_cache.attributes = share_token.__dict__
                 token_cache.cached_datetime = datetime.utcnow()
                 token_cache.expiration_datetime = datetime.utcnow() + timedelta(seconds=TOKEN_CACHE_TTL)
-                db_session.add(token_cache)
+                db_session.merge(token_cache)
                 db_session.commit()
             except SAIntegrityError:
                 db_session.rollback()


### PR DESCRIPTION
Related to: #401
Close : #426 

The following errors were frequently occurring in the DB when creating a cache of token attributes, and have been corrected to suppress them.

```
2022-11-21 09:20:43.727 UTC [752019] ERROR:  duplicate key value violates unique constraint "token_cache_pkey"
2022-11-21 09:20:43.727 UTC [752019] DETAIL:  Key (token_address)=(0x2ff71d6769773B8E7cB368444FdD0678f2214E5c) already exists.
```