### PR TITLE
Add token update operation log for audit

### DIFF
--- a/app/model/db/__init__.py
+++ b/app/model/db/__init__.py
@@ -69,6 +69,10 @@ from .notification import Notification, NotificationType
 from .scheduled_events import ScheduledEvents, ScheduledEventType
 from .token import Token, TokenAttrUpdate, TokenCache, TokenType
 from .token_holders import TokenHolder, TokenHolderBatchStatus, TokenHoldersList
+from .token_update_operation_log import (
+    TokenUpdateOperationCategory,
+    TokenUpdateOperationLog,
+)
 from .transfer_appoval_history import (
     TransferApprovalHistory,
     TransferApprovalOperationType,

--- a/app/model/db/token_update_operation_log.py
+++ b/app/model/db/token_update_operation_log.py
@@ -18,33 +18,34 @@ SPDX-License-Identifier: Apache-2.0
 """
 from enum import StrEnum
 
-from sqlalchemy import JSON, Integer, String
+from sqlalchemy import JSON, BigInteger, String
 from sqlalchemy.orm import Mapped, mapped_column
 
-from .base import Base
+from app.model.db import Base
 
 
-class UpdateToken(Base):
-    """Update Token"""
+class TokenUpdateOperationLog(Base):
+    """Token Update Operation Log"""
 
-    __tablename__ = "update_token"
+    __tablename__ = "token_update_operation_log"
 
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
     # token address
-    token_address: Mapped[str | None] = mapped_column(String(42), index=True)
+    token_address: Mapped[str] = mapped_column(String(42), index=True, nullable=False)
     # issuer address
-    issuer_address: Mapped[str | None] = mapped_column(String(42), nullable=True)
-    # token type
+    issuer_address: Mapped[str] = mapped_column(String(42), nullable=False)
+    # token type(TokenType)
     type: Mapped[str] = mapped_column(String(40), nullable=False)
     # arguments
     arguments: Mapped[dict] = mapped_column(JSON, nullable=False)
-    # processing status (pending:0, succeeded:1, failed:2)
-    status: Mapped[int] = mapped_column(Integer, nullable=False)
-    # update trigger
-    trigger: Mapped[str] = mapped_column(String(40), nullable=False)
+    # original contents
+    original_contents: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    # operation category(TokenUpdateOperationCategory)
+    operation_category: Mapped[str] = mapped_column(String(40), nullable=False)
 
 
-class UpdateTokenTrigger(StrEnum):
-    """Trigger of update token"""
+class TokenUpdateOperationCategory(StrEnum):
+    """Operation category of update token"""
 
     ISSUE = "Issue"
+    UPDATE = "Update"

--- a/app/model/schema/__init__.py
+++ b/app/model/schema/__init__.py
@@ -114,11 +114,11 @@ from .token import (
     ListAllTokenLockEventsQuery,
     ListAllTokenLockEventsResponse,
     ListAllTokenLockEventsSortItem,
-    ListTokenHistoryQuery,
-    ListTokenHistoryResponse,
+    ListTokenHistorySortItem,
+    ListTokenOperationLogHistoryQuery,
+    ListTokenOperationLogHistoryResponse,
     TokenAddressResponse,
-    TokenHistoryResponse,
-    UpdateTokenTrigger,
+    TokenUpdateOperationCategory,
 )
 from .token_holders import (
     CreateTokenHoldersListRequest,

--- a/app/model/schema/token.py
+++ b/app/model/schema/token.py
@@ -382,8 +382,8 @@ class ListAllTokenLockEventsQuery:
     )
 
 
-class UpdateTokenTrigger(StrEnum):
-    """Trigger of update token"""
+class TokenUpdateOperationCategory(StrEnum):
+    """Operation category of update token"""
 
     ISSUE = "Issue"
     UPDATE = "Update"
@@ -393,15 +393,15 @@ class ListTokenHistorySortItem(StrEnum):
     """Sort item of token history"""
 
     created = "created"
-    trigger = "trigger"
+    operation_category = "operation_category"
 
 
 @dataclass
-class ListTokenHistoryQuery:
+class ListTokenOperationLogHistoryQuery:
     modified_contents: Optional[str] = Query(
         default=None, description="Modified contents query"
     )
-    trigger: Optional[UpdateTokenTrigger] = Query(
+    operation_category: Optional[TokenUpdateOperationCategory] = Query(
         default=None, description="Trigger of change"
     )
     created_from: Optional[datetime] = Query(
@@ -490,18 +490,18 @@ class IbetShareResponse(BaseModel):
     memo: str
 
 
-class TokenHistoryResponse(BaseModel):
+class TokenOperationLogResponse(BaseModel):
     original_contents: dict | None = Field(
         default=None, nullable=True, description="original attributes before update"
     )
     modified_contents: dict = Field(..., description="update attributes")
-    trigger: UpdateTokenTrigger
+    operation_category: TokenUpdateOperationCategory
     created: datetime
 
 
-class ListTokenHistoryResponse(BaseModel):
+class ListTokenOperationLogHistoryResponse(BaseModel):
     result_set: ResultSet
-    history: list[TokenHistoryResponse] = Field(
+    history: list[TokenOperationLogResponse] = Field(
         default=[], description="token update histories"
     )
 

--- a/cmd/explorer/src/connector/__init__.py
+++ b/cmd/explorer/src/connector/__init__.py
@@ -22,6 +22,7 @@ from dataclasses import asdict
 from typing import Any
 
 from aiohttp import ClientSession
+
 from cache import AsyncTTL
 
 path = os.path.join(os.path.dirname(__file__), "../../../../")

--- a/migrations/versions/8ed94523e21c_v23_9_0_feature_529.py
+++ b/migrations/versions/8ed94523e21c_v23_9_0_feature_529.py
@@ -1,0 +1,67 @@
+"""v23.9.0_feature_529
+
+Revision ID: 8ed94523e21c
+Revises: fedec7fb783a
+Create Date: 2023-08-07 17:22:33.511682
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import delete
+from sqlalchemy.dialects import postgresql
+
+from app.database import get_db_schema
+from app.model.db import UpdateToken
+
+# revision identifiers, used by Alembic.
+revision = "8ed94523e21c"
+down_revision = "fedec7fb783a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "token_update_operation_log",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("token_address", sa.String(length=42), nullable=False),
+        sa.Column("issuer_address", sa.String(length=42), nullable=False),
+        sa.Column("type", sa.String(length=40), nullable=False),
+        sa.Column("arguments", sa.JSON(), nullable=False),
+        sa.Column("original_contents", sa.JSON(), nullable=True),
+        sa.Column("operation_category", sa.String(length=40), nullable=False),
+        sa.Column("created", sa.DateTime(), nullable=True),
+        sa.Column("modified", sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        schema=get_db_schema(),
+    )
+    op.create_index(
+        op.f("ix_token_update_operation_log_token_address"),
+        "token_update_operation_log",
+        ["token_address"],
+        unique=False,
+        schema=get_db_schema(),
+    )
+    op.drop_column("update_token", "original_contents", schema=get_db_schema())
+
+    # Remove All `update_token` data of which trigger attribute has "Update" value
+    op.get_bind().execute(delete(UpdateToken).where(UpdateToken.trigger == "Update"))
+
+
+def downgrade():
+    op.add_column(
+        "update_token",
+        sa.Column(
+            "original_contents",
+            postgresql.JSON(astext_type=sa.Text()),
+            autoincrement=False,
+            nullable=True,
+        ),
+        schema=get_db_schema(),
+    )
+    op.drop_index(
+        op.f("ix_token_update_operation_log_token_address"),
+        table_name="token_update_operation_log",
+        schema=get_db_schema(),
+    )
+    op.drop_table("token_update_operation_log", schema=get_db_schema())

--- a/tests/model/blockchain/test_token_IbetShare.py
+++ b/tests/model/blockchain/test_token_IbetShare.py
@@ -604,7 +604,9 @@ class TestUpdate:
         assert share_contract.memo == ""
 
         _token_attr_update = db.query(TokenAttrUpdate).first()
-        assert _token_attr_update is None
+        assert _token_attr_update.id == 1
+        assert _token_attr_update.token_address == contract_address
+        assert _token_attr_update.updated_datetime > pre_datetime
 
     # <Normal_2>
     # Update all items

--- a/tests/model/blockchain/test_token_IbetStraightBond.py
+++ b/tests/model/blockchain/test_token_IbetStraightBond.py
@@ -682,7 +682,9 @@ class TestUpdate:
         assert bond_contract.memo == ""
 
         _token_attr_update = db.query(TokenAttrUpdate).first()
-        assert _token_attr_update is None
+        assert _token_attr_update.id == 1
+        assert _token_attr_update.token_address == contract_address
+        assert _token_attr_update.updated_datetime > pre_datetime
 
     # <Normal_2>
     # Update all items

--- a/tests/test_app_routers_bond_tokens_POST.py
+++ b/tests/test_app_routers_bond_tokens_POST.py
@@ -36,6 +36,7 @@ from app.model.db import (
     IDXPosition,
     Token,
     TokenType,
+    TokenUpdateOperationLog,
     UpdateToken,
 )
 from app.utils.contract_utils import ContractUtils
@@ -152,11 +153,10 @@ class TestAppRoutersBondTokensPOST:
             assert utxo.block_number == 12345
             assert utxo.block_timestamp == datetime(2021, 4, 27, 12, 34, 56)
 
-            update_token = db.query(UpdateToken).first()
-            assert update_token.token_address == "contract_address_test1"
-            assert update_token.type == TokenType.IBET_STRAIGHT_BOND.value
-            assert update_token.status == 1
-            assert update_token.trigger == "Issue"
+            operation_log = db.query(TokenUpdateOperationLog).first()
+            assert operation_log.token_address == "contract_address_test1"
+            assert operation_log.type == TokenType.IBET_STRAIGHT_BOND.value
+            assert operation_log.operation_category == "Issue"
 
     # <Normal_2>
     # include updates
@@ -382,11 +382,10 @@ class TestAppRoutersBondTokensPOST:
             assert utxo.block_number == 12345
             assert utxo.block_timestamp == datetime(2021, 4, 27, 12, 34, 56)
 
-            update_token = db.query(UpdateToken).first()
-            assert update_token.token_address == "contract_address_test1"
-            assert update_token.type == TokenType.IBET_STRAIGHT_BOND.value
-            assert update_token.status == 1
-            assert update_token.trigger == "Issue"
+            operation_log = db.query(TokenUpdateOperationLog).first()
+            assert operation_log.token_address == "contract_address_test1"
+            assert operation_log.type == TokenType.IBET_STRAIGHT_BOND.value
+            assert operation_log.operation_category == "Issue"
 
     ###########################################################################
     # Error Case

--- a/tests/test_app_routers_bond_tokens_{token_address}_POST.py
+++ b/tests/test_app_routers_bond_tokens_{token_address}_POST.py
@@ -33,6 +33,7 @@ from app.model.db import (
     Token,
     TokenAttrUpdate,
     TokenType,
+    TokenUpdateOperationLog,
     UpdateToken,
 )
 from app.utils.contract_utils import ContractUtils
@@ -140,10 +141,13 @@ class TestAppRoutersBondTokensTokenAddressPOST:
         assert len(token_attr_update) == 1
 
         update_token = db.query(UpdateToken).first()
-        assert update_token.token_address == _token_address
-        assert update_token.issuer_address == _issuer_address
-        assert update_token.type == TokenType.IBET_STRAIGHT_BOND.value
-        assert update_token.original_contents == {
+        assert update_token is None
+
+        operation_log = db.query(TokenUpdateOperationLog).first()
+        assert operation_log.token_address == _token_address
+        assert operation_log.issuer_address == _issuer_address
+        assert operation_log.type == TokenType.IBET_STRAIGHT_BOND.value
+        assert operation_log.original_contents == {
             "contact_information": "",
             "contract_name": "IbetStraightBond",
             "face_value": 20,
@@ -169,7 +173,7 @@ class TestAppRoutersBondTokensTokenAddressPOST:
             "transfer_approval_required": False,
             "transferable": False,
         }
-        assert update_token.arguments == {
+        assert operation_log.arguments == {
             "face_value": 10000,
             "interest_rate": 0.5,
             "interest_payment_date": ["0101", "0701"],
@@ -185,7 +189,7 @@ class TestAppRoutersBondTokensTokenAddressPOST:
             "transfer_approval_required": True,
             "memo": "m" * 10000,
         }
-        assert update_token.status == 1
+        assert operation_log.operation_category == "Update"
 
     # <Normal_2>
     # No request parameters
@@ -237,10 +241,10 @@ class TestAppRoutersBondTokensTokenAddressPOST:
             .filter(TokenAttrUpdate.token_address == _token_address)
             .all()
         )
-        assert len(token_attr_update) == 0
+        assert len(token_attr_update) == 1
 
-        update_token = db.query(UpdateToken).first()
-        assert update_token is None
+        operation_log = db.query(TokenUpdateOperationLog).first()
+        assert operation_log is not None
 
     # <Normal_3>
     # Authorization by auth token
@@ -319,10 +323,13 @@ class TestAppRoutersBondTokensTokenAddressPOST:
         assert len(token_attr_update) == 1
 
         update_token = db.query(UpdateToken).first()
-        assert update_token.token_address == _token_address
-        assert update_token.issuer_address == _issuer_address
-        assert update_token.type == TokenType.IBET_STRAIGHT_BOND.value
-        assert update_token.original_contents == {
+        assert update_token is None
+
+        operation_log = db.query(TokenUpdateOperationLog).first()
+        assert operation_log.token_address == _token_address
+        assert operation_log.issuer_address == _issuer_address
+        assert operation_log.type == TokenType.IBET_STRAIGHT_BOND.value
+        assert operation_log.original_contents == {
             "contact_information": "",
             "contract_name": "IbetStraightBond",
             "face_value": 20,
@@ -348,7 +355,7 @@ class TestAppRoutersBondTokensTokenAddressPOST:
             "transfer_approval_required": False,
             "transferable": False,
         }
-        assert update_token.arguments == {
+        assert operation_log.arguments == {
             "face_value": 10000,
             "interest_rate": 0.5,
             "interest_payment_date": ["0101", "0701"],
@@ -364,7 +371,7 @@ class TestAppRoutersBondTokensTokenAddressPOST:
             "transfer_approval_required": True,
             "memo": "memo_test1",
         }
-        assert update_token.status == 1
+        assert operation_log.operation_category == "Update"
 
     ###########################################################################
     # Error Case

--- a/tests/test_app_routers_bond_tokens_{token_address}_history_GET.py
+++ b/tests/test_app_routers_bond_tokens_{token_address}_history_GET.py
@@ -30,7 +30,14 @@ from web3.middleware import geth_poa_middleware
 
 import config
 from app.model.blockchain import IbetStraightBondContract
-from app.model.db import Account, Token, TokenType, UpdateToken, UpdateTokenTrigger
+from app.model.db import (
+    Account,
+    Token,
+    TokenType,
+    TokenUpdateOperationCategory,
+    TokenUpdateOperationLog,
+    UpdateToken,
+)
 from app.model.schema import IbetStraightBondCreate
 from app.utils.contract_utils import ContractUtils
 from app.utils.e2ee_utils import E2EEUtils
@@ -88,17 +95,19 @@ def deploy_bond_token_contract(
     ).__dict__
 
     token_create_param.pop("image_url")
-    update_token = UpdateToken()
-    update_token.token_address = token_address
-    update_token.type = TokenType.IBET_STRAIGHT_BOND.value
-    update_token.issuer_address = address
-    update_token.arguments = token_create_param
-    update_token.original_contents = None
-    update_token.status = 1
-    update_token.trigger = UpdateTokenTrigger.ISSUE.value
+    token_update_operation_log = TokenUpdateOperationLog()
+    token_update_operation_log.issuer_address = address
+    token_update_operation_log.token_address = token_address
+    token_update_operation_log.type = TokenType.IBET_STRAIGHT_BOND.value
+    token_update_operation_log.issuer_address = address
+    token_update_operation_log.arguments = token_create_param
+    token_update_operation_log.original_contents = None
+    token_update_operation_log.operation_category = (
+        TokenUpdateOperationCategory.ISSUE.value
+    )
     if created:
-        update_token.created = created
-    session.add(update_token)
+        token_update_operation_log.created = created
+    session.add(token_update_operation_log)
 
     build_tx_param = {
         "chainId": config.CHAIN_ID,
@@ -315,7 +324,7 @@ class TestAppRoutersBondTokensTokenAddressHistoryGET:
                         **{"interest_rate": 0.5},
                     },
                     "modified_contents": {"interest_payment_date": ["0101", "0701"]},
-                    "trigger": UpdateTokenTrigger.UPDATE.value,
+                    "operation_category": TokenUpdateOperationCategory.UPDATE.value,
                     "created": ANY,
                 },
                 {
@@ -324,19 +333,19 @@ class TestAppRoutersBondTokensTokenAddressHistoryGET:
                         **{"face_value": 10000},
                     },
                     "modified_contents": {"interest_rate": 0.5},
-                    "trigger": UpdateTokenTrigger.UPDATE.value,
+                    "operation_category": TokenUpdateOperationCategory.UPDATE.value,
                     "created": ANY,
                 },
                 {
                     "original_contents": original_after_issue,
                     "modified_contents": {"face_value": 10000},
-                    "trigger": UpdateTokenTrigger.UPDATE.value,
+                    "operation_category": TokenUpdateOperationCategory.UPDATE.value,
                     "created": ANY,
                 },
                 {
                     "original_contents": None,
                     "modified_contents": create_param,
-                    "trigger": UpdateTokenTrigger.ISSUE.value,
+                    "operation_category": TokenUpdateOperationCategory.ISSUE.value,
                     "created": ANY,
                 },
             ],
@@ -382,7 +391,7 @@ class TestAppRoutersBondTokensTokenAddressHistoryGET:
         resp = client.get(
             self.base_url.format(_token_address),
             params={
-                "trigger": "Update",
+                "operation_category": "Update",
             },
         )
 
@@ -407,7 +416,7 @@ class TestAppRoutersBondTokensTokenAddressHistoryGET:
                         **{"interest_rate": 0.5},
                     },
                     "modified_contents": {"interest_payment_date": ["0101", "0701"]},
