### PR TITLE
feat: Make contract class object-oriented

### DIFF
--- a/app/model/blockchain/e2e_messaging.py
+++ b/app/model/blockchain/e2e_messaging.py
@@ -42,20 +42,21 @@ from app.exceptions import SendTransactionError, ContractRevertError
 class E2EMessaging:
     """E2EMessaging model"""
 
-    @staticmethod
-    def send_message(contract_address: str,
-                     to_address: str,
-                     message: str,
-                     tx_from: str,
-                     private_key: str):
+    def __init__(self, contract_address: str):
+        self.contract_address = contract_address
+
+    def send_message(self,
+                     to_address: str, message: str,
+                     tx_from: str, private_key: str):
         """Send Message"""
         contract = ContractUtils.get_contract(
             contract_name="E2EMessaging",
-            contract_address=contract_address
+            contract_address=self.contract_address
         )
         try:
             tx = contract.functions.sendMessage(
-                to_address, message
+                to_address,
+                message
             ).build_transaction({
                 "chainId": CHAIN_ID,
                 "from": tx_from,
@@ -71,14 +72,9 @@ class E2EMessaging:
         except Exception as err:
             raise SendTransactionError(err)
 
-    @staticmethod
-    def send_message_external(contract_address: str,
-                              to_address: str,
-                              _type: str,
-                              message_org: str,
-                              to_rsa_public_key: str,
-                              tx_from: str,
-                              private_key: str):
+    def send_message_external(self,
+                              to_address: str, _type: str, message_org: str, to_rsa_public_key: str,
+                              tx_from: str, private_key: str):
         """Send Message(Format message for external system)"""
 
         # Encrypt message with AES-256-CBC
@@ -111,8 +107,7 @@ class E2EMessaging:
         message = json.dumps(message_dict)
 
         # Send message
-        tx_hash, tx_receipt = E2EMessaging.send_message(
-            contract_address=contract_address,
+        tx_hash, tx_receipt = E2EMessaging(self.contract_address).send_message(
             to_address=to_address,
             message=message,
             tx_from=tx_from,
@@ -120,20 +115,18 @@ class E2EMessaging:
         )
         return tx_hash, tx_receipt
 
-    @staticmethod
-    def set_public_key(contract_address: str,
-                       public_key: str,
-                       key_type: str,
-                       tx_from: str,
-                       private_key: str):
+    def set_public_key(self,
+                       public_key: str, key_type: str,
+                       tx_from: str, private_key: str):
         """Set Public Key"""
         contract = ContractUtils.get_contract(
             contract_name="E2EMessaging",
-            contract_address=contract_address
+            contract_address=self.contract_address
         )
         try:
             tx = contract.functions.setPublicKey(
-                public_key, key_type
+                public_key,
+                key_type
             ).build_transaction({
                 "chainId": CHAIN_ID,
                 "from": tx_from,

--- a/app/model/blockchain/token_list.py
+++ b/app/model/blockchain/token_list.py
@@ -31,37 +31,38 @@ web3 = Web3Wrapper()
 
 class TokenListContract:
 
-    @staticmethod
-    def register(
-            token_list_address: str,
-            token_address: str,
-            token_template: str,
-            account_address: str,
-            private_key: str
-    ) -> None:
+    def __init__(self, contract_address: str):
+        self.contract_address = contract_address
+
+    def register(self,
+                 token_address: str, token_template: str,
+                 tx_from: str, private_key: str) -> None:
         """Register TokenList
 
-        :param token_list_address: token list contract address
-        :param token_address: token_address
-        :param token_template: TokenType
-        :param account_address: token owner account address
+        :param token_address: token address
+        :param token_template: token type
+        :param tx_from: transaction from
         :param private_key: private_key
         :return: None
         """
         try:
             contract = ContractUtils.get_contract(
                 contract_name="TokenList",
-                contract_address=token_list_address,
+                contract_address=self.contract_address,
             )
-            tx = contract.functions.register(token_address, token_template). \
-                build_transaction({
-                    "chainId": CHAIN_ID,
-                    "from": account_address,
-                    "gas": TX_GAS_LIMIT,
-                    "gasPrice": 0
-                })
-            ContractUtils.send_transaction(transaction=tx, private_key=private_key)
-
+            tx = contract.functions.register(
+                token_address,
+                token_template
+            ).build_transaction({
+                "chainId": CHAIN_ID,
+                "from": tx_from,
+                "gas": TX_GAS_LIMIT,
+                "gasPrice": 0
+            })
+            ContractUtils.send_transaction(
+                transaction=tx,
+                private_key=private_key
+            )
         except ContractRevertError:
             raise
         except TimeExhausted as timeout_error:

--- a/app/routers/bond.py
+++ b/app/routers/bond.py
@@ -207,7 +207,7 @@ def issue_token(
         token.purpose
     ]
     try:
-        contract_address, abi, tx_hash = IbetStraightBondContract.create(
+        contract_address, abi, tx_hash = IbetStraightBondContract().create(
             args=arguments,
             tx_from=issuer_address,
             private_key=private_key
@@ -333,10 +333,11 @@ def list_all_tokens(
     bond_tokens = []
     for token in tokens:
         # Get contract data
-        bond_token = IbetStraightBondContract.get(contract_address=token.token_address).__dict__
+        bond_token = IbetStraightBondContract(token.token_address).get().__dict__
         issue_datetime_utc = timezone("UTC").localize(token.created)
         bond_token["issue_datetime"] = issue_datetime_utc.astimezone(local_tz).isoformat()
         bond_token["token_status"] = token.token_status
+        bond_token.pop("contract_name")
         bond_tokens.append(bond_token)
 
     return json_response(bond_tokens)
@@ -364,10 +365,11 @@ def retrieve_token(
         raise InvalidParameterError("this token is temporarily unavailable")
 
     # Get contract data
-    bond_token = IbetStraightBondContract.get(contract_address=token_address).__dict__
+    bond_token = IbetStraightBondContract(token_address).get().__dict__
     issue_datetime_utc = timezone("UTC").localize(_token.created)
     bond_token["issue_datetime"] = issue_datetime_utc.astimezone(local_tz).isoformat()
     bond_token["token_status"] = _token.token_status
+    bond_token.pop("contract_name")
 
     return json_response(bond_token)
 
@@ -424,8 +426,7 @@ def update_token(
 
     # Send transaction
     try:
-        IbetStraightBondContract.update(
-            contract_address=token_address,
+        IbetStraightBondContract(token_address).update(
             data=UpdateParams(**token.dict()),
             tx_from=issuer_address,
             private_key=private_key
@@ -562,8 +563,7 @@ def additional_issue(
 
     # Send transaction
     try:
-        IbetStraightBondContract.additional_issue(
-            contract_address=token_address,
+        IbetStraightBondContract(token_address).additional_issue(
             data=AdditionalIssueParams(**data.dict()),
             tx_from=issuer_address,
             private_key=private_key
@@ -889,8 +889,7 @@ def redeem_token(
 
     # Send transaction
     try:
-        IbetStraightBondContract.redeem(
-            contract_address=token_address,
+        IbetStraightBondContract(token_address).redeem(
             data=RedeemParams(**data.dict()),
             tx_from=issuer_address,
             private_key=private_key
@@ -1590,7 +1589,7 @@ def modify_holder_personal_info(
         raise InvalidParameterError("this token is temporarily unavailable")
 
     # Modify Personal Info
-    token_contract = IbetStraightBondContract.get(token_address)
+    token_contract = IbetStraightBondContract(token_address).get()
     try:
         personal_info_contract = PersonalInfoContract(
             db=db,
@@ -1652,7 +1651,7 @@ def register_holder_personal_info(
         raise InvalidParameterError("this token is temporarily unavailable")
 
     # Register Personal Info
-    token_contract = IbetStraightBondContract.get(token_address)
+    token_contract = IbetStraightBondContract(token_address).get()
     try:
         personal_info_contract = PersonalInfoContract(
             db=db,
@@ -1915,8 +1914,7 @@ def transfer_ownership(
         raise InvalidParameterError("this token is temporarily unavailable")
 
     try:
-        IbetStraightBondContract.transfer(
-            contract_address=token.token_address,
+        IbetStraightBondContract(token.token_address).transfer(
             data=TransferParams(**token.dict()),
             tx_from=issuer_address,
             private_key=private_key
@@ -2383,8 +2381,7 @@ def update_transfer_approval(
                     "data": now
                 }
                 try:
-                    _, tx_receipt = IbetStraightBondContract.approve_transfer(
-                        contract_address=token_address,
+                    _, tx_receipt = IbetStraightBondContract(token_address).approve_transfer(
                         data=ApproveTransferParams(**_data),
                         tx_from=issuer_address,
                         private_key=private_key,
@@ -2394,8 +2391,7 @@ def update_transfer_approval(
                     # cancelTransfer should be performed immediately.
                     # After cancelTransfer, ContractRevertError is returned.
                     try:
-                        IbetStraightBondContract.cancel_transfer(
-                            contract_address=token_address,
+                        IbetStraightBondContract(token_address).cancel_transfer(
                             data=CancelTransferParams(**_data),
                             tx_from=issuer_address,
                             private_key=private_key,
@@ -2429,8 +2425,7 @@ def update_transfer_approval(
                 "data": now
             }
             try:
-                _, tx_receipt = IbetStraightBondContract.cancel_transfer(
-                    contract_address=token_address,
+                _, tx_receipt = IbetStraightBondContract(token_address).cancel_transfer(
                     data=CancelTransferParams(**_data),
                     tx_from=issuer_address,
                     private_key=private_key,

--- a/app/routers/bond.py
+++ b/app/routers/bond.py
@@ -252,11 +252,10 @@ def issue_token(
     else:
         # Register token_address token list
         try:
-            TokenListContract.register(
-                token_list_address=config.TOKEN_LIST_CONTRACT_ADDRESS,
+            TokenListContract(config.TOKEN_LIST_CONTRACT_ADDRESS).register(
                 token_address=contract_address,
                 token_template=TokenType.IBET_STRAIGHT_BOND.value,
-                account_address=issuer_address,
+                tx_from=issuer_address,
                 private_key=private_key
             )
         except SendTransactionError:

--- a/app/routers/e2e_messaging.py
+++ b/app/routers/e2e_messaging.py
@@ -143,8 +143,7 @@ def create_account(
 
     # Send transaction
     try:
-        tx_hash, _ = E2EMessaging.set_public_key(
-            contract_address=E2E_MESSAGING_CONTRACT_ADDRESS,
+        tx_hash, _ = E2EMessaging(E2E_MESSAGING_CONTRACT_ADDRESS).set_public_key(
             public_key=rsa_public_key,
             key_type="RSA4096",
             tx_from=addr,

--- a/app/routers/ledger.py
+++ b/app/routers/ledger.py
@@ -715,9 +715,9 @@ def __get_personal_info(token_address: str, token_type: str, account_address: st
             # Get personal info from contract
             token_contract = None
             if token_type == TokenType.IBET_SHARE.value:
-                token_contract = IbetShareContract.get(token_address)
+                token_contract = IbetShareContract(token_address).get()
             elif token_type == TokenType.IBET_STRAIGHT_BOND.value:
-                token_contract = IbetStraightBondContract.get(token_address)
+                token_contract = IbetStraightBondContract(token_address).get()
             personal_info_contract = PersonalInfoContract(
                 db=db,
                 issuer_address=issuer_address,

--- a/app/routers/position.py
+++ b/app/routers/position.py
@@ -155,10 +155,10 @@ def list_all_position(
         # Get Token Name
         token_name = None
         if _token.type == TokenType.IBET_STRAIGHT_BOND.value:
-            _bond = IbetStraightBondContract.get(contract_address=_token.token_address)
+            _bond = IbetStraightBondContract(_token.token_address).get()
             token_name = _bond.name
         elif _token.type == TokenType.IBET_SHARE.value:
-            _share = IbetShareContract.get(contract_address=_token.token_address)
+            _share = IbetShareContract(_token.token_address).get()
             token_name = _share.name
         positions.append({
             "issuer_address": _token.issuer_address,
@@ -237,10 +237,10 @@ def list_all_locked_position(
         # Get Token Name
         token_name = None
         if _token.type == TokenType.IBET_STRAIGHT_BOND.value:
-            _bond = IbetStraightBondContract.get(contract_address=_token.token_address)
+            _bond = IbetStraightBondContract(_token.token_address).get()
             token_name = _bond.name
         elif _token.type == TokenType.IBET_SHARE.value:
-            _share = IbetShareContract.get(contract_address=_token.token_address)
+            _share = IbetShareContract(_token.token_address).get()
             token_name = _share.name
         positions.append({
             "issuer_address": _token.issuer_address,
@@ -371,10 +371,10 @@ def list_all_lock_events(
         token_name = None
         _token = lock_event[9]
         if _token.type == TokenType.IBET_STRAIGHT_BOND.value:
-            _bond = IbetStraightBondContract.get(contract_address=_token.token_address)
+            _bond = IbetStraightBondContract(_token.token_address).get()
             token_name = _bond.name
         elif _token.type == TokenType.IBET_SHARE.value:
-            _share = IbetShareContract.get(contract_address=_token.token_address)
+            _share = IbetShareContract(_token.token_address).get()
             token_name = _share.name
 
         block_timestamp_utc = timezone("UTC").localize(lock_event[8])
@@ -465,8 +465,7 @@ def force_unlock(
         "data": ""
     }
     try:
-        IbetSecurityTokenInterface.force_unlock(
-            contract_address=data.token_address,
+        IbetSecurityTokenInterface(data.token_address).force_unlock(
             data=ForceUnlockParams(**unlock_data),
             tx_from=issuer_address,
             private_key=private_key
@@ -540,10 +539,10 @@ def retrieve_position(
     # Get Token Name
     token_name = None
     if _token.type == TokenType.IBET_STRAIGHT_BOND.value:
-        _bond = IbetStraightBondContract.get(contract_address=_token.token_address)
+        _bond = IbetStraightBondContract(_token.token_address).get()
         token_name = _bond.name
     elif _token.type == TokenType.IBET_SHARE.value:
-        _share = IbetShareContract.get(contract_address=_token.token_address)
+        _share = IbetShareContract(_token.token_address).get()
         token_name = _share.name
 
     resp = {

--- a/app/routers/share.py
+++ b/app/routers/share.py
@@ -207,7 +207,7 @@ def issue_token(
         token.principal_value
     ]
     try:
-        contract_address, abi, tx_hash = IbetShareContract.create(
+        contract_address, abi, tx_hash = IbetShareContract().create(
             args=arguments,
             tx_from=issuer_address,
             private_key=private_key
@@ -320,10 +320,11 @@ def list_all_tokens(
     share_tokens = []
     for token in tokens:
         # Get contract data
-        share_token = IbetShareContract.get(contract_address=token.token_address).__dict__
+        share_token = IbetShareContract(token.token_address).get().__dict__
         issue_datetime_utc = timezone("UTC").localize(token.created)
         share_token["issue_datetime"] = issue_datetime_utc.astimezone(local_tz).isoformat()
         share_token["token_status"] = token.token_status
+        share_token.pop("contract_name")
         share_tokens.append(share_token)
 
     return json_response(share_tokens)
@@ -351,10 +352,11 @@ def retrieve_token(
         raise InvalidParameterError("this token is temporarily unavailable")
 
     # Get contract data
-    share_token = IbetShareContract.get(contract_address=token_address).__dict__
+    share_token = IbetShareContract(token_address).get().__dict__
     issue_datetime_utc = timezone("UTC").localize(_token.created)
     share_token["issue_datetime"] = issue_datetime_utc.astimezone(local_tz).isoformat()
     share_token["token_status"] = _token.token_status
+    share_token.pop("contract_name")
 
     return json_response(share_token)
 
@@ -411,8 +413,7 @@ def update_token(
 
     # Send transaction
     try:
-        IbetShareContract.update(
-            contract_address=token_address,
+        IbetShareContract(token_address).update(
             data=UpdateParams(**token.dict()),
             tx_from=issuer_address,
             private_key=private_key
@@ -550,8 +551,7 @@ def additional_issue(
 
     # Send transaction
     try:
-        IbetShareContract.additional_issue(
-            contract_address=token_address,
+        IbetShareContract(token_address).additional_issue(
             data=AdditionalIssueParams(**data.dict()),
             tx_from=issuer_address,
             private_key=private_key
@@ -877,8 +877,7 @@ def redeem_token(
 
     # Send transaction
     try:
-        IbetShareContract.redeem(
-            contract_address=token_address,
+        IbetShareContract(token_address).redeem(
             data=RedeemParams(**data.dict()),
             tx_from=issuer_address,
             private_key=private_key
@@ -1577,7 +1576,7 @@ def modify_holder_personal_info(
         raise InvalidParameterError("this token is temporarily unavailable")
 
     # Modify Personal Info
-    token_contract = IbetShareContract.get(token_address)
+    token_contract = IbetShareContract(token_address).get()
     try:
         personal_info_contract = PersonalInfoContract(
             db=db,
@@ -1713,7 +1712,7 @@ def register_holder_personal_info(
         raise InvalidParameterError("this token is temporarily unavailable")
 
     # Register Personal Info
-    token_contract = IbetShareContract.get(token_address)
+    token_contract = IbetShareContract(token_address).get()
     try:
         personal_info_contract = PersonalInfoContract(
             db=db,
@@ -1902,8 +1901,7 @@ def transfer_ownership(
         raise InvalidParameterError("this token is temporarily unavailable")
 
     try:
-        IbetShareContract.transfer(
-            contract_address=token.token_address,
+        IbetShareContract(token.token_address).transfer(
             data=TransferParams(**token.dict()),
             tx_from=issuer_address,
             private_key=private_key
@@ -2370,8 +2368,7 @@ def update_transfer_approval(
                     "data": now
                 }
                 try:
-                    _, tx_receipt = IbetShareContract.approve_transfer(
-                        contract_address=token_address,
+                    _, tx_receipt = IbetShareContract(token_address).approve_transfer(
                         data=ApproveTransferParams(**_data),
                         tx_from=issuer_address,
                         private_key=private_key,
@@ -2381,8 +2378,7 @@ def update_transfer_approval(
                     # cancelTransfer should be performed immediately.
                     # After cancelTransfer, ContractRevertError is returned.
                     try:
-                        IbetShareContract.cancel_transfer(
-                            contract_address=token_address,
+                        IbetShareContract(token_address).cancel_transfer(
                             data=CancelTransferParams(**_data),
                             tx_from=issuer_address,
                             private_key=private_key,
@@ -2416,8 +2412,7 @@ def update_transfer_approval(
                 "data": now
             }
             try:
-                _, tx_receipt = IbetShareContract.cancel_transfer(
-                    contract_address=token_address,
+                _, tx_receipt = IbetShareContract(token_address).cancel_transfer(
                     data=CancelTransferParams(**_data),
                     tx_from=issuer_address,
                     private_key=private_key,

--- a/app/routers/share.py
+++ b/app/routers/share.py
@@ -242,11 +242,10 @@ def issue_token(
     else:
         # Register token_address token list
         try:
-            TokenListContract.register(
-                token_list_address=config.TOKEN_LIST_CONTRACT_ADDRESS,
+            TokenListContract(config.TOKEN_LIST_CONTRACT_ADDRESS).register(
                 token_address=contract_address,
                 token_template=TokenType.IBET_SHARE.value,
-                account_address=issuer_address,
+                tx_from=issuer_address,
                 private_key=private_key
             )
         except SendTransactionError:

--- a/app/utils/ledger_utils.py
+++ b/app/utils/ledger_utils.py
@@ -147,10 +147,10 @@ def __get_details_data_list(token_address: str, token_type: str, data_type: str,
 
 def __get_details_data_list_from_ibetfin(token_address: str, token_type: str, db: Session):
     if token_type == TokenType.IBET_SHARE.value:
-        token_contract = IbetShareContract.get(token_address)
+        token_contract = IbetShareContract(token_address).get()
         price = token_contract.principal_value
     elif token_type == TokenType.IBET_STRAIGHT_BOND.value:
-        token_contract = IbetStraightBondContract.get(token_address)
+        token_contract = IbetStraightBondContract(token_address).get()
         price = token_contract.face_value
 
     issuer_address = token_contract.issuer_address

--- a/batch/processor_batch_issue_redeem.py
+++ b/batch/processor_batch_issue_redeem.py
@@ -133,8 +133,7 @@ class Processor:
                     try:
                         if upload.token_type == TokenType.IBET_STRAIGHT_BOND.value:
                             if upload.category == BatchIssueRedeemProcessingCategory.ISSUE.value:
-                                tx_hash = IbetStraightBondContract.additional_issue(
-                                    contract_address=upload.token_address,
+                                tx_hash = IbetStraightBondContract(upload.token_address).additional_issue(
                                     data=IbetStraightBondAdditionalIssueParams(
                                         account_address=batch_data.account_address,
                                         amount=batch_data.amount
@@ -143,8 +142,7 @@ class Processor:
                                     private_key=issuer_pk
                                 )
                             elif upload.category == BatchIssueRedeemProcessingCategory.REDEEM.value:
-                                tx_hash = IbetStraightBondContract.redeem(
-                                    contract_address=upload.token_address,
+                                tx_hash = IbetStraightBondContract(upload.token_address).redeem(
                                     data=IbetStraightBondRedeemParams(
                                         account_address=batch_data.account_address,
                                         amount=batch_data.amount
@@ -154,8 +152,7 @@ class Processor:
                                 )
                         elif upload.token_type == TokenType.IBET_SHARE.value:
                             if upload.category == BatchIssueRedeemProcessingCategory.ISSUE.value:
-                                tx_hash = IbetShareContract.additional_issue(
-                                    contract_address=upload.token_address,
+                                tx_hash = IbetShareContract(upload.token_address).additional_issue(
                                     data=IbetShareAdditionalIssueParams(
                                         account_address=batch_data.account_address,
                                         amount=batch_data.amount
@@ -164,8 +161,7 @@ class Processor:
                                     private_key=issuer_pk
                                 )
                             elif upload.category == BatchIssueRedeemProcessingCategory.REDEEM.value:
-                                tx_hash = IbetShareContract.redeem(
-                                    contract_address=upload.token_address,
+                                tx_hash = IbetShareContract(upload.token_address).redeem(
                                     data=IbetShareRedeemParams(
                                         account_address=batch_data.account_address,
                                         amount=batch_data.amount

--- a/batch/processor_batch_register_personal_info.py
+++ b/batch/processor_batch_register_personal_info.py
@@ -213,9 +213,9 @@ class Processor:
             all()
         for token in token_list:
             if token.type == TokenType.IBET_SHARE.value:
-                token_contract = IbetShareContract.get(token.token_address)
+                token_contract = IbetShareContract(token.token_address).get()
             elif token.type == TokenType.IBET_STRAIGHT_BOND.value:
-                token_contract = IbetStraightBondContract.get(token.token_address)
+                token_contract = IbetStraightBondContract(token.token_address).get()
             else:
                 continue
 

--- a/batch/processor_bulk_transfer.py
+++ b/batch/processor_bulk_transfer.py
@@ -157,16 +157,14 @@ class Processor:
                     try:
                         if _transfer.token_type == TokenType.IBET_SHARE.value:
                             _transfer_data = IbetShareTransferParams(**token)
-                            IbetShareContract.transfer(
-                                contract_address=_transfer.token_address,
+                            IbetShareContract(_transfer.token_address).transfer(
                                 data=_transfer_data,
                                 tx_from=_transfer.issuer_address,
                                 private_key=private_key
                             )
                         elif _transfer.token_type == TokenType.IBET_STRAIGHT_BOND.value:
                             _transfer_data = IbetStraightBondTransferParams(**token)
-                            IbetStraightBondContract.transfer(
-                                contract_address=_transfer.token_address,
+                            IbetStraightBondContract(_transfer.token_address).transfer(
                                 data=_transfer_data,
                                 tx_from=_transfer.issuer_address,
                                 private_key=private_key

--- a/batch/processor_modify_personal_info.py
+++ b/batch/processor_modify_personal_info.py
@@ -142,9 +142,9 @@ class Processor:
         personal_info_contract_list = set()
         for token in token_list:
             if token.type == TokenType.IBET_SHARE.value:
-                token_contract = IbetShareContract.get(token.token_address)
+                token_contract = IbetShareContract(token.token_address).get()
             elif token.type == TokenType.IBET_STRAIGHT_BOND.value:
-                token_contract = IbetStraightBondContract.get(token.token_address)
+                token_contract = IbetStraightBondContract(token.token_address).get()
             else:
                 continue
 

--- a/batch/processor_rotate_e2e_messaging_rsa_key.py
+++ b/batch/processor_rotate_e2e_messaging_rsa_key.py
@@ -134,8 +134,7 @@ class Processor:
                               f"account_address={e2e_messaging_account.account_address}")
                 return
             try:
-                tx_hash, _ = E2EMessaging.set_public_key(
-                    contract_address=E2E_MESSAGING_CONTRACT_ADDRESS,
+                tx_hash, _ = E2EMessaging(E2E_MESSAGING_CONTRACT_ADDRESS).set_public_key(
                     public_key=rsa_public_key,
                     key_type="RSA4096",
                     tx_from=e2e_messaging_account.account_address,

--- a/batch/processor_scheduled_events.py
+++ b/batch/processor_scheduled_events.py
@@ -191,8 +191,7 @@ class Processor:
                     # Update
                     if _event.event_type == ScheduledEventType.UPDATE.value:
                         _update_data = IbetShareUpdateParams(**_event.data)
-                        IbetShareContract.update(
-                            contract_address=_event.token_address,
+                        IbetShareContract(_event.token_address).update(
                             data=_update_data,
                             tx_from=_event.issuer_address,
                             private_key=private_key
@@ -201,8 +200,7 @@ class Processor:
                     # Update
                     if _event.event_type == ScheduledEventType.UPDATE.value:
                         _update_data = IbetStraightBondUpdateParams(**_event.data)
-                        IbetStraightBondContract.update(
-                            contract_address=_event.token_address,
+                        IbetStraightBondContract(_event.token_address).update(
                             data=_update_data,
                             tx_from=_event.issuer_address,
                             private_key=private_key

--- a/batch/processor_update_token.py
+++ b/batch/processor_update_token.py
@@ -170,11 +170,10 @@ class Processor:
                     if _update_token.trigger == "Issue":
 
                         # Register token_address token list
-                        TokenListContract.register(
-                            token_list_address=TOKEN_LIST_CONTRACT_ADDRESS,
+                        TokenListContract(TOKEN_LIST_CONTRACT_ADDRESS).register(
                             token_address=_update_token.token_address,
                             token_template=token_template,
-                            account_address=_update_token.issuer_address,
+                            tx_from=_update_token.issuer_address,
                             private_key=private_key
                         )
 

--- a/batch/processor_update_token.py
+++ b/batch/processor_update_token.py
@@ -147,8 +147,7 @@ class Processor:
                             token_type=TokenType.IBET_SHARE.value,
                             arguments=_update_token.arguments
                         )
-                        IbetShareContract.update(
-                            contract_address=_update_token.token_address,
+                        IbetShareContract(_update_token.token_address).update(
                             data=_update_data,
                             tx_from=_update_token.issuer_address,
                             private_key=private_key
@@ -161,8 +160,7 @@ class Processor:
                             token_type=TokenType.IBET_STRAIGHT_BOND.value,
                             arguments=_update_token.arguments
                         )
-                        IbetStraightBondContract.update(
-                            contract_address=_update_token.token_address,
+                        IbetStraightBondContract(_update_token.token_address).update(
                             data=_update_data,
                             tx_from=_update_token.issuer_address,
                             private_key=private_key

--- a/tests/model/blockchain/test_E2EMessaging.py
+++ b/tests/model/blockchain/test_E2EMessaging.py
@@ -64,8 +64,7 @@ class TestSendMessage:
         message = "test message"
 
         # Run Test
-        tx_hash, tx_receipt = E2EMessaging.send_message(
-            contract_address=e2e_messaging_contract.address,
+        tx_hash, tx_receipt = E2EMessaging(e2e_messaging_contract.address).send_message(
             to_address=user_address_2,
             message=message,
             tx_from=user_address_1,
@@ -102,8 +101,7 @@ class TestSendMessage:
             with mock.patch("app.utils.contract_utils.ContractUtils.send_transaction",
                             MagicMock(side_effect=Exception("tx error"))):
                 # Run Test
-                E2EMessaging.send_message(
-                    contract_address=e2e_messaging_contract.address,
+                E2EMessaging(e2e_messaging_contract.address).send_message(
                     to_address=user_address_2,
                     message=message,
                     tx_from=user_address_1,
@@ -132,8 +130,7 @@ class TestSendMessage:
             with mock.patch("app.utils.contract_utils.ContractUtils.send_transaction",
                             MagicMock(side_effect=TimeExhausted("Timeout Error test"))):
                 # Run Test
-                E2EMessaging.send_message(
-                    contract_address=e2e_messaging_contract.address,
+                E2EMessaging(e2e_messaging_contract.address).send_message(
                     to_address=user_address_2,
                     message=message,
                     tx_from=user_address_1,
@@ -235,8 +232,7 @@ EK7Y4zFFnfKP3WIA3atUbbcCAwEAAQ==
         _type = "test_type"
 
         # Run Test
-        tx_hash, tx_receipt = E2EMessaging.send_message_external(
-            contract_address=e2e_messaging_contract.address,
+        tx_hash, tx_receipt = E2EMessaging(e2e_messaging_contract.address).send_message_external(
             to_address=user_address_2,
             _type=_type,
             message_org=message_org,
@@ -303,8 +299,7 @@ EK7Y4zFFnfKP3WIA3atUbbcCAwEAAQ==
         ]
 
         # Run Test
-        tx_hash, tx_receipt = E2EMessaging.send_message_external(
-            contract_address=e2e_messaging_contract.address,
+        tx_hash, tx_receipt = E2EMessaging(e2e_messaging_contract.address).send_message_external(
             to_address=user_address_2,
             _type=_type,
             message_org=message_org,
@@ -357,8 +352,7 @@ EK7Y4zFFnfKP3WIA3atUbbcCAwEAAQ==
             with mock.patch("app.utils.contract_utils.ContractUtils.send_transaction",
                             MagicMock(side_effect=Exception("tx error"))):
                 # Run Test
-                E2EMessaging.send_message_external(
-                    contract_address=e2e_messaging_contract.address,
+                E2EMessaging(e2e_messaging_contract.address).send_message_external(
                     to_address=user_address_2,
                     _type=_type,
                     message_org=message_org,
@@ -390,8 +384,7 @@ EK7Y4zFFnfKP3WIA3atUbbcCAwEAAQ==
             with mock.patch("app.utils.contract_utils.ContractUtils.send_transaction",
                             MagicMock(side_effect=TimeExhausted("Timeout Error test"))):
                 # Run Test
-                E2EMessaging.send_message_external(
-                    contract_address=e2e_messaging_contract.address,
+                E2EMessaging(e2e_messaging_contract.address).send_message_external(
                     to_address=user_address_2,
                     _type=_type,
                     message_org=message_org,
@@ -438,8 +431,7 @@ EK7Y4zFFnfKP3WIA3atUbbcCAwEAAQ==
         key_type = "RSA4098"
 
         # Run Test
-        tx_hash, tx_receipt = E2EMessaging.set_public_key(
-            contract_address=e2e_messaging_contract.address,
+        tx_hash, tx_receipt = E2EMessaging(e2e_messaging_contract.address).set_public_key(
             public_key=self.rsa_public_key,
             key_type=key_type,
             tx_from=user_address_1,
@@ -473,8 +465,7 @@ EK7Y4zFFnfKP3WIA3atUbbcCAwEAAQ==
             with mock.patch("app.utils.contract_utils.ContractUtils.send_transaction",
                             MagicMock(side_effect=Exception("tx error"))):
                 # Run Test
-                E2EMessaging.set_public_key(
-                    contract_address=e2e_messaging_contract.address,
+                E2EMessaging(e2e_messaging_contract.address).set_public_key(
                     public_key=self.rsa_public_key,
                     key_type=key_type,
                     tx_from=user_address_1,
@@ -501,8 +492,7 @@ EK7Y4zFFnfKP3WIA3atUbbcCAwEAAQ==
             with mock.patch("app.utils.contract_utils.ContractUtils.send_transaction",
                             MagicMock(side_effect=TimeExhausted("Timeout Error test"))):
                 # Run Test
-                E2EMessaging.set_public_key(
-                    contract_address=e2e_messaging_contract.address,
+                E2EMessaging(e2e_messaging_contract.address).set_public_key(
                     public_key=self.rsa_public_key,
                     key_type=key_type,
                     tx_from=user_address_1,

--- a/tests/model/blockchain/test_exchange_IbetExchangeInterface.py
+++ b/tests/model/blockchain/test_exchange_IbetExchangeInterface.py
@@ -104,7 +104,7 @@ def issue_bond_token(issuer: dict, exchange_address: str):
         "リターン内容",
         "発行目的"
     ]
-    token_contract_address, abi, tx_hash = IbetStraightBondContract.create(
+    token_contract_address, abi, tx_hash = IbetStraightBondContract().create(
         args=arguments,
         tx_from=issuer_address,
         private_key=issuer_pk

--- a/tests/model/blockchain/test_exchange_IbetSecurityTokenEscrow.py
+++ b/tests/model/blockchain/test_exchange_IbetSecurityTokenEscrow.py
@@ -112,7 +112,7 @@ def issue_bond_token(issuer: dict, exchange_address: str):
         "リターン内容",
         "発行目的"
     ]
-    token_contract_address, abi, tx_hash = IbetStraightBondContract.create(
+    token_contract_address, abi, tx_hash = IbetStraightBondContract().create(
         args=arguments,
         tx_from=issuer_address,
         private_key=issuer_pk

--- a/tests/model/blockchain/test_token_list.py
+++ b/tests/model/blockchain/test_token_list.py
@@ -85,7 +85,8 @@ class TestRegisterTokenList:
             "20221231",
             10000
         ]
-        share_token_address, abi, tx_hash = IbetShareContract.create(
+        share_contract = IbetShareContract()
+        share_token_address, abi, tx_hash = share_contract.create(
             args=arguments,
             tx_from=issuer_address,
             private_key=private_key
@@ -118,7 +119,7 @@ class TestRegisterTokenList:
             "リターン内容",
             "発行目的"
         ]
-        bond_token_address, abi, tx_hash = IbetStraightBondContract.create(
+        bond_token_address, abi, tx_hash = IbetStraightBondContract().create(
             args=arguments,
             tx_from=issuer_address,
             private_key=private_key

--- a/tests/model/blockchain/test_token_list.py
+++ b/tests/model/blockchain/test_token_list.py
@@ -92,11 +92,10 @@ class TestRegisterTokenList:
             private_key=private_key
         )
 
-        TokenListContract.register(
+        TokenListContract(config.TOKEN_LIST_CONTRACT_ADDRESS).register(
             token_address=share_token_address,
             token_template=TokenType.IBET_SHARE.value,
-            token_list_address=config.TOKEN_LIST_CONTRACT_ADDRESS,
-            account_address=issuer_address,
+            tx_from=issuer_address,
             private_key=private_key
         )
 
@@ -125,11 +124,10 @@ class TestRegisterTokenList:
             private_key=private_key
         )
 
-        TokenListContract.register(
+        TokenListContract(config.TOKEN_LIST_CONTRACT_ADDRESS).register(
             token_address=bond_token_address,
             token_template=TokenType.IBET_STRAIGHT_BOND.value,
-            token_list_address=config.TOKEN_LIST_CONTRACT_ADDRESS,
-            account_address=issuer_address,
+            tx_from=issuer_address,
             private_key=private_key
         )
 
@@ -161,11 +159,10 @@ class TestRegisterTokenList:
         )
 
         with pytest.raises(SendTransactionError) as exc_info:
-            TokenListContract.register(
+            TokenListContract(config.TOKEN_LIST_CONTRACT_ADDRESS).register(
                 token_address="dummy_token_address",
                 token_template=TokenType.IBET_SHARE.value,
-                token_list_address=config.TOKEN_LIST_CONTRACT_ADDRESS,
-                account_address=issuer_address,
+                tx_from=issuer_address,
                 private_key=private_key
             )
         assert isinstance(exc_info.value.args[0], ValidationError)
@@ -180,11 +177,10 @@ class TestRegisterTokenList:
         )
 
         with pytest.raises(SendTransactionError) as exc_info:
-            TokenListContract.register(
+            TokenListContract("dummy_token_list_address").register(
                 token_address=ZERO_ADDRESS,
                 token_template=TokenType.IBET_STRAIGHT_BOND.value,
-                token_list_address="dummy_token_list_address",
-                account_address=issuer_address,
+                tx_from=issuer_address,
                 private_key=private_key
             )
         assert isinstance(exc_info.value.args[0], ValueError)
@@ -199,11 +195,10 @@ class TestRegisterTokenList:
         )
 
         with pytest.raises(SendTransactionError) as exc_info:
-            TokenListContract.register(
+            TokenListContract(config.TOKEN_LIST_CONTRACT_ADDRESS).register(
                 token_address=ZERO_ADDRESS,
                 token_template=TokenType.IBET_SHARE.value,
-                token_list_address=config.TOKEN_LIST_CONTRACT_ADDRESS,
-                account_address=issuer_address[:-1],
+                tx_from=issuer_address[:-1],
                 private_key=private_key
             )
         assert isinstance(exc_info.value.args[0], InvalidAddress)
@@ -214,11 +209,10 @@ class TestRegisterTokenList:
         issuer_address = test_account.get("address")
 
         with pytest.raises(SendTransactionError) as exc_info:
-            TokenListContract.register(
+            TokenListContract(config.TOKEN_LIST_CONTRACT_ADDRESS).register(
                 token_address=ZERO_ADDRESS,
                 token_template=TokenType.IBET_SHARE.value,
-                token_list_address=config.TOKEN_LIST_CONTRACT_ADDRESS,
-                account_address=issuer_address,
+                tx_from=issuer_address,
                 private_key="not private key"
             )
         assert isinstance(exc_info.value.args[0], Error)
@@ -241,11 +235,10 @@ class TestRegisterTokenList:
         # execute the function
         with ContractUtils_send_transaction:
             with pytest.raises(SendTransactionError):
-                TokenListContract.register(
+                TokenListContract(config.TOKEN_LIST_CONTRACT_ADDRESS).register(
                     token_address=ZERO_ADDRESS,
                     token_template=TokenType.IBET_SHARE.value,
-                    token_list_address=config.TOKEN_LIST_CONTRACT_ADDRESS,
-                    account_address=issuer_address,
+                    tx_from=issuer_address,
                     private_key=private_key
                 )
 
@@ -269,11 +262,10 @@ class TestRegisterTokenList:
 
         # execute the function
         with InspectionMock, pytest.raises(ContractRevertError) as exc_info:
-            TokenListContract.register(
+            TokenListContract(config.TOKEN_LIST_CONTRACT_ADDRESS).register(
                 token_address=ZERO_ADDRESS,
                 token_template=TokenType.IBET_SHARE.value,
-                token_list_address=config.TOKEN_LIST_CONTRACT_ADDRESS,
-                account_address=issuer_address,
+                tx_from=issuer_address,
                 private_key=private_key
             )
 

--- a/tests/test_app_routers_accounts_{issuer_address}_eoa_password_POST.py
+++ b/tests/test_app_routers_accounts_{issuer_address}_eoa_password_POST.py
@@ -87,7 +87,7 @@ class TestAppRoutersAccountsIssuerAddressEOAPasswordPOST:
             "return_amount_test",
             "purpose_test"
         ]
-        IbetStraightBondContract.create(
+        IbetStraightBondContract().create(
             args=arguments,
             tx_from=_issuer_address,
             private_key=private_key

--- a/tests/test_app_routers_bond_tokens_GET.py
+++ b/tests/test_app_routers_bond_tokens_GET.py
@@ -18,7 +18,8 @@ SPDX-License-Identifier: Apache-2.0
 """
 import pytz
 from unittest import mock
-from unittest.mock import call
+
+from web3.datastructures import AttributeDict
 
 from app.model.blockchain import IbetStraightBondContract
 from app.model.db import (
@@ -96,13 +97,10 @@ class TestAppRoutersBondTokensGET:
         mock_token.memo = "memo_test1"
 
         mock_get.side_effect = [
-            mock_token
+            AttributeDict(mock_token.__dict__)
         ]
 
         resp = client.get(self.apiurl)
-
-        # assertion mock call arguments
-        mock_get.assert_any_call(contract_address=token.token_address)
 
         assumed_response = [
             {
@@ -241,14 +239,11 @@ class TestAppRoutersBondTokensGET:
         mock_token_2.memo = "memo_test2"
 
         mock_get.side_effect = [
-            mock_token_1, mock_token_2
+            AttributeDict(mock_token_1.__dict__),
+            AttributeDict(mock_token_2.__dict__)
         ]
 
         resp = client.get(self.apiurl)
-
-        # assertion mock call arguments
-        mock_get.assert_has_calls(
-            [call(contract_address=token_1.token_address), call(contract_address=token_2.token_address)])
 
         assumed_response = [
             {
@@ -398,7 +393,7 @@ class TestAppRoutersBondTokensGET:
         mock_token.memo = "memo_test1"
 
         mock_get.side_effect = [
-            mock_token
+            AttributeDict(mock_token.__dict__)
         ]
 
         # No Target Data
@@ -411,9 +406,6 @@ class TestAppRoutersBondTokensGET:
         db.add(token_2)
 
         resp = client.get(self.apiurl, headers={"issuer-address": issuer_address_1})
-
-        # assertion mock call arguments
-        mock_get.assert_any_call(contract_address=token_1.token_address)
 
         assumed_response = [
             {
@@ -552,7 +544,8 @@ class TestAppRoutersBondTokensGET:
         mock_token_2.memo = "memo_test2"
 
         mock_get.side_effect = [
-            mock_token_1, mock_token_2
+            AttributeDict(mock_token_1.__dict__),
+            AttributeDict(mock_token_2.__dict__)
         ]
 
         # No Target Data
@@ -565,10 +558,6 @@ class TestAppRoutersBondTokensGET:
         db.add(token_3)
 
         resp = client.get(self.apiurl, headers={"issuer-address": issuer_address_1})
-
-        # assertion mock call arguments
-        mock_get.assert_has_calls(
-            [call(contract_address=token_1.token_address), call(contract_address=token_2.token_address)])
 
         assumed_response = [
             {

--- a/tests/test_app_routers_bond_tokens_POST.py
+++ b/tests/test_app_routers_bond_tokens_POST.py
@@ -120,10 +120,9 @@ class TestAppRoutersBondTokensPOST:
                 private_key=ANY
             )
             TokenListContract.register.assert_called_with(
-                token_list_address=config.TOKEN_LIST_CONTRACT_ADDRESS,
                 token_address="contract_address_test1",
                 token_template=TokenType.IBET_STRAIGHT_BOND.value,
-                account_address=test_account["address"],
+                tx_from=test_account["address"],
                 private_key=ANY
             )
             ContractUtils.get_block_by_transaction_hash(
@@ -349,10 +348,9 @@ class TestAppRoutersBondTokensPOST:
                 private_key=ANY
             )
             TokenListContract.register.assert_called_with(
-                token_list_address=config.TOKEN_LIST_CONTRACT_ADDRESS,
                 token_address="contract_address_test1",
                 token_template=TokenType.IBET_STRAIGHT_BOND.value,
-                account_address=test_account["address"],
+                tx_from=test_account["address"],
                 private_key=ANY
             )
             ContractUtils.get_block_by_transaction_hash(

--- a/tests/test_app_routers_bond_tokens_{token_address}_GET.py
+++ b/tests/test_app_routers_bond_tokens_{token_address}_GET.py
@@ -89,8 +89,6 @@ class TestAppRoutersBondTokensTokenAddressGET:
         resp = client.get(self.base_apiurl + "token_address_test1")
 
         # assertion
-        mock_get.assert_any_call(contract_address="token_address_test1")
-
         assumed_response = {
             "issuer_address": "issuer_address_test1",
             "token_address": "token_address_test1",
@@ -182,8 +180,6 @@ class TestAppRoutersBondTokensTokenAddressGET:
         resp = client.get(self.base_apiurl + "token_address_test1")
 
         # assertion
-        mock_get.assert_any_call(contract_address="token_address_test1")
-
         assumed_response = {
             "issuer_address": "issuer_address_test1",
             "token_address": "token_address_test1",

--- a/tests/test_app_routers_bond_tokens_{token_address}_POST.py
+++ b/tests/test_app_routers_bond_tokens_{token_address}_POST.py
@@ -103,7 +103,6 @@ class TestAppRoutersBondTokensTokenAddressPOST:
 
         # assertion
         IbetStraightBondContract_mock.assert_any_call(
-            contract_address=_token_address,
             data=req_param,
             tx_from=_issuer_address,
             private_key=ANY
@@ -214,7 +213,6 @@ class TestAppRoutersBondTokensTokenAddressPOST:
 
         # assertion
         IbetStraightBondContract_mock.assert_any_call(
-            contract_address=_token_address,
             data=req_param,
             tx_from=_issuer_address,
             private_key=ANY

--- a/tests/test_app_routers_bond_tokens_{token_address}_additional_issue_POST.py
+++ b/tests/test_app_routers_bond_tokens_{token_address}_additional_issue_POST.py
@@ -82,7 +82,6 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssuePOST:
 
         # assertion
         IbetStraightBondContract_mock.assert_any_call(
-            contract_address=_token_address,
             data=req_param,
             tx_from=_issuer_address,
             private_key=ANY
@@ -140,7 +139,6 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssuePOST:
 
         # assertion
         IbetStraightBondContract_mock.assert_any_call(
-            contract_address=_token_address,
             data=req_param,
             tx_from=_issuer_address,
             private_key=ANY

--- a/tests/test_app_routers_bond_tokens_{token_address}_holders_{account_address}_personal_info_POST.py
+++ b/tests/test_app_routers_bond_tokens_{token_address}_holders_{account_address}_personal_info_POST.py
@@ -108,7 +108,6 @@ class TestAppRoutersBondTokensTokenAddressHoldersAccountAddressPersonalInfoPOST:
             # assertion
             assert resp.status_code == 200
             assert resp.json() is None
-            IbetStraightBondContract.get.assert_called_with(_token_address)
             PersonalInfoContract.__init__.assert_called_with(
                 db=db,
                 issuer_address=_issuer_address,
@@ -187,7 +186,6 @@ class TestAppRoutersBondTokensTokenAddressHoldersAccountAddressPersonalInfoPOST:
             # assertion
             assert resp.status_code == 200
             assert resp.json() is None
-            IbetStraightBondContract.get.assert_called_with(_token_address)
             PersonalInfoContract.__init__.assert_called_with(
                 db=db,
                 issuer_address=_issuer_address,
@@ -272,7 +270,6 @@ class TestAppRoutersBondTokensTokenAddressHoldersAccountAddressPersonalInfoPOST:
             # assertion
             assert resp.status_code == 200
             assert resp.json() is None
-            IbetStraightBondContract.get.assert_called_with(_token_address)
             PersonalInfoContract.__init__.assert_called_with(
                 db=db,
                 issuer_address=_issuer_address,

--- a/tests/test_app_routers_bond_tokens_{token_address}_personal_info_POST.py
+++ b/tests/test_app_routers_bond_tokens_{token_address}_personal_info_POST.py
@@ -109,7 +109,6 @@ class TestAppRoutersBondTokensTokenAddressPersonalInfoPOST:
             # assertion
             assert resp.status_code == 200
             assert resp.json() is None
-            IbetStraightBondContract.get.assert_called_with(_token_address)
             PersonalInfoContract.__init__.assert_called_with(
                 db=db,
                 issuer_address=_issuer_address,
@@ -189,7 +188,6 @@ class TestAppRoutersBondTokensTokenAddressPersonalInfoPOST:
             # assertion
             assert resp.status_code == 200
             assert resp.json() is None
-            IbetStraightBondContract.get.assert_called_with(_token_address)
             PersonalInfoContract.__init__.assert_called_with(
                 db=db,
                 issuer_address=_issuer_address,
@@ -275,7 +273,6 @@ class TestAppRoutersBondTokensTokenAddressPersonalInfoPOST:
             # assertion
             assert resp.status_code == 200
             assert resp.json() is None
-            IbetStraightBondContract.get.assert_called_with(_token_address)
             PersonalInfoContract.__init__.assert_called_with(
                 db=db,
                 issuer_address=_issuer_address,

--- a/tests/test_app_routers_bond_tokens_{token_address}_redeem_POST.py
+++ b/tests/test_app_routers_bond_tokens_{token_address}_redeem_POST.py
@@ -82,7 +82,6 @@ class TestAppRoutersBondTokensTokenAddressRedeemPOST:
 
         # assertion
         IbetStraightBondContract_mock.assert_any_call(
-            contract_address=_token_address,
             data=req_param,
             tx_from=_issuer_address,
             private_key=ANY
@@ -140,7 +139,6 @@ class TestAppRoutersBondTokensTokenAddressRedeemPOST:
 
         # assertion
         IbetStraightBondContract_mock.assert_any_call(
-            contract_address=_token_address,
             data=req_param,
             tx_from=_issuer_address,
             private_key=ANY

--- a/tests/test_app_routers_bond_transfer_approvals_{token_Address}_{id}_POST.py
+++ b/tests/test_app_routers_bond_transfer_approvals_{token_Address}_{id}_POST.py
@@ -142,7 +142,6 @@ class TestAppRoutersBondTransferApprovalsTokenAddressIdPOST:
         }
 
         mock_transfer.assert_called_once_with(
-            contract_address=self.test_token_address,
             data=ApproveTransferParams(**_expected),
             tx_from=issuer_address,
             private_key=ANY
@@ -306,7 +305,6 @@ class TestAppRoutersBondTransferApprovalsTokenAddressIdPOST:
         }
 
         mock_transfer.assert_called_once_with(
-            contract_address=self.test_token_address,
             data=ApproveTransferParams(**_expected),
             tx_from=issuer_address,
             private_key=ANY
@@ -393,7 +391,6 @@ class TestAppRoutersBondTransferApprovalsTokenAddressIdPOST:
         }
 
         mock_transfer.assert_called_once_with(
-            contract_address=self.test_token_address,
             data=ApproveTransferParams(**_expected),
             tx_from=issuer_address,
             private_key=ANY

--- a/tests/test_app_routers_bond_transfers_POST.py
+++ b/tests/test_app_routers_bond_transfers_POST.py
@@ -91,7 +91,6 @@ class TestAppRoutersBondTransfersPOST:
 
         # assertion
         IbetStraightBondContract_mock.assert_any_call(
-            contract_address=_token_address,
             data={
                 "from_address": _from_address,
                 "to_address": _to_address,
@@ -162,7 +161,6 @@ class TestAppRoutersBondTransfersPOST:
 
         # assertion
         IbetStraightBondContract_mock.assert_any_call(
-            contract_address=_token_address,
             data={
                 "from_address": _from_address,
                 "to_address": _to_address,

--- a/tests/test_app_routers_e2e_messaging_accounts_POST.py
+++ b/tests/test_app_routers_e2e_messaging_accounts_POST.py
@@ -85,7 +85,6 @@ class TestAppRoutersE2EMessagingAccountsPOST:
 
             # assertion
             E2EMessaging.set_public_key.assert_called_with(
-                contract_address=e2e_messaging_contract.address,
                 public_key=ANY,
                 key_type="RSA4096",
                 tx_from=resp.json()["account_address"],
@@ -181,7 +180,6 @@ class TestAppRoutersE2EMessagingAccountsPOST:
 
             # assertion
             E2EMessaging.set_public_key.assert_called_with(
-                contract_address=e2e_messaging_contract.address,
                 public_key=ANY,
                 key_type="RSA4096",
                 tx_from=resp.json()["account_address"],

--- a/tests/test_app_routers_e2e_messaging_accounts_{account_address}_eoa_password_POST.py
+++ b/tests/test_app_routers_e2e_messaging_accounts_{account_address}_eoa_password_POST.py
@@ -80,7 +80,7 @@ class TestAppRoutersE2EMessagingAccountsAccountAddressEoaPasswordPOST:
             "return_amount_test",
             "purpose_test"
         ]
-        IbetStraightBondContract.create(
+        IbetStraightBondContract().create(
             args=arguments,
             tx_from=user_address_1,
             private_key=private_key

--- a/tests/test_app_routers_ledger_{token_address}_history_{ledger_id}_GET.py
+++ b/tests/test_app_routers_ledger_{token_address}_history_{ledger_id}_GET.py
@@ -763,7 +763,6 @@ class TestAppRoutersLedgerTokenAddressHistoryLedgerIdGET:
                 }
             )
             # assertion
-            token_get_mock_patch.assert_any_call(token_address)
             personal_get_info_mock_patch.assert_has_calls([
                 call(account_address=account_address_2, default_value=None)
             ])
@@ -1085,7 +1084,6 @@ class TestAppRoutersLedgerTokenAddressHistoryLedgerIdGET:
                 }
             )
             # assertion
-            token_get_mock_patch.assert_any_call(token_address)
             personal_get_info_mock_patch.assert_has_calls([
                 call(account_address=account_address_2, default_value=None)
             ])

--- a/tests/test_app_routers_positions_{account_address}_forceunlock_POST.py
+++ b/tests/test_app_routers_positions_{account_address}_forceunlock_POST.py
@@ -93,7 +93,6 @@ class TestAppRoutersForceUnlockPOST:
 
         # assertion
         IbetSecurityTokenInterface_mock.assert_any_call(
-            contract_address=_token_address,
             data={
                 "lock_address": _lock_address,
                 "account_address": _admin_address,
@@ -164,7 +163,6 @@ class TestAppRoutersForceUnlockPOST:
 
         # assertion
         IbetSecurityTokenInterface_mock.assert_any_call(
-            contract_address=_token_address,
             data={
                 "lock_address": _lock_address,
                 "account_address": _admin_address,

--- a/tests/test_app_routers_share_tokens_GET.py
+++ b/tests/test_app_routers_share_tokens_GET.py
@@ -90,9 +90,6 @@ class TestAppRoutersShareTokensGET:
 
         resp = client.get(self.apiurl)
 
-        # assertion mock call arguments
-        mock_get.assert_any_call(contract_address=token.token_address)
-
         assumed_response = [
             {
                 "issuer_address": issuer_address_1,
@@ -206,12 +203,6 @@ class TestAppRoutersShareTokensGET:
         ]
 
         resp = client.get(self.apiurl)
-
-        # assertion mock call arguments
-        mock_get.assert_has_calls([
-            call(contract_address=token_1.token_address),
-            call(contract_address=token_2.token_address)
-        ])
 
         assumed_response = [
             {
@@ -342,9 +333,6 @@ class TestAppRoutersShareTokensGET:
 
         resp = client.get(self.apiurl, headers={"issuer-address": issuer_address_1})
 
-        # assertion mock call arguments
-        mock_get.assert_any_call(contract_address=token_1.token_address)
-
         assumed_response = [
             {
                 "issuer_address": issuer_address_1,
@@ -467,12 +455,6 @@ class TestAppRoutersShareTokensGET:
         db.add(token_3)
 
         resp = client.get(self.apiurl, headers={"issuer-address": issuer_address_1})
-
-        # assertion mock call arguments
-        mock_get.assert_has_calls([
-            call(contract_address=token_1.token_address),
-            call(contract_address=token_2.token_address)
-        ])
 
         assumed_response = [
             {

--- a/tests/test_app_routers_share_tokens_POST.py
+++ b/tests/test_app_routers_share_tokens_POST.py
@@ -125,10 +125,9 @@ class TestAppRoutersShareTokensPOST:
                 private_key=ANY
             )
             TokenListContract.register.assert_called_with(
-                token_list_address=config.TOKEN_LIST_CONTRACT_ADDRESS,
                 token_address="contract_address_test1",
                 token_template=TokenType.IBET_SHARE.value,
-                account_address=test_account["address"],
+                tx_from=test_account["address"],
                 private_key=ANY
             )
             ContractUtils.get_block_by_transaction_hash(
@@ -231,10 +230,9 @@ class TestAppRoutersShareTokensPOST:
                 private_key=ANY
             )
             TokenListContract.register.assert_called_with(
-                token_list_address=config.TOKEN_LIST_CONTRACT_ADDRESS,
                 token_address="contract_address_test1",
                 token_template=TokenType.IBET_SHARE.value,
-                account_address=test_account["address"],
+                tx_from=test_account["address"],
                 private_key=ANY
             )
             ContractUtils.get_block_by_transaction_hash(
@@ -454,10 +452,9 @@ class TestAppRoutersShareTokensPOST:
                 private_key=ANY
             )
             TokenListContract.register.assert_called_with(
-                token_list_address=config.TOKEN_LIST_CONTRACT_ADDRESS,
                 token_address="contract_address_test1",
                 token_template=TokenType.IBET_SHARE.value,
-                account_address=test_account["address"],
+                tx_from=test_account["address"],
                 private_key=ANY
             )
             ContractUtils.get_block_by_transaction_hash(

--- a/tests/test_app_routers_share_tokens_{token_address}_GET.py
+++ b/tests/test_app_routers_share_tokens_{token_address}_GET.py
@@ -79,8 +79,6 @@ class TestAppRoutersShareTokensTokenAddressGET:
         resp = client.get(self.base_apiurl + "token_address_test1")
 
         # assertion
-        mock_get.assert_any_call(contract_address="token_address_test1")
-
         assumed_response = {
             "issuer_address": "issuer_address_test1",
             "token_address": "token_address_test1",
@@ -153,8 +151,6 @@ class TestAppRoutersShareTokensTokenAddressGET:
         resp = client.get(self.base_apiurl + "token_address_test1")
 
         # assertion
-        mock_get.assert_any_call(contract_address="token_address_test1")
-
         assumed_response = {
             "issuer_address": "issuer_address_test1",
             "token_address": "token_address_test1",

--- a/tests/test_app_routers_share_tokens_{token_address}_POST.py
+++ b/tests/test_app_routers_share_tokens_{token_address}_POST.py
@@ -104,7 +104,6 @@ class TestAppRoutersShareTokensTokenAddressPOST:
 
         # assertion
         IbetShareContract_mock.assert_any_call(
-            contract_address=_token_address,
             data=req_param,
             tx_from=_issuer_address,
             private_key=ANY
@@ -216,7 +215,6 @@ class TestAppRoutersShareTokensTokenAddressPOST:
 
         # assertion
         IbetShareContract_mock.assert_any_call(
-            contract_address=_token_address,
             data=req_param,
             tx_from=_issuer_address,
             private_key=ANY
@@ -269,7 +267,6 @@ class TestAppRoutersShareTokensTokenAddressPOST:
 
         # assertion
         IbetShareContract_mock.assert_any_call(
-            contract_address=_token_address,
             data={
                 "cancellation_date": "20221231",
                 "dividends": 345.67,
@@ -338,7 +335,6 @@ class TestAppRoutersShareTokensTokenAddressPOST:
 
         # assertion
         IbetShareContract_mock.assert_any_call(
-            contract_address=_token_address,
             data={
                 "cancellation_date": "",
                 "dividends": 345.67,

--- a/tests/test_app_routers_share_tokens_{token_address}_additional_issue_POST.py
+++ b/tests/test_app_routers_share_tokens_{token_address}_additional_issue_POST.py
@@ -82,7 +82,6 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssuePOST:
 
         # assertion
         IbetShareContract_mock.assert_any_call(
-            contract_address=_token_address,
             data=req_param,
             tx_from=_issuer_address,
             private_key=ANY
@@ -140,7 +139,6 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssuePOST:
 
         # assertion
         IbetShareContract_mock.assert_any_call(
-            contract_address=_token_address,
             data=req_param,
             tx_from=_issuer_address,
             private_key=ANY

--- a/tests/test_app_routers_share_tokens_{token_address}_holders_{account_address}_personal_info_POST.py
+++ b/tests/test_app_routers_share_tokens_{token_address}_holders_{account_address}_personal_info_POST.py
@@ -108,7 +108,6 @@ class TestAppRoutersShareTokensTokenAddressHoldersAccountAddressPersonalInfoPOST
             # assertion
             assert resp.status_code == 200
             assert resp.json() is None
-            IbetShareContract.get.assert_called_with(_token_address)
             PersonalInfoContract.__init__.assert_called_with(
                 db=db,
                 issuer_address=_issuer_address,
@@ -187,7 +186,6 @@ class TestAppRoutersShareTokensTokenAddressHoldersAccountAddressPersonalInfoPOST
             # assertion
             assert resp.status_code == 200
             assert resp.json() is None
-            IbetShareContract.get.assert_called_with(_token_address)
             PersonalInfoContract.__init__.assert_called_with(
                 db=db,
                 issuer_address=_issuer_address,
@@ -272,7 +270,6 @@ class TestAppRoutersShareTokensTokenAddressHoldersAccountAddressPersonalInfoPOST
             # assertion
             assert resp.status_code == 200
             assert resp.json() is None
-            IbetShareContract.get.assert_called_with(_token_address)
             PersonalInfoContract.__init__.assert_called_with(
                 db=db,
                 issuer_address=_issuer_address,

--- a/tests/test_app_routers_share_tokens_{token_address}_personal_info_POST.py
+++ b/tests/test_app_routers_share_tokens_{token_address}_personal_info_POST.py
@@ -109,7 +109,6 @@ class TestAppRoutersShareTokensTokenAddressPersonalInfoPOST:
             # assertion
             assert resp.status_code == 200
             assert resp.json() is None
-            IbetShareContract.get.assert_called_with(_token_address)
             PersonalInfoContract.__init__.assert_called_with(
                 db=db,
                 issuer_address=_issuer_address,
@@ -189,7 +188,6 @@ class TestAppRoutersShareTokensTokenAddressPersonalInfoPOST:
             # assertion
             assert resp.status_code == 200
             assert resp.json() is None
-            IbetShareContract.get.assert_called_with(_token_address)
             PersonalInfoContract.__init__.assert_called_with(
                 db=db,
                 issuer_address=_issuer_address,
@@ -275,7 +273,6 @@ class TestAppRoutersShareTokensTokenAddressPersonalInfoPOST:
             # assertion
             assert resp.status_code == 200
             assert resp.json() is None
-            IbetShareContract.get.assert_called_with(_token_address)
             PersonalInfoContract.__init__.assert_called_with(
                 db=db,
                 issuer_address=_issuer_address,

--- a/tests/test_app_routers_share_tokens_{token_address}_redeem_POST.py
+++ b/tests/test_app_routers_share_tokens_{token_address}_redeem_POST.py
@@ -82,7 +82,6 @@ class TestAppRoutersShareTokensTokenAddressRedeemPOST:
 
         # assertion
         IbetShareContract_mock.assert_any_call(
-            contract_address=_token_address,
             data=req_param,
             tx_from=_issuer_address,
             private_key=ANY
@@ -140,7 +139,6 @@ class TestAppRoutersShareTokensTokenAddressRedeemPOST:
 
         # assertion
         IbetShareContract_mock.assert_any_call(
-            contract_address=_token_address,
             data=req_param,
             tx_from=_issuer_address,
             private_key=ANY

--- a/tests/test_app_routers_share_transfer_approvals_{token_Address}_{id}_POST.py
+++ b/tests/test_app_routers_share_transfer_approvals_{token_Address}_{id}_POST.py
@@ -142,7 +142,6 @@ class TestAppRoutersShareTransferApprovalsTokenAddressIdPOST:
         }
 
         mock_transfer.assert_called_once_with(
-            contract_address=self.test_token_address,
             data=ApproveTransferParams(**_expected),
             tx_from=issuer_address,
             private_key=ANY
@@ -306,7 +305,6 @@ class TestAppRoutersShareTransferApprovalsTokenAddressIdPOST:
         }
 
         mock_transfer.assert_called_once_with(
-            contract_address=self.test_token_address,
             data=ApproveTransferParams(**_expected),
             tx_from=issuer_address,
             private_key=ANY
@@ -393,7 +391,6 @@ class TestAppRoutersShareTransferApprovalsTokenAddressIdPOST:
         }
 
         mock_transfer.assert_called_once_with(
-            contract_address=self.test_token_address,
             data=ApproveTransferParams(**_expected),
             tx_from=issuer_address,
             private_key=ANY

--- a/tests/test_app_routers_share_transfers_POST.py
+++ b/tests/test_app_routers_share_transfers_POST.py
@@ -91,7 +91,6 @@ class TestAppRoutersShareTransfersPOST:
 
         # assertion
         IbetShareContract_mock.assert_any_call(
-            contract_address=_token_address,
             data={
                 "from_address": _from_address,
                 "to_address": _to_address,
@@ -162,7 +161,6 @@ class TestAppRoutersShareTransfersPOST:
 
         # assertion
         IbetShareContract_mock.assert_any_call(
-            contract_address=_token_address,
             data={
                 "from_address": _from_address,
                 "to_address": _to_address,

--- a/tests/test_batch_indexer_e2e_messaging.py
+++ b/tests/test_batch_indexer_e2e_messaging.py
@@ -188,8 +188,7 @@ EK7Y4zFFnfKP3WIA3atUbbcCAwEAAQ==
             "address": "東京都1",
         }
         message_message_str = json.dumps(message)
-        sending_tx_hash, sending_tx_receipt = E2EMessaging.send_message_external(
-            e2e_messaging_contract.address,
+        sending_tx_hash, sending_tx_receipt = E2EMessaging(e2e_messaging_contract.address).send_message_external(
             user_address_1,
             _type,
             message_message_str,
@@ -276,8 +275,7 @@ EK7Y4zFFnfKP3WIA3atUbbcCAwEAAQ==
             "address": "東京都1",
         }
         message_message_str = json.dumps(message)
-        sending_tx_hash, sending_tx_receipt = E2EMessaging.send_message_external(
-            e2e_messaging_contract.address,
+        sending_tx_hash, sending_tx_receipt = E2EMessaging(e2e_messaging_contract.address).send_message_external(
             user_address_1,
             _type,
             message_message_str,
@@ -385,8 +383,7 @@ EK7Y4zFFnfKP3WIA3atUbbcCAwEAAQ==
             "address": "東京都1",
         }
         message_message_str_1 = json.dumps(message)
-        sending_tx_hash_1, sending_tx_receipt = E2EMessaging.send_message_external(
-            e2e_messaging_contract.address,
+        sending_tx_hash_1, sending_tx_receipt = E2EMessaging(e2e_messaging_contract.address).send_message_external(
             user_address_1,
             _type_1,
             message_message_str_1,
@@ -401,8 +398,7 @@ EK7Y4zFFnfKP3WIA3atUbbcCAwEAAQ==
         _type_2 = "test_type2"
         message = ["テスト太郎2", "東京都2"]
         message_message_str_2 = json.dumps(message)
-        sending_tx_hash_2, sending_tx_receipt = E2EMessaging.send_message_external(
-            e2e_messaging_contract.address,
+        sending_tx_hash_2, sending_tx_receipt = E2EMessaging(e2e_messaging_contract.address).send_message_external(
             user_address_2,
             _type_2,
             message_message_str_2,
@@ -416,8 +412,7 @@ EK7Y4zFFnfKP3WIA3atUbbcCAwEAAQ==
         # Send Message(user3 -> user1)
         _type_3 = "test_type3"
         message_message_str_3 = "テスト太郎1,東京都1"
-        sending_tx_hash_3, sending_tx_receipt = E2EMessaging.send_message_external(
-            e2e_messaging_contract.address,
+        sending_tx_hash_3, sending_tx_receipt = E2EMessaging(e2e_messaging_contract.address).send_message_external(
             user_address_1,
             _type_3,
             message_message_str_3,
@@ -431,8 +426,7 @@ EK7Y4zFFnfKP3WIA3atUbbcCAwEAAQ==
         # Send Message(user3 -> user2)
         _type_4 = "a" * 50
         message_message_str_4 = "a" * 5000
-        sending_tx_hash_4, sending_tx_receipt = E2EMessaging.send_message_external(
-            e2e_messaging_contract.address,
+        sending_tx_hash_4, sending_tx_receipt = E2EMessaging(e2e_messaging_contract.address).send_message_external(
             user_address_2,
             _type_4,
             message_message_str_4,
@@ -529,8 +523,7 @@ EK7Y4zFFnfKP3WIA3atUbbcCAwEAAQ==
             "address": "東京都1",
         }
         message_message_str = json.dumps(message)
-        E2EMessaging.send_message_external(
-            e2e_messaging_contract.address,
+        E2EMessaging(e2e_messaging_contract.address).send_message_external(
             user_address_3,  # not target
             _type,
             message_message_str,
@@ -587,11 +580,8 @@ EK7Y4zFFnfKP3WIA3atUbbcCAwEAAQ==
 
         # Send Message
         message = "test"
-        E2EMessaging.send_message(e2e_messaging_contract.address,
-                                  user_address_1,
-                                  message,
-                                  user_address_2,
-                                  user_private_key_2)
+        E2EMessaging(e2e_messaging_contract.address).\
+            send_message(user_address_1, message, user_address_2, user_private_key_2)
 
         # Run target process
         block_number = web3.eth.block_number
@@ -650,11 +640,8 @@ EK7Y4zFFnfKP3WIA3atUbbcCAwEAAQ==
                 "message": encrypted_message,
             }
         })
-        E2EMessaging.send_message(e2e_messaging_contract.address,
-                                  user_address_1,
-                                  message,
-                                  user_address_2,
-                                  user_private_key_2)
+        E2EMessaging(e2e_messaging_contract.address).\
+            send_message(user_address_1, message, user_address_2, user_private_key_2)
 
         # Run target process
         block_number = web3.eth.block_number
@@ -702,11 +689,8 @@ EK7Y4zFFnfKP3WIA3atUbbcCAwEAAQ==
         message = json.dumps({
             "type": "test_type",
         })
-        E2EMessaging.send_message(e2e_messaging_contract.address,
-                                  user_address_1,
-                                  message,
-                                  user_address_2,
-                                  user_private_key_2)
+        E2EMessaging(e2e_messaging_contract.address).\
+            send_message(user_address_1, message, user_address_2, user_private_key_2)
 
         # Run target process
         block_number = web3.eth.block_number
@@ -766,11 +750,8 @@ EK7Y4zFFnfKP3WIA3atUbbcCAwEAAQ==
                 "message": encrypted_message
             }
         })
-        E2EMessaging.send_message(e2e_messaging_contract.address,
-                                  user_address_1,
-                                  message,
-                                  user_address_2,
-                                  user_private_key_2)
+        E2EMessaging(e2e_messaging_contract.address).\
+            send_message(user_address_1, message, user_address_2, user_private_key_2)
 
         # Run target process
         block_number = web3.eth.block_number
@@ -826,11 +807,8 @@ EK7Y4zFFnfKP3WIA3atUbbcCAwEAAQ==
                 "message": encrypted_message,
             }
         })
-        E2EMessaging.send_message(e2e_messaging_contract.address,
-                                  user_address_1,
-                                  message,
-                                  user_address_2,
-                                  user_private_key_2)
+        E2EMessaging(e2e_messaging_contract.address).\
+            send_message(user_address_1, message, user_address_2, user_private_key_2)
 
         # Run target process
         block_number = web3.eth.block_number
@@ -885,11 +863,8 @@ EK7Y4zFFnfKP3WIA3atUbbcCAwEAAQ==
                 "cipher_key": cipher_key,
             }
         })
-        E2EMessaging.send_message(e2e_messaging_contract.address,
-                                  user_address_1,
-                                  message,
-                                  user_address_2,
-                                  user_private_key_2)
+        E2EMessaging(e2e_messaging_contract.address).\
+            send_message(user_address_1, message, user_address_2, user_private_key_2)
 
         # Run target process
         block_number = web3.eth.block_number
@@ -949,11 +924,8 @@ EK7Y4zFFnfKP3WIA3atUbbcCAwEAAQ==
                 "message": encrypted_message
             }
         })
-        E2EMessaging.send_message(e2e_messaging_contract.address,
-                                  user_address_1,
-                                  message,
-                                  user_address_2,
-                                  user_private_key_2)
+        E2EMessaging(e2e_messaging_contract.address). \
+            send_message(user_address_1, message, user_address_2, user_private_key_2)
 
         # Run target process
         block_number = web3.eth.block_number
@@ -991,8 +963,7 @@ EK7Y4zFFnfKP3WIA3atUbbcCAwEAAQ==
             "address": "東京都1",
         }
         message_message_str = json.dumps(message)
-        E2EMessaging.send_message_external(
-            e2e_messaging_contract.address,
+        E2EMessaging(e2e_messaging_contract.address).send_message_external(
             user_address_1,
             _type,
             message_message_str,
@@ -1068,11 +1039,8 @@ EK7Y4zFFnfKP3WIA3atUbbcCAwEAAQ==
                 "message": encrypted_message
             }
         })
-        E2EMessaging.send_message(e2e_messaging_contract.address,
-                                  user_address_1,
-                                  message,
-                                  user_address_2,
-                                  user_private_key_2)
+        E2EMessaging(e2e_messaging_contract.address). \
+            send_message(user_address_1, message, user_address_2, user_private_key_2)
 
         # Run target process
         block_number = web3.eth.block_number
@@ -1130,11 +1098,8 @@ EK7Y4zFFnfKP3WIA3atUbbcCAwEAAQ==
                 "message": encrypted_message
             }
         })
-        E2EMessaging.send_message(e2e_messaging_contract.address,
-                                  user_address_1,
-                                  message,
-                                  user_address_2,
-                                  user_private_key_2)
+        E2EMessaging(e2e_messaging_contract.address). \
+            send_message(user_address_1, message, user_address_2, user_private_key_2)
 
         # Run target process
         block_number = web3.eth.block_number
@@ -1197,11 +1162,8 @@ EK7Y4zFFnfKP3WIA3atUbbcCAwEAAQ==
                 "message": encrypted_message
             }
         })
-        E2EMessaging.send_message(e2e_messaging_contract.address,
-                                  user_address_1,
-                                  message,
-                                  user_address_2,
-                                  user_private_key_2)
+        E2EMessaging(e2e_messaging_contract.address). \
+            send_message(user_address_1, message, user_address_2, user_private_key_2)
 
         # Run target process
         block_number = web3.eth.block_number
@@ -1257,11 +1219,8 @@ EK7Y4zFFnfKP3WIA3atUbbcCAwEAAQ==
                 "message": "test_message"
             }
         })
-        E2EMessaging.send_message(e2e_messaging_contract.address,
-                                  user_address_1,
-                                  message,
-                                  user_address_2,
-                                  user_private_key_2)
+        E2EMessaging(e2e_messaging_contract.address). \
+            send_message(user_address_1, message, user_address_2, user_private_key_2)
 
         # Run target process
         block_number = web3.eth.block_number
@@ -1322,11 +1281,8 @@ EK7Y4zFFnfKP3WIA3atUbbcCAwEAAQ==
                 "message": encrypted_message
             }
         })
-        E2EMessaging.send_message(e2e_messaging_contract.address,
-                                  user_address_1,
-                                  message,
-                                  user_address_2,
-                                  user_private_key_2)
+        E2EMessaging(e2e_messaging_contract.address). \
+            send_message(user_address_1, message, user_address_2, user_private_key_2)
 
         # Run target process
         block_number = web3.eth.block_number

--- a/tests/test_batch_indexer_issue_redeem.py
+++ b/tests/test_batch_indexer_issue_redeem.py
@@ -35,7 +35,8 @@ from app.model.db import (
     IDXIssueRedeemBlockNumber
 )
 from app.model.blockchain import IbetStraightBondContract, IbetShareContract
-from app.model.schema import IbetStraightBondUpdate, IbetShareUpdate
+from app.model.blockchain.tx_params.ibet_straight_bond import UpdateParams as IbetStraightBondUpdateParams
+from app.model.blockchain.tx_params.ibet_share import UpdateParams as IbetShareUpdateParams
 from app.utils.web3_utils import Web3Wrapper
 from app.utils.contract_utils import ContractUtils
 from batch.indexer_issue_redeem import Processor, LOG, main
@@ -84,14 +85,15 @@ def deploy_bond_token_contract(address,
         "token.return_amount",
         "token.purpose"
     ]
-
-    token_address, _, _ = IbetStraightBondContract.create(arguments, address, private_key)
-    IbetStraightBondContract.update(
-        contract_address=token_address,
-        data=IbetStraightBondUpdate(transferable=True,
-                                    personal_info_contract_address=personal_info_contract_address,
-                                    tradable_exchange_contract_address=tradable_exchange_contract_address,
-                                    transfer_approval_required=transfer_approval_required),
+    bond_contrat = IbetStraightBondContract()
+    token_address, _, _ = bond_contrat.create(arguments, address, private_key)
+    bond_contrat.update(
+        data=IbetStraightBondUpdateParams(
+            transferable=True,
+            personal_info_contract_address=personal_info_contract_address,
+            tradable_exchange_contract_address=tradable_exchange_contract_address,
+            transfer_approval_required=transfer_approval_required
+        ),
         tx_from=address,
         private_key=private_key
     )
@@ -115,14 +117,15 @@ def deploy_share_token_contract(address,
         "token.cancellation_date",
         30
     ]
-
-    token_address, _, _ = IbetShareContract.create(arguments, address, private_key)
-    IbetShareContract.update(
-        contract_address=token_address,
-        data=IbetShareUpdate(transferable=True,
-                             personal_info_contract_address=personal_info_contract_address,
-                             tradable_exchange_contract_address=tradable_exchange_contract_address,
-                             transfer_approval_required=transfer_approval_required),
+    share_contract = IbetShareContract()
+    token_address, _, _ = share_contract.create(arguments, address, private_key)
+    share_contract.update(
+        data=IbetShareUpdateParams(
+            transferable=True,
+            personal_info_contract_address=personal_info_contract_address,
+            tradable_exchange_contract_address=tradable_exchange_contract_address,
+            transfer_approval_required=transfer_approval_required
+        ),
         tx_from=address,
         private_key=private_key
     )

--- a/tests/test_batch_indexer_personal_info.py
+++ b/tests/test_batch_indexer_personal_info.py
@@ -45,10 +45,8 @@ from app.model.blockchain import (
     IbetStraightBondContract,
     IbetShareContract
 )
-from app.model.schema import (
-    IbetStraightBondUpdate,
-    IbetShareUpdate
-)
+from app.model.blockchain.tx_params.ibet_straight_bond import UpdateParams as IbetStraightBondUpdateParams
+from app.model.blockchain.tx_params.ibet_share import UpdateParams as IbetShareUpdateParams
 from app.utils.web3_utils import Web3Wrapper
 from app.utils.contract_utils import ContractUtils
 from app.utils.e2ee_utils import E2EEUtils
@@ -96,14 +94,15 @@ def deploy_bond_token_contract(address,
         "token.return_amount",
         "token.purpose"
     ]
-
-    token_address, _, _ = IbetStraightBondContract.create(arguments, address, private_key)
-    IbetStraightBondContract.update(
-        contract_address=token_address,
-        data=IbetStraightBondUpdate(transferable=True,
-                                    personal_info_contract_address=personal_info_contract_address,
-                                    tradable_exchange_contract_address=tradable_exchange_contract_address,
-                                    transfer_approval_required=transfer_approval_required),
+    bond_contrat = IbetStraightBondContract()
+    token_address, _, _ = bond_contrat.create(arguments, address, private_key)
+    bond_contrat.update(
+        data=IbetStraightBondUpdateParams(
+            transferable=True,
+            personal_info_contract_address=personal_info_contract_address,
+            tradable_exchange_contract_address=tradable_exchange_contract_address,
+            transfer_approval_required=transfer_approval_required
+        ),
         tx_from=address,
         private_key=private_key
     )
@@ -127,14 +126,15 @@ def deploy_share_token_contract(address,
         "token.cancellation_date",
         30
     ]
-
-    token_address, _, _ = IbetShareContract.create(arguments, address, private_key)
-    IbetShareContract.update(
-        contract_address=token_address,
-        data=IbetShareUpdate(transferable=True,
-                             personal_info_contract_address=personal_info_contract_address,
-                             tradable_exchange_contract_address=tradable_exchange_contract_address,
-                             transfer_approval_required=transfer_approval_required),
+    share_contract = IbetShareContract()
+    token_address, _, _ = share_contract.create(arguments, address, private_key)
+    share_contract.update(
+        data=IbetShareUpdateParams(
+            transferable=True,
+            personal_info_contract_address=personal_info_contract_address,
+            tradable_exchange_contract_address=tradable_exchange_contract_address,
+            transfer_approval_required=transfer_approval_required
+        ),
         tx_from=address,
         private_key=private_key
     )

--- a/tests/test_batch_indexer_position_bond.py
+++ b/tests/test_batch_indexer_position_bond.py
@@ -35,7 +35,7 @@ from app.model.db import (
     IDXUnlock
 )
 from app.model.blockchain import IbetStraightBondContract
-from app.model.schema import IbetStraightBondUpdate
+from app.model.blockchain.tx_params.ibet_straight_bond import UpdateParams as IbetStraightBondUpdateParams
 from app.utils.web3_utils import Web3Wrapper
 from app.utils.contract_utils import ContractUtils
 from batch.indexer_position_bond import Processor, LOG, main
@@ -89,14 +89,15 @@ def deploy_bond_token_contract(address,
         "token.return_amount",
         "token.purpose"
     ]
-
-    token_address, _, _ = IbetStraightBondContract.create(arguments, address, private_key)
-    IbetStraightBondContract.update(
-        contract_address=token_address,
-        data=IbetStraightBondUpdate(transferable=True,
-                                    personal_info_contract_address=personal_info_contract_address,
-                                    tradable_exchange_contract_address=tradable_exchange_contract_address,
-                                    transfer_approval_required=transfer_approval_required),
+    bond_contrat = IbetStraightBondContract()
+    token_address, _, _ = bond_contrat.create(arguments, address, private_key)
+    bond_contrat.update(
+        data=IbetStraightBondUpdateParams(
+            transferable=True,
+            personal_info_contract_address=personal_info_contract_address,
+            tradable_exchange_contract_address=tradable_exchange_contract_address,
+            transfer_approval_required=transfer_approval_required
+        ),
         tx_from=address,
         private_key=private_key
     )

--- a/tests/test_batch_indexer_position_share.py
+++ b/tests/test_batch_indexer_position_share.py
@@ -35,7 +35,7 @@ from app.model.db import (
     IDXUnlock
 )
 from app.model.blockchain import IbetShareContract
-from app.model.schema import IbetShareUpdate
+from app.model.blockchain.tx_params.ibet_share import UpdateParams as IbetShareUpdateParams
 from app.utils.web3_utils import Web3Wrapper
 from app.utils.contract_utils import ContractUtils
 from batch.indexer_position_share import Processor, LOG, main
@@ -89,14 +89,15 @@ def deploy_share_token_contract(address,
         "token.cancellation_date",
         30
     ]
-
-    token_address, _, _ = IbetShareContract.create(arguments, address, private_key)
-    IbetShareContract.update(
-        contract_address=token_address,
-        data=IbetShareUpdate(transferable=True,
-                             personal_info_contract_address=personal_info_contract_address,
-                             tradable_exchange_contract_address=tradable_exchange_contract_address,
-                             transfer_approval_required=transfer_approval_required),
+    share_contract = IbetShareContract()
+    token_address, _, _ = share_contract.create(arguments, address, private_key)
+    share_contract.update(
+        data=IbetShareUpdateParams(
+            transferable=True,
+            personal_info_contract_address=personal_info_contract_address,
+            tradable_exchange_contract_address=tradable_exchange_contract_address,
+            transfer_approval_required=transfer_approval_required
+        ),
         tx_from=address,
         private_key=private_key
     )

--- a/tests/test_batch_indexer_token_holders.py
+++ b/tests/test_batch_indexer_token_holders.py
@@ -30,7 +30,8 @@ from app.model.blockchain import (
     IbetStraightBondContract,
     IbetShareContract,
 )
-from app.model.schema import IbetStraightBondUpdate, IbetShareUpdate
+from app.model.blockchain.tx_params.ibet_straight_bond import UpdateParams as IbetStraightBondUpdateParams
+from app.model.blockchain.tx_params.ibet_share import UpdateParams as IbetShareUpdateParams
 from app.utils.web3_utils import Web3Wrapper
 from app.utils.contract_utils import ContractUtils
 from batch.indexer_token_holders import Processor, LOG, main
@@ -96,11 +97,10 @@ def deploy_bond_token_contract(
         "token.return_amount",
         "token.purpose",
     ]
-
-    token_address, _, _ = IbetStraightBondContract.create(arguments, address, private_key)
-    IbetStraightBondContract.update(
-        contract_address=token_address,
-        data=IbetStraightBondUpdate(
+    bond_contrat = IbetStraightBondContract()
+    token_address, _, _ = bond_contrat.create(arguments, address, private_key)
+    bond_contrat.update(
+        data=IbetStraightBondUpdateParams(
             transferable=True,
             personal_info_contract_address=personal_info_contract_address,
             tradable_exchange_contract_address=tradable_exchange_contract_address,
@@ -131,11 +131,10 @@ def deploy_share_token_contract(
         "token.cancellation_date",
         30,
     ]
-
-    token_address, _, _ = IbetShareContract.create(arguments, address, private_key)
-    IbetShareContract.update(
-        contract_address=token_address,
-        data=IbetShareUpdate(
+    share_contract = IbetShareContract()
+    token_address, _, _ = share_contract.create(arguments, address, private_key)
+    share_contract.update(
+        data=IbetShareUpdateParams(
             transferable=True,
             personal_info_contract_address=personal_info_contract_address,
             tradable_exchange_contract_address=tradable_exchange_contract_address,

--- a/tests/test_batch_indexer_transfer.py
+++ b/tests/test_batch_indexer_transfer.py
@@ -83,9 +83,11 @@ def deploy_bond_token_contract(address,
     token_address, _, _ = bond_contrat.create(arguments, address, private_key)
     bond_contrat.update(
         data=IbetStraightBondUpdateParams(
-                                    personal_info_contract_address=personal_info_contract_address,
-                                    tradable_exchange_contract_address=tradable_exchange_contract_address,
-                                    transfer_approval_required=transfer_approval_required),
+            transferable=True,
+            personal_info_contract_address=personal_info_contract_address,
+            tradable_exchange_contract_address=tradable_exchange_contract_address,
+            transfer_approval_required=transfer_approval_required
+        ),
         tx_from=address,
         private_key=private_key
     )

--- a/tests/test_batch_indexer_transfer.py
+++ b/tests/test_batch_indexer_transfer.py
@@ -28,7 +28,8 @@ from unittest.mock import patch
 from app.exceptions import ServiceUnavailableError
 from app.model.db import Token, TokenType, IDXTransfer, IDXTransferBlockNumber
 from app.model.blockchain import IbetStraightBondContract, IbetShareContract
-from app.model.schema import IbetStraightBondUpdate, IbetShareUpdate
+from app.model.blockchain.tx_params.ibet_straight_bond import UpdateParams as IbetStraightBondUpdateParams
+from app.model.blockchain.tx_params.ibet_share import UpdateParams as IbetShareUpdateParams
 from app.utils.web3_utils import Web3Wrapper
 from app.utils.contract_utils import ContractUtils
 from batch.indexer_transfer import Processor, LOG, main
@@ -78,11 +79,10 @@ def deploy_bond_token_contract(address,
         "token.return_amount",
         "token.purpose"
     ]
-
-    token_address, _, _ = IbetStraightBondContract.create(arguments, address, private_key)
-    IbetStraightBondContract.update(
-        contract_address=token_address,
-        data=IbetStraightBondUpdate(transferable=True,
+    bond_contrat = IbetStraightBondContract()
+    token_address, _, _ = bond_contrat.create(arguments, address, private_key)
+    bond_contrat.update(
+        data=IbetStraightBondUpdateParams(
                                     personal_info_contract_address=personal_info_contract_address,
                                     tradable_exchange_contract_address=tradable_exchange_contract_address,
                                     transfer_approval_required=transfer_approval_required),
@@ -109,14 +109,15 @@ def deploy_share_token_contract(address,
         "token.cancellation_date",
         30
     ]
-
-    token_address, _, _ = IbetShareContract.create(arguments, address, private_key)
-    IbetShareContract.update(
-        contract_address=token_address,
-        data=IbetShareUpdate(transferable=True,
-                             personal_info_contract_address=personal_info_contract_address,
-                             tradable_exchange_contract_address=tradable_exchange_contract_address,
-                             transfer_approval_required=transfer_approval_required),
+    share_contract = IbetShareContract()
+    token_address, _, _ = share_contract.create(arguments, address, private_key)
+    share_contract.update(
+        data=IbetShareUpdateParams(
+            transferable=True,
+            personal_info_contract_address=personal_info_contract_address,
+            tradable_exchange_contract_address=tradable_exchange_contract_address,
+            transfer_approval_required=transfer_approval_required,
+        ),
         tx_from=address,
         private_key=private_key
     )

--- a/tests/test_batch_indexer_transfer_approval.py
+++ b/tests/test_batch_indexer_transfer_approval.py
@@ -37,7 +37,8 @@ from app.model.db import (
     NotificationType
 )
 from app.model.blockchain import IbetStraightBondContract, IbetShareContract
-from app.model.schema import IbetStraightBondUpdate, IbetShareUpdate
+from app.model.blockchain.tx_params.ibet_straight_bond import UpdateParams as IbetStraightBondUpdateParams
+from app.model.blockchain.tx_params.ibet_share import UpdateParams as IbetShareUpdateParams
 from app.utils.web3_utils import Web3Wrapper
 from app.utils.contract_utils import ContractUtils
 from batch.indexer_transfer_approval import Processor, LOG, main
@@ -90,16 +91,17 @@ def deploy_bond_token_contract(address,
         "token.return_amount",
         "token.purpose"
     ]
-
-    token_address, _, _ = IbetStraightBondContract.create(arguments, address, private_key)
-    IbetStraightBondContract.update(
-        contract_address=token_address,
-        data=IbetStraightBondUpdate(transferable=True,
-                                    personal_info_contract_address=personal_info_contract_address,
-                                    tradable_exchange_contract_address=tradable_exchange_contract_address,
-                                    transfer_approval_required=transfer_approval_required),
+    bond_contrat = IbetStraightBondContract()
+    token_address, _, _ = bond_contrat.create(arguments, address, private_key)
+    bond_contrat.update(
+        data=IbetStraightBondUpdateParams(
+            transferable=True,
+            personal_info_contract_address=personal_info_contract_address,
+            tradable_exchange_contract_address=tradable_exchange_contract_address,
+            transfer_approval_required=transfer_approval_required,
+        ),
         tx_from=address,
-        private_key=private_key
+        private_key=private_key,
     )
 
     return ContractUtils.get_contract("IbetStraightBond", token_address)
@@ -121,16 +123,17 @@ def deploy_share_token_contract(address,
         "token.cancellation_date",
         30
     ]
-
-    token_address, _, _ = IbetShareContract.create(arguments, address, private_key)
-    IbetShareContract.update(
-        contract_address=token_address,
-        data=IbetShareUpdate(transferable=True,
-                             personal_info_contract_address=personal_info_contract_address,
-                             tradable_exchange_contract_address=tradable_exchange_contract_address,
-                             transfer_approval_required=transfer_approval_required),
+    share_contract = IbetShareContract()
+    token_address, _, _ = share_contract.create(arguments, address, private_key)
+    share_contract.update(
+        data=IbetShareUpdateParams(
+            transferable=True,
+            personal_info_contract_address=personal_info_contract_address,
+            tradable_exchange_contract_address=tradable_exchange_contract_address,
+            transfer_approval_required=transfer_approval_required,
+        ),
         tx_from=address,
-        private_key=private_key
+        private_key=private_key,
     )
 
     return ContractUtils.get_contract("IbetShare", token_address)

--- a/tests/test_batch_processor_batch_issue_redeem.py
+++ b/tests/test_batch_processor_batch_issue_redeem.py
@@ -120,7 +120,6 @@ class TestProcessor:
 
             # Assertion: contract
             IbetStraightBondContract_additional_issue.assert_called_with(
-                contract_address=token_address,
                 data=IbetStraightBondAdditionalIssue(
                     account_address=target_address,
                     amount=target_amount
@@ -219,7 +218,6 @@ class TestProcessor:
 
         # Assertion: contract
         IbetStraightBondContract_redeem.assert_called_with(
-            contract_address=token_address,
             data=IbetStraightBondRedeem(
                 account_address=target_address,
                 amount=target_amount
@@ -318,7 +316,6 @@ class TestProcessor:
 
         # Assertion: contract
         IbetShareContract_additional_issue.assert_called_with(
-            contract_address=token_address,
             data=IbetShareAdditionalIssue(
                 account_address=target_address,
                 amount=target_amount
@@ -417,7 +414,6 @@ class TestProcessor:
 
         # Assertion: contract
         IbetShareContract_redeem.assert_called_with(
-            contract_address=token_address,
             data=IbetShareRedeem(
                 account_address=target_address,
                 amount=target_amount

--- a/tests/test_batch_processor_create_utxo.py
+++ b/tests/test_batch_processor_create_utxo.py
@@ -81,10 +81,9 @@ def deploy_bond_token_contract(address, private_key):
         "token.return_amount",
         "token.purpose"
     ]
-
-    contract_address, _, _ = IbetStraightBondContract.create(arguments, address, private_key)
-    IbetStraightBondContract.update(
-        contract_address,
+    bond_contrat = IbetStraightBondContract()
+    contract_address, _, _ = bond_contrat.create(arguments, address, private_key)
+    bond_contrat.update(
         IbetStraightBondUpdateParams(transferable=True),
         address,
         private_key
@@ -105,10 +104,9 @@ def deploy_share_token_contract(address, private_key):
         "token.cancellation_date",
         30
     ]
-
-    contract_address, _, _ = IbetShareContract.create(arguments, address, private_key)
-    IbetShareContract.update(
-        contract_address,
+    share_contract = IbetShareContract()
+    contract_address, _, _ = share_contract.create(arguments, address, private_key)
+    share_contract.update(
         IbetShareUpdateParams(transferable=True),
         address,
         private_key
@@ -178,7 +176,7 @@ class TestProcessor:
             to_address=user_address_1,
             amount=70
         )
-        IbetShareContract.transfer(token_address_2, _transfer_1, issuer_address, issuer_private_key)
+        IbetShareContract(token_address_2).transfer(_transfer_1, issuer_address, issuer_private_key)
         time.sleep(1)
 
         # Bond:issuer -> user1
@@ -187,7 +185,7 @@ class TestProcessor:
             to_address=user_address_1,
             amount=40
         )
-        IbetStraightBondContract.transfer(token_address_1, _transfer_2, issuer_address, issuer_private_key)
+        IbetStraightBondContract(token_address_1).transfer(_transfer_2, issuer_address, issuer_private_key)
         time.sleep(1)
 
         # Bond:issuer -> user2
@@ -196,7 +194,7 @@ class TestProcessor:
             to_address=user_address_2,
             amount=20
         )
-        IbetStraightBondContract.transfer(token_address_1, _transfer_3, issuer_address, issuer_private_key)
+        IbetStraightBondContract(token_address_1).transfer(_transfer_3, issuer_address, issuer_private_key)
         time.sleep(1)
 
         # Share:user1 -> user2
@@ -205,7 +203,7 @@ class TestProcessor:
             to_address=user_address_2,
             amount=10
         )
-        IbetShareContract.transfer(token_address_2, _transfer_4, issuer_address, issuer_private_key)
+        IbetShareContract(token_address_2).transfer(_transfer_4, issuer_address, issuer_private_key)
         time.sleep(1)
 
         # Execute batch(Run 2nd)
@@ -295,22 +293,22 @@ class TestProcessor:
             to_address=user_address_1,
             amount=60
         )
-        IbetStraightBondContract.transfer(token_address_1, _transfer, issuer_address, issuer_private_key)
+        IbetStraightBondContract(token_address_1).transfer(_transfer, issuer_address, issuer_private_key)
         time.sleep(1)
         _transfer = IbetStraightBondTransferParams(
             from_address=user_address_1,
             to_address=user_address_2,
             amount=10
         )
-        IbetStraightBondContract.transfer(token_address_1, _transfer, issuer_address, issuer_private_key)
+        IbetStraightBondContract(token_address_1).transfer(_transfer, issuer_address, issuer_private_key)
         time.sleep(1)
-        IbetStraightBondContract.transfer(token_address_1, _transfer, issuer_address, issuer_private_key)
+        IbetStraightBondContract(token_address_1).transfer(_transfer, issuer_address, issuer_private_key)
         time.sleep(1)
-        IbetStraightBondContract.transfer(token_address_1, _transfer, issuer_address, issuer_private_key)
+        IbetStraightBondContract(token_address_1).transfer(_transfer, issuer_address, issuer_private_key)
         time.sleep(1)
-        IbetStraightBondContract.transfer(token_address_1, _transfer, issuer_address, issuer_private_key)
+        IbetStraightBondContract(token_address_1).transfer(_transfer, issuer_address, issuer_private_key)
         time.sleep(1)
-        IbetStraightBondContract.transfer(token_address_1, _transfer, issuer_address, issuer_private_key)
+        IbetStraightBondContract(token_address_1).transfer(_transfer, issuer_address, issuer_private_key)
         time.sleep(1)
 
         # Execute batch
@@ -392,8 +390,11 @@ class TestProcessor:
         # set personal info
         personal_contract_address, _, _ = ContractUtils.deploy_contract(
             "PersonalInfo", [], issuer_address, issuer_private_key)
-        IbetStraightBondContract.update(token_address_1, IbetStraightBondUpdateParams(
-            personal_info_contract_address=personal_contract_address), issuer_address, issuer_private_key)
+        IbetStraightBondContract(token_address_1).update(
+            IbetStraightBondUpdateParams(personal_info_contract_address=personal_contract_address),
+            issuer_address,
+            issuer_private_key
+        )
         personal_contract = ContractUtils.get_contract("PersonalInfo", personal_contract_address)
         tx = personal_contract.functions.register(issuer_address, "").build_transaction(
             {
@@ -482,7 +483,7 @@ class TestProcessor:
         })
         ContractUtils.send_transaction(tx, issuer_private_key)
         update_data = IbetStraightBondUpdateParams(tradable_exchange_contract_address=exchange_address)
-        IbetStraightBondContract.update(token_address_1, update_data, issuer_address, issuer_private_key)
+        IbetStraightBondContract(token_address_1).update(update_data, issuer_address, issuer_private_key)
 
         # Execute Transfer Event
         # Bond:issuer -> Exchange
@@ -491,7 +492,7 @@ class TestProcessor:
             to_address=exchange_address,
             amount=100
         )
-        IbetStraightBondContract.transfer(token_address_1, _transfer_1, issuer_address, issuer_private_key)
+        IbetStraightBondContract(token_address_1).transfer(_transfer_1, issuer_address, issuer_private_key)
 
         # Execute batch
         # Assume: Not Create UTXO and Ledger
@@ -544,7 +545,7 @@ class TestProcessor:
             account_address=user_address_1,
             amount=70
         )
-        IbetShareContract.additional_issue(token_address_1, _additional_issue_1, issuer_address, issuer_private_key)
+        IbetShareContract(token_address_1).additional_issue(_additional_issue_1, issuer_address, issuer_private_key)
         time.sleep(1)
 
         # Bond
@@ -552,7 +553,7 @@ class TestProcessor:
             account_address=user_address_2,
             amount=80
         )
-        IbetStraightBondContract.additional_issue(token_address_2, _additional_issue_2, issuer_address, issuer_private_key)
+        IbetStraightBondContract(token_address_2).additional_issue(_additional_issue_2, issuer_address, issuer_private_key)
         time.sleep(1)
 
         # Execute batch
@@ -618,13 +619,13 @@ class TestProcessor:
             account_address=user_address_1,
             amount=10
         )
-        IbetShareContract.additional_issue(token_address_1, _additional_issue_1, issuer_address, issuer_private_key)
+        IbetShareContract(token_address_1).additional_issue(_additional_issue_1, issuer_address, issuer_private_key)
         time.sleep(1)
         _additional_issue_2 = IbetShareAdditionalIssueParams(
             account_address=user_address_1,
             amount=20
         )
-        IbetShareContract.additional_issue(token_address_1, _additional_issue_2, issuer_address, issuer_private_key)
+        IbetShareContract(token_address_1).additional_issue(_additional_issue_2, issuer_address, issuer_private_key)
         time.sleep(1)
 
         # Bond
@@ -632,13 +633,13 @@ class TestProcessor:
             account_address=user_address_2,
             amount=30
         )
-        IbetStraightBondContract.additional_issue(token_address_2, _additional_issue_3, issuer_address, issuer_private_key)
+        IbetStraightBondContract(token_address_2).additional_issue(_additional_issue_3, issuer_address, issuer_private_key)
         time.sleep(1)
         _additional_issue_4 = IbetStraightBondAdditionalIssueParams(
             account_address=user_address_2,
             amount=40
         )
-        IbetStraightBondContract.additional_issue(token_address_2, _additional_issue_4, issuer_address, issuer_private_key)
+        IbetStraightBondContract(token_address_2).additional_issue(_additional_issue_4, issuer_address, issuer_private_key)
         time.sleep(1)
 
         # Before execute
@@ -672,7 +673,7 @@ class TestProcessor:
             account_address=user_address_1,
             amount=20
         )
-        IbetShareContract.redeem(token_address_1, _redeem_1, issuer_address, issuer_private_key)
+        IbetShareContract(token_address_1).redeem(_redeem_1, issuer_address, issuer_private_key)
         time.sleep(1)
 
         # Bond
@@ -680,7 +681,7 @@ class TestProcessor:
             account_address=user_address_2,
             amount=40
         )
-        IbetStraightBondContract.redeem(token_address_2, _redeem_2, issuer_address, issuer_private_key)
+        IbetStraightBondContract(token_address_2).redeem(_redeem_2, issuer_address, issuer_private_key)
         time.sleep(1)
 
         # Execute batch

--- a/tests/test_batch_processor_modify_personal_info.py
+++ b/tests/test_batch_processor_modify_personal_info.py
@@ -32,6 +32,8 @@ from app.model.blockchain import (
     IbetShareContract,
     PersonalInfoContract
 )
+from app.model.blockchain.tx_params.ibet_straight_bond import UpdateParams as IbetStraightBondUpdateParams
+from app.model.blockchain.tx_params.ibet_share import UpdateParams as IbetShareUpdateParams
 from app.utils.contract_utils import ContractUtils
 from app.model.db import (
     Account,
@@ -42,10 +44,6 @@ from app.model.db import (
     IDXPersonalInfo
 )
 from app.utils.e2ee_utils import E2EEUtils
-from app.model.schema import (
-    IbetStraightBondUpdate,
-    IbetShareUpdate
-)
 from batch.processor_modify_personal_info import Processor
 from tests.account_config import config_eth_account
 
@@ -115,12 +113,13 @@ def deploy_bond_token_contract(issuer_user, personal_info_contract_address):
         password=eoa_password.encode("utf-8")
     )
 
-    contract_address, _, _ = IbetStraightBondContract.create(arguments, address, private_key)
+    bond_contract = IbetStraightBondContract()
+    contract_address, _, _ = bond_contract.create(arguments, address, private_key)
 
     if personal_info_contract_address:
-        data = IbetStraightBondUpdate()
+        data = IbetStraightBondUpdateParams()
         data.personal_info_contract_address = personal_info_contract_address
-        IbetStraightBondContract.update(contract_address, data, address, private_key)
+        bond_contract.update(data, address, private_key)
 
     return contract_address
 
@@ -147,12 +146,13 @@ def deploy_share_token_contract(issuer_user, personal_info_contract_address):
         password=eoa_password.encode("utf-8")
     )
 
-    contract_address, _, _ = IbetShareContract.create(arguments, address, private_key)
+    share_contract = IbetShareContract()
+    contract_address, _, _ = share_contract.create(arguments, address, private_key)
 
     if personal_info_contract_address:
-        data = IbetShareUpdate()
+        data = IbetShareUpdateParams()
         data.personal_info_contract_address = personal_info_contract_address
-        IbetShareContract.update(contract_address, data, address, private_key)
+        share_contract.update(data, address, private_key)
 
     return contract_address
 

--- a/tests/test_batch_processor_register_personal_info.py
+++ b/tests/test_batch_processor_register_personal_info.py
@@ -22,17 +22,19 @@ import pytest
 from eth_keyfile import decode_keyfile_json
 from sqlalchemy.orm import Session
 from unittest.mock import patch
-from app.model.blockchain import IbetShareContract
 
+from app.model.blockchain import IbetShareContract
+from app.model.blockchain.tx_params.ibet_share import UpdateParams as IbetShareUpdateParams
 from app.model.db import (
     Account,
-    BulkTransfer,
-    BulkTransferUpload,
     TokenType,
     Notification,
-    NotificationType, BatchRegisterPersonalInfoUpload, BatchRegisterPersonalInfo, BatchRegisterPersonalInfoUploadStatus, Token
+    NotificationType,
+    BatchRegisterPersonalInfoUpload,
+    BatchRegisterPersonalInfo,
+    BatchRegisterPersonalInfoUploadStatus,
+    Token
 )
-from app.model.schema import IbetShareUpdate
 from app.utils.contract_utils import ContractUtils
 from app.utils.e2ee_utils import E2EEUtils
 from app.exceptions import SendTransactionError, ContractRevertError
@@ -107,14 +109,15 @@ class TestProcessor:
             "token.cancellation_date",
             30
         ]
-
-        token_address, _, _ = IbetShareContract.create(arguments, address, private_key)
-        IbetShareContract.update(
-            contract_address=token_address,
-            data=IbetShareUpdate(transferable=True,
-                                 personal_info_contract_address=personal_info_contract_address,
-                                 tradable_exchange_contract_address=tradable_exchange_contract_address,
-                                 transfer_approval_required=transfer_approval_required),
+        share_contract = IbetShareContract()
+        token_address, _, _ = share_contract.create(arguments, address, private_key)
+        share_contract.update(
+            data=IbetShareUpdateParams(
+                transferable=True,
+                personal_info_contract_address=personal_info_contract_address,
+                tradable_exchange_contract_address=tradable_exchange_contract_address,
+                transfer_approval_required=transfer_approval_required
+            ),
             tx_from=address,
             private_key=private_key
         )

--- a/tests/test_batch_processor_rotate_e2e_messaging_rsa_key.py
+++ b/tests/test_batch_processor_rotate_e2e_messaging_rsa_key.py
@@ -275,13 +275,11 @@ class TestProcessor:
             # # Assertion
             assert user_address_2 < user_address_1
             E2EMessaging.set_public_key.assert_has_calls([
-                call(contract_address=e2e_messaging_contract.address,
-                     public_key=ANY,
+                call(public_key=ANY,
                      key_type="RSA4096",
                      tx_from=user_address_2,
                      private_key=user_private_key_2),
-                call(contract_address=e2e_messaging_contract.address,
-                     public_key=ANY,
+                call(public_key=ANY,
                      key_type="RSA4096",
                      tx_from=user_address_1,
                      private_key=user_private_key_1),
@@ -425,7 +423,6 @@ class TestProcessor:
 
             # Assertion
             E2EMessaging.set_public_key.assert_called_with(
-                contract_address=e2e_messaging_contract.address,
                 public_key=ANY,
                 key_type="RSA4096",
                 tx_from=user_address_1,
@@ -482,7 +479,6 @@ class TestProcessor:
 
             # Assertion
             E2EMessaging.set_public_key.assert_called_with(
-                contract_address=e2e_messaging_contract.address,
                 public_key=ANY,
                 key_type="RSA4096",
                 tx_from=user_address_1,

--- a/tests/test_batch_processor_update_token.py
+++ b/tests/test_batch_processor_update_token.py
@@ -192,7 +192,6 @@ class TestProcessor:
 
             # assertion(contract)
             IbetShareContract_update.assert_called_with(
-                contract_address=_token_address_1,
                 data=IbetShareUpdate(
                     cancellation_date=None,
                     dividend_record_date=None,
@@ -213,7 +212,6 @@ class TestProcessor:
             )
 
             IbetStraightBondContract_update.assert_called_with(
-                contract_address=_token_address_2,
                 data=IbetStraightBondUpdate(
                     interest_rate=0.0001,
                     interest_payment_date=["0331", "0930"],
@@ -1061,7 +1059,6 @@ class TestProcessor:
 
             # assertion(contract)
             IbetShareContract_update.assert_called_with(
-                contract_address=_token_address_1,
                 data=IbetShareUpdate(
                     cancellation_date=None,
                     dividend_record_date=None,
@@ -1082,7 +1079,6 @@ class TestProcessor:
             )
 
             IbetStraightBondContract_update.assert_called_with(
-                contract_address=_token_address_2,
                 data=IbetStraightBondUpdate(
                     interest_rate=0.0001,
                     interest_payment_date=["0331", "0930"],

--- a/tests/test_batch_processor_update_token.py
+++ b/tests/test_batch_processor_update_token.py
@@ -230,15 +230,13 @@ class TestProcessor:
             )
 
             TokenListContract_register.assert_has_calls([
-                call(token_list_address=TOKEN_LIST_CONTRACT_ADDRESS,
-                     token_address=_token_address_1,
+                call(token_address=_token_address_1,
                      token_template=TokenType.IBET_SHARE.value,
-                     account_address=_issuer_address,
+                     tx_from=_issuer_address,
                      private_key=ANY),
-                call(token_list_address=TOKEN_LIST_CONTRACT_ADDRESS,
-                     token_address=_token_address_2,
+                call(token_address=_token_address_2,
                      token_template=TokenType.IBET_STRAIGHT_BOND.value,
-                     account_address=_issuer_address,
+                     tx_from=_issuer_address,
                      private_key=ANY),
             ])
 

--- a/tests/test_utils_ledger_utils.py
+++ b/tests/test_utils_ledger_utils.py
@@ -36,11 +36,9 @@ from app.model.blockchain import (
     IbetStraightBondContract,
     PersonalInfoContract,
 )
+from app.model.blockchain.tx_params.ibet_straight_bond import UpdateParams as IbetStraightBondUpdateParams
+from app.model.blockchain.tx_params.ibet_share import UpdateParams as IbetShareUpdateParams
 from app.utils.contract_utils import ContractUtils
-from app.model.schema import (
-    IbetShareUpdate,
-    IbetStraightBondUpdate
-)
 from app.model.db import (
     Account,
     AccountRsaStatus,
@@ -75,12 +73,12 @@ def deploy_bond_token_contract(address, private_key, personal_info_contract_addr
         "token.return_amount",
         "token.purpose"
     ]
+    bond_contrat = IbetStraightBondContract()
+    contract_address, _, _ = bond_contrat.create(arguments, address, private_key)
 
-    contract_address, _, _ = IbetStraightBondContract.create(arguments, address, private_key)
-
-    data = IbetStraightBondUpdate()
+    data = IbetStraightBondUpdateParams()
     data.personal_info_contract_address = personal_info_contract_address
-    IbetStraightBondContract.update(contract_address, data, address, private_key)
+    bond_contrat.update(data, address, private_key)
 
     return contract_address
 
@@ -97,12 +95,12 @@ def deploy_share_token_contract(address, private_key, personal_info_contract_add
         "token.cancellation_date",
         200
     ]
+    share_contract = IbetShareContract()
+    contract_address, _, _ = share_contract.create(arguments, address, private_key)
 
-    contract_address, _, _ = IbetShareContract.create(arguments, address, private_key)
-
-    data = IbetShareUpdate()
+    data = IbetShareUpdateParams()
     data.personal_info_contract_address = personal_info_contract_address
-    IbetShareContract.update(contract_address, data, address, private_key)
+    share_contract.update(data, address, private_key)
 
     return contract_address
 


### PR DESCRIPTION
The current contract classes (model layer for blockchain) is stateless, where the contract address is entered for each function execution, but this is difficult for developers to understand, so I refactored them.