### PR TITLE
fix: Omit response validation in all API endpoints

### DIFF
--- a/app/routers/ledger.py
+++ b/app/routers/ledger.py
@@ -727,4 +727,4 @@ def __get_personal_info(token_address: str, token_type: str, account_address: st
                 account_address=account_address,
                 default_value=None
             )
-        return json_response(personal_info)
+        return personal_info


### PR DESCRIPTION
fix: #452 

### Changes

- Removed unnecessary `json_response()` func in ledger API.
  - Checked that the unit test with `RESPONSE_VALIDATION_MODE=0` is passed.