-                    "trigger": UpdateTokenTrigger.UPDATE.value,
+                    "operation_category": TokenUpdateOperationCategory.UPDATE.value,
                     "created": ANY,
                 },
                 {
@@ -416,13 +425,13 @@ class TestAppRoutersBondTokensTokenAddressHistoryGET:
                         **{"face_value": 10000},
                     },
                     "modified_contents": {"interest_rate": 0.5},
-                    "trigger": UpdateTokenTrigger.UPDATE.value,
+                    "operation_category": TokenUpdateOperationCategory.UPDATE.value,
                     "created": ANY,
                 },
                 {
                     "original_contents": original_after_issue,
                     "modified_contents": {"face_value": 10000},
-                    "trigger": UpdateTokenTrigger.UPDATE.value,
+                    "operation_category": TokenUpdateOperationCategory.UPDATE.value,
                     "created": ANY,
                 },
             ],
@@ -489,13 +498,13 @@ class TestAppRoutersBondTokensTokenAddressHistoryGET:
                 {
                     "original_contents": original_after_issue,
                     "modified_contents": {"face_value": 10000},
-                    "trigger": UpdateTokenTrigger.UPDATE.value,
+                    "operation_category": TokenUpdateOperationCategory.UPDATE.value,
                     "created": ANY,
                 },
                 {
                     "original_contents": None,
                     "modified_contents": create_param,
-                    "trigger": UpdateTokenTrigger.ISSUE.value,
+                    "operation_category": TokenUpdateOperationCategory.ISSUE.value,
                     "created": ANY,
                 },
             ],
@@ -537,33 +546,33 @@ class TestAppRoutersBondTokensTokenAddressHistoryGET:
         _token.abi = ""
         db.add(_token)
 
-        _update_token_1 = UpdateToken()
-        _update_token_1.created = datetime(2023, 5, 2, tzinfo=timezone("UTC"))
-        _update_token_1.token_address = _token_address
-        _update_token_1.type = TokenType.IBET_STRAIGHT_BOND.value
-        _update_token_1.arguments = {"memo": "20230502"}
-        _update_token_1.original_contents = {}
-        _update_token_1.status = 1
-        _update_token_1.trigger = UpdateTokenTrigger.UPDATE.value
-        db.add(_update_token_1)
-        _update_token_2 = UpdateToken()
-        _update_token_2.created = datetime(2023, 5, 3, tzinfo=timezone("UTC"))
-        _update_token_2.token_address = _token_address
-        _update_token_2.type = TokenType.IBET_STRAIGHT_BOND.value
-        _update_token_2.arguments = {"memo": "20230503"}
-        _update_token_2.original_contents = {}
-        _update_token_2.status = 1
-        _update_token_2.trigger = UpdateTokenTrigger.UPDATE.value
-        db.add(_update_token_2)
-        _update_token_3 = UpdateToken()
-        _update_token_3.created = datetime(2023, 5, 4, tzinfo=timezone("UTC"))
-        _update_token_3.token_address = _token_address
-        _update_token_3.type = TokenType.IBET_STRAIGHT_BOND.value
-        _update_token_3.arguments = {"memo": "20230504"}
-        _update_token_3.original_contents = {}
-        _update_token_3.status = 1
-        _update_token_3.trigger = UpdateTokenTrigger.UPDATE.value
-        db.add(_update_token_3)
+        _operation_log_1 = TokenUpdateOperationLog()
+        _operation_log_1.created = datetime(2023, 5, 2, tzinfo=timezone("UTC"))
+        _operation_log_1.issuer_address = _issuer_address
+        _operation_log_1.token_address = _token_address
+        _operation_log_1.type = TokenType.IBET_STRAIGHT_BOND.value
+        _operation_log_1.arguments = {"memo": "20230502"}
+        _operation_log_1.original_contents = {}
+        _operation_log_1.operation_category = TokenUpdateOperationCategory.UPDATE.value
+        db.add(_operation_log_1)
+        _operation_log_2 = TokenUpdateOperationLog()
+        _operation_log_2.created = datetime(2023, 5, 3, tzinfo=timezone("UTC"))
+        _operation_log_2.issuer_address = _issuer_address
+        _operation_log_2.token_address = _token_address
+        _operation_log_2.type = TokenType.IBET_STRAIGHT_BOND.value
+        _operation_log_2.arguments = {"memo": "20230503"}
+        _operation_log_2.original_contents = {}
+        _operation_log_2.operation_category = TokenUpdateOperationCategory.UPDATE.value
+        db.add(_operation_log_2)
+        _operation_log_3 = TokenUpdateOperationLog()
+        _operation_log_3.created = datetime(2023, 5, 4, tzinfo=timezone("UTC"))
+        _operation_log_3.issuer_address = _issuer_address
+        _operation_log_3.token_address = _token_address
+        _operation_log_3.type = TokenType.IBET_STRAIGHT_BOND.value
+        _operation_log_3.arguments = {"memo": "20230504"}
+        _operation_log_3.original_contents = {}
+        _operation_log_3.operation_category = TokenUpdateOperationCategory.UPDATE.value
+        db.add(_operation_log_3)
         db.commit()
 
         # request target API
@@ -591,13 +600,13 @@ class TestAppRoutersBondTokensTokenAddressHistoryGET:
                 {
                     "original_contents": {},
                     "modified_contents": {"memo": "20230504"},
-                    "trigger": UpdateTokenTrigger.UPDATE.value,
+                    "operation_category": TokenUpdateOperationCategory.UPDATE.value,
                     "created": ANY,
                 },
                 {
                     "original_contents": {},
                     "modified_contents": {"memo": "20230503"},
-                    "trigger": UpdateTokenTrigger.UPDATE.value,
+                    "operation_category": TokenUpdateOperationCategory.UPDATE.value,
                     "created": ANY,
                 },
             ],
@@ -639,33 +648,33 @@ class TestAppRoutersBondTokensTokenAddressHistoryGET:
         _token.abi = ""
         db.add(_token)
 
-        _update_token_1 = UpdateToken()
-        _update_token_1.created = datetime(2023, 5, 2, tzinfo=timezone("UTC"))
-        _update_token_1.token_address = _token_address
-        _update_token_1.type = TokenType.IBET_STRAIGHT_BOND.value
-        _update_token_1.arguments = {"memo": "20230502"}
-        _update_token_1.original_contents = {}
-        _update_token_1.status = 1
-        _update_token_1.trigger = UpdateTokenTrigger.UPDATE.value
-        db.add(_update_token_1)
-        _update_token_2 = UpdateToken()
-        _update_token_2.created = datetime(2023, 5, 3, tzinfo=timezone("UTC"))
-        _update_token_2.token_address = _token_address
-        _update_token_2.type = TokenType.IBET_STRAIGHT_BOND.value
-        _update_token_2.arguments = {"memo": "20230503"}
-        _update_token_2.original_contents = {}
-        _update_token_2.status = 1
-        _update_token_2.trigger = UpdateTokenTrigger.UPDATE.value
-        db.add(_update_token_2)
-        _update_token_3 = UpdateToken()
-        _update_token_3.created = datetime(2023, 5, 4, tzinfo=timezone("UTC"))
-        _update_token_3.token_address = _token_address
-        _update_token_3.type = TokenType.IBET_STRAIGHT_BOND.value
-        _update_token_3.arguments = {"memo": "20230504"}
-        _update_token_3.original_contents = {}
-        _update_token_3.status = 1
-        _update_token_3.trigger = UpdateTokenTrigger.UPDATE.value
-        db.add(_update_token_3)
+        _operation_log_1 = TokenUpdateOperationLog()
+        _operation_log_1.created = datetime(2023, 5, 2, tzinfo=timezone("UTC"))
+        _operation_log_1.issuer_address = _issuer_address
+        _operation_log_1.token_address = _token_address
+        _operation_log_1.type = TokenType.IBET_STRAIGHT_BOND.value
+        _operation_log_1.arguments = {"memo": "20230502"}
+        _operation_log_1.original_contents = {}
+        _operation_log_1.operation_category = TokenUpdateOperationCategory.UPDATE.value
+        db.add(_operation_log_1)
+        _operation_log_2 = TokenUpdateOperationLog()
+        _operation_log_2.created = datetime(2023, 5, 3, tzinfo=timezone("UTC"))
+        _operation_log_2.issuer_address = _issuer_address
+        _operation_log_2.token_address = _token_address
+        _operation_log_2.type = TokenType.IBET_STRAIGHT_BOND.value
+        _operation_log_2.arguments = {"memo": "20230503"}
+        _operation_log_2.original_contents = {}
+        _operation_log_2.operation_category = TokenUpdateOperationCategory.UPDATE.value
+        db.add(_operation_log_2)
+        _operation_log_3 = TokenUpdateOperationLog()
+        _operation_log_3.created = datetime(2023, 5, 4, tzinfo=timezone("UTC"))
+        _operation_log_3.issuer_address = _issuer_address
+        _operation_log_3.token_address = _token_address
+        _operation_log_3.type = TokenType.IBET_STRAIGHT_BOND.value
+        _operation_log_3.arguments = {"memo": "20230504"}
+        _operation_log_3.original_contents = {}
+        _operation_log_3.operation_category = TokenUpdateOperationCategory.UPDATE.value
+        db.add(_operation_log_3)
         db.commit()
 
         # request target API
@@ -689,7 +698,7 @@ class TestAppRoutersBondTokensTokenAddressHistoryGET:
                 {
                     "original_contents": None,
                     "modified_contents": create_param,
-                    "trigger": UpdateTokenTrigger.ISSUE.value,
+                    "operation_category": TokenUpdateOperationCategory.ISSUE.value,
                     "created": ANY,
                 },
             ],
@@ -756,13 +765,13 @@ class TestAppRoutersBondTokensTokenAddressHistoryGET:
                 {
                     "original_contents": None,
                     "modified_contents": create_param,
-                    "trigger": UpdateTokenTrigger.ISSUE.value,
+                    "operation_category": TokenUpdateOperationCategory.ISSUE.value,
                     "created": ANY,
                 },
                 {
                     "original_contents": original_after_issue,
                     "modified_contents": {"face_value": 10000},
-                    "trigger": UpdateTokenTrigger.UPDATE.value,
+                    "operation_category": TokenUpdateOperationCategory.UPDATE.value,
                     "created": ANY,
                 },
                 {
@@ -771,7 +780,7 @@ class TestAppRoutersBondTokensTokenAddressHistoryGET:
                         **{"face_value": 10000},
                     },
                     "modified_contents": {"interest_rate": 0.5},
-                    "trigger": UpdateTokenTrigger.UPDATE.value,
+                    "operation_category": TokenUpdateOperationCategory.UPDATE.value,
                     "created": ANY,
                 },
                 {
@@ -781,7 +790,7 @@ class TestAppRoutersBondTokensTokenAddressHistoryGET:
                         **{"interest_rate": 0.5},
                     },
                     "modified_contents": {"interest_payment_date": ["0101", "0701"]},
-                    "trigger": UpdateTokenTrigger.UPDATE.value,
+                    "operation_category": TokenUpdateOperationCategory.UPDATE.value,
                     "created": ANY,
                 },
             ],
@@ -828,7 +837,7 @@ class TestAppRoutersBondTokensTokenAddressHistoryGET:
             self.base_url.format(_token_address),
             params={
                 "sort_order": 0,
-                "sort_item": "trigger",
+                "sort_item": "operation_category",
             },
         )
 
@@ -849,7 +858,7 @@ class TestAppRoutersBondTokensTokenAddressHistoryGET:
                 {
                     "original_contents": None,
                     "modified_contents": create_param,
-                    "trigger": UpdateTokenTrigger.ISSUE.value,
+                    "operation_category": TokenUpdateOperationCategory.ISSUE.value,
                     "created": ANY,
                 },
                 {
@@ -859,7 +868,7 @@ class TestAppRoutersBondTokensTokenAddressHistoryGET:
                         **{"interest_rate": 0.5},
                     },
                     "modified_contents": {"interest_payment_date": ["0101", "0701"]},
-                    "trigger": UpdateTokenTrigger.UPDATE.value,
+                    "operation_category": TokenUpdateOperationCategory.UPDATE.value,
                     "created": ANY,
                 },
                 {
@@ -868,13 +877,13 @@ class TestAppRoutersBondTokensTokenAddressHistoryGET:
                         **{"face_value": 10000},
                     },
                     "modified_contents": {"interest_rate": 0.5},
-                    "trigger": UpdateTokenTrigger.UPDATE.value,
+                    "operation_category": TokenUpdateOperationCategory.UPDATE.value,
                     "created": ANY,
                 },
                 {
                     "original_contents": original_after_issue,
                     "modified_contents": {"face_value": 10000},
-                    "trigger": UpdateTokenTrigger.UPDATE.value,
+                    "operation_category": TokenUpdateOperationCategory.UPDATE.value,
                     "created": ANY,
                 },
             ],
@@ -945,13 +954,13 @@ class TestAppRoutersBondTokensTokenAddressHistoryGET:
                         **{"face_value": 10000},
                     },
                     "modified_contents": {"interest_rate": 0.5},
-                    "trigger": UpdateTokenTrigger.UPDATE.value,
+                    "operation_category": TokenUpdateOperationCategory.UPDATE.value,
                     "created": ANY,
                 },
                 {
                     "original_contents": original_after_issue,
                     "modified_contents": {"face_value": 10000},
-                    "trigger": UpdateTokenTrigger.UPDATE.value,
+                    "operation_category": TokenUpdateOperationCategory.UPDATE.value,
                     "created": ANY,
                 },
             ],
@@ -1028,7 +1037,7 @@ class TestAppRoutersBondTokensTokenAddressHistoryGET:
         resp = client.get(
             self.base_url.format(token_address),
             params={
-                "trigger": "test",
+                "operation_category": "test",
                 "sort_order": "test",
                 "sort_item": "test",
                 "offset": "test",
@@ -1043,16 +1052,16 @@ class TestAppRoutersBondTokensTokenAddressHistoryGET:
             "detail": [
                 {
                     "ctx": {"enum_values": ["Issue", "Update"]},
-                    "loc": ["query", "trigger"],
+                    "loc": ["query", "operation_category"],
                     "msg": "value is not a valid enumeration member; permitted: "
                     "'Issue', 'Update'",
                     "type": "type_error.enum",
                 },
                 {
-                    "ctx": {"enum_values": ["created", "trigger"]},
+                    "ctx": {"enum_values": ["created", "operation_category"]},
                     "loc": ["query", "sort_item"],
                     "msg": "value is not a valid enumeration member; permitted: "
-                    "'created', 'trigger'",
+                    "'created', 'operation_category'",
                     "type": "type_error.enum",
                 },
                 {

--- a/tests/test_app_routers_share_tokens_POST.py
+++ b/tests/test_app_routers_share_tokens_POST.py
@@ -36,6 +36,7 @@ from app.model.db import (
     IDXPosition,
     Token,
     TokenType,
+    TokenUpdateOperationLog,
     UpdateToken,
 )
 from app.utils.contract_utils import ContractUtils
@@ -168,10 +169,13 @@ class TestAppRoutersShareTokensPOST:
             assert utxo.block_timestamp == datetime(2021, 4, 27, 12, 34, 56)
 
             update_token = db.query(UpdateToken).first()
-            assert update_token.token_address == "contract_address_test1"
-            assert update_token.type == TokenType.IBET_SHARE.value
-            assert update_token.status == 1
-            assert update_token.trigger == "Issue"
+            assert update_token is None
+
+            operation_log = db.query(TokenUpdateOperationLog).first()
+            assert operation_log.token_address == "contract_address_test1"
+            assert operation_log.type == TokenType.IBET_SHARE.value
+            assert operation_log.original_contents is None
+            assert operation_log.operation_category == "Issue"
 
     # <Normal_1_2>
     # create only
@@ -273,10 +277,13 @@ class TestAppRoutersShareTokensPOST:
             assert utxo.block_timestamp == datetime(2021, 4, 27, 12, 34, 56)
 
             update_token = db.query(UpdateToken).first()
-            assert update_token.token_address == "contract_address_test1"
-            assert update_token.type == TokenType.IBET_SHARE.value
-            assert update_token.status == 1
-            assert update_token.trigger == "Issue"
+            assert update_token is None
+
+            operation_log = db.query(TokenUpdateOperationLog).first()
+            assert operation_log.token_address == "contract_address_test1"
+            assert operation_log.type == TokenType.IBET_SHARE.value
+            assert operation_log.original_contents is None
+            assert operation_log.operation_category == "Issue"
 
     # <Normal_2>
     # include updates
@@ -514,10 +521,13 @@ class TestAppRoutersShareTokensPOST:
             assert utxo.block_timestamp == datetime(2021, 4, 27, 12, 34, 56)
 
             update_token = db.query(UpdateToken).first()
-            assert update_token.token_address == "contract_address_test1"
-            assert update_token.type == TokenType.IBET_SHARE.value
-            assert update_token.status == 1
-            assert update_token.trigger == "Issue"
+            assert update_token is None
+
+            operation_log = db.query(TokenUpdateOperationLog).first()
+            assert operation_log.token_address == "contract_address_test1"
+            assert operation_log.type == TokenType.IBET_SHARE.value
+            assert operation_log.original_contents is None
+            assert operation_log.operation_category == "Issue"
 
     # <Normal_4_1>
     # YYYYMMDD parameter is not empty

--- a/tests/test_app_routers_share_tokens_{token_address}_POST.py
+++ b/tests/test_app_routers_share_tokens_{token_address}_POST.py
@@ -33,7 +33,8 @@ from app.model.db import (
     Token,
     TokenAttrUpdate,
     TokenType,
-    UpdateToken,
+    TokenUpdateOperationCategory,
+    TokenUpdateOperationLog,
 )
 from app.utils.contract_utils import ContractUtils
 from app.utils.e2ee_utils import E2EEUtils
@@ -142,11 +143,11 @@ class TestAppRoutersShareTokensTokenAddressPOST:
         )
         assert len(token_attr_update) == 1
 
-        update_token = db.query(UpdateToken).first()
-        assert update_token.token_address == _token_address
-        assert update_token.issuer_address == _issuer_address
-        assert update_token.type == TokenType.IBET_SHARE.value
-        assert update_token.original_contents == {
+        operation_log = db.query(TokenUpdateOperationLog).first()
+        assert operation_log.token_address == _token_address
+        assert operation_log.issuer_address == _issuer_address
+        assert operation_log.type == TokenType.IBET_SHARE.value
+        assert operation_log.original_contents == {
             "cancellation_date": "token.cancellation_date",
             "contact_information": "",
             "contract_name": "IbetShare",
@@ -170,7 +171,7 @@ class TestAppRoutersShareTokensTokenAddressPOST:
             "transfer_approval_required": False,
             "transferable": False,
         }
-        assert update_token.arguments == {
+        assert operation_log.arguments == {
             "cancellation_date": "20221231",
             "dividends": 345.67,
             "dividend_record_date": "20211231",
@@ -187,7 +188,7 @@ class TestAppRoutersShareTokensTokenAddressPOST:
             "is_canceled": True,
             "memo": "m" * 10000,
         }
-        assert update_token.status == 1
+        assert operation_log.operation_category == "Update"
 
     # <Normal_2>
     # No request parameters
@@ -242,10 +243,10 @@ class TestAppRoutersShareTokensTokenAddressPOST:
             .filter(TokenAttrUpdate.token_address == _token_address)
             .all()
         )
-        assert len(token_attr_update) == 0
+        assert len(token_attr_update) == 1
 
-        update_token = db.query(UpdateToken).first()
-        assert update_token is None
+        operation_log = db.query(TokenUpdateOperationLog).first()
+        assert operation_log is not None
 
     # <Normal_3>
     # Authorization by auth-token
@@ -324,11 +325,11 @@ class TestAppRoutersShareTokensTokenAddressPOST:
         )
         assert len(token_attr_update) == 1
 
-        update_token = db.query(UpdateToken).first()
-        assert update_token.token_address == _token_address
-        assert update_token.issuer_address == _issuer_address
-        assert update_token.type == TokenType.IBET_SHARE.value
-        assert update_token.original_contents == {
+        operation_log = db.query(TokenUpdateOperationLog).first()
+        assert operation_log.token_address == _token_address
+        assert operation_log.issuer_address == _issuer_address
+        assert operation_log.type == TokenType.IBET_SHARE.value
+        assert operation_log.original_contents == {
             "cancellation_date": "token.cancellation_date",
             "contact_information": "",
             "contract_name": "IbetShare",
@@ -352,7 +353,7 @@ class TestAppRoutersShareTokensTokenAddressPOST:
             "transfer_approval_required": False,
             "transferable": False,
         }
-        assert update_token.arguments == {
+        assert operation_log.arguments == {
             "cancellation_date": "20221231",
             "dividends": 345.67,
             "dividend_record_date": "20211231",
@@ -369,7 +370,7 @@ class TestAppRoutersShareTokensTokenAddressPOST:
             "is_canceled": True,
             "memo": "memo_test1",
         }
-        assert update_token.status == 1
+        assert operation_log.operation_category == "Update"
 
     # <Normal_4_1>
     # YYYYMMDD parameter is not an empty string
@@ -431,11 +432,11 @@ class TestAppRoutersShareTokensTokenAddressPOST:
         )
         assert len(token_attr_update) == 1
 
-        update_token = db.query(UpdateToken).first()
-        assert update_token.token_address == _token_address
-        assert update_token.issuer_address == _issuer_address
-        assert update_token.type == TokenType.IBET_SHARE.value
-        assert update_token.original_contents == {
+        operation_log = db.query(TokenUpdateOperationLog).first()
+        assert operation_log.token_address == _token_address
+        assert operation_log.issuer_address == _issuer_address
+        assert operation_log.type == TokenType.IBET_SHARE.value
+        assert operation_log.original_contents == {
             "cancellation_date": "token.cancellation_date",
             "contact_information": "",
             "contract_name": "IbetShare",
@@ -459,13 +460,13 @@ class TestAppRoutersShareTokensTokenAddressPOST:
             "transfer_approval_required": False,
             "transferable": False,
         }
-        assert update_token.arguments == {
+        assert operation_log.arguments == {
             "cancellation_date": "20221231",
             "dividends": 345.67,
             "dividend_record_date": "20211231",
             "dividend_payment_date": "20211231",
         }
-        assert update_token.status == 1
+        assert operation_log.operation_category == "Update"
 
     # <Normal_4_2>
     # YYYYMMDD parameter is an empty string
@@ -527,11 +528,11 @@ class TestAppRoutersShareTokensTokenAddressPOST:
         )
         assert len(token_attr_update) == 1
 
-        update_token = db.query(UpdateToken).first()
-        assert update_token.token_address == _token_address
-        assert update_token.issuer_address == _issuer_address
-        assert update_token.type == TokenType.IBET_SHARE.value
-        assert update_token.original_contents == {
+        operation_log = db.query(TokenUpdateOperationLog).first()
+        assert operation_log.token_address == _token_address
+        assert operation_log.issuer_address == _issuer_address
+        assert operation_log.type == TokenType.IBET_SHARE.value
+        assert operation_log.original_contents == {
             "cancellation_date": "token.cancellation_date",
             "contact_information": "",
             "contract_name": "IbetShare",
@@ -555,13 +556,13 @@ class TestAppRoutersShareTokensTokenAddressPOST:
             "transfer_approval_required": False,
             "transferable": False,
         }
-        assert update_token.arguments == {
+        assert operation_log.arguments == {
             "cancellation_date": "",
             "dividends": 345.67,
             "dividend_record_date": "",
             "dividend_payment_date": "",
         }
-        assert update_token.status == 1
+        assert operation_log.operation_category == "Update"
 
     ###########################################################################
     # Error Case


### PR DESCRIPTION
Close: #529 

----

- API
  - GET: `/bond/{token_address}/history`
    - Changed to use **token_update_operation_log** data for response data
  - POST: `/bond`
    - Changed to store **token_update_operation_log** data as Issue data
  - POST: `/bond/{token_address}`
    - Changed to store **token_update_operation_log** data as Update data
  - GET: `/share/{token_address}/history`
    - Changed to use **token_update_operation_log** data for response data
  - POST: `/share`
    - Changed to store **token_update_operation_log** data as Issue data
  - POST: `/share/{token_address}`
    - Changed to store **token_update_operation_log** data as Update data

- DB
  - `update_token.original_contents`: column deleted
  - `token_update_operation_log`: table added