### PR TITLE
feat: unlimited request line size

### DIFF
--- a/bin/run_server.sh
+++ b/bin/run_server.sh
@@ -48,6 +48,7 @@ function start () {
            --timeout ${WORKER_TIMEOUT} \
            --max-requests ${WORKER_MAX_REQUESTS} \
            --max-requests-jitter ${WORKER_MAX_REQUESTS_JITTER} \
+           --limit-request-line 0 \
            app.main:app
 }
 


### PR DESCRIPTION
Close: #430 

Changed the limit_request_line setting for gunicorn to unlimited.