### PR TITLE
Add `personal_information` field to API response of list all batch redeem/issue records

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,8 @@ RUN apt-get update -q \
  language-pack-ja-base \
  language-pack-ja \
  git \
- libyaml-cpp-dev
+ libyaml-cpp-dev \
+ liblzma-dev
 
 # remove unnessesory package files
 RUN apt clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/app/model/schema/batch_issue_redeem.py
+++ b/app/model/schema/batch_issue_redeem.py
@@ -22,6 +22,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from app.model.db import TokenType
 
+from .personal_info import PersonalInfo
 from .types import ResultSet
 
 ############################
@@ -73,6 +74,7 @@ class GetBatchIssueRedeemResult(BaseModel):
     account_address: str
     amount: int
     status: int
+    personal_information: PersonalInfo
 
 
 class GetBatchIssueRedeemResponse(BaseModel):

--- a/app/model/schema/personal_info.py
+++ b/app/model/schema/personal_info.py
@@ -26,7 +26,18 @@ from app.model.schema.types import ResultSet
 
 
 class PersonalInfo(BaseModel):
-    """Personal Information schema"""
+    key_manager: Optional[str] = Field(...)
+    name: Optional[str] = Field(...)
+    postal_code: Optional[str] = Field(...)
+    address: Optional[str] = Field(...)
+    email: Optional[str] = Field(...)
+    birth: Optional[str] = Field(...)
+    is_corporate: Optional[bool] = Field(...)
+    tax_category: Optional[int] = Field(...)
+
+
+class PersonalInfoInput(BaseModel):
+    """Personal Information Input schema"""
 
     name: Optional[str] = None
     postal_code: Optional[str] = None
@@ -42,7 +53,7 @@ class PersonalInfo(BaseModel):
 ############################
 
 
-class RegisterPersonalInfoRequest(PersonalInfo):
+class RegisterPersonalInfoRequest(PersonalInfoInput):
     """Register Personal Information schema (REQUEST)"""
 
     account_address: str

--- a/app/routers/share.py
+++ b/app/routers/share.py
@@ -930,18 +930,44 @@ def retrieve_batch_additional_issue(
         raise HTTPException(status_code=404, detail="batch not found")
 
     # Get Batch Records
-    record_list: Sequence[BatchIssueRedeem] = db.scalars(
-        select(BatchIssueRedeem).where(BatchIssueRedeem.upload_id == batch_id)
-    ).all()
+    record_list: Sequence[tuple[BatchIssueRedeem, IDXPersonalInfo | None]] = (
+        db.execute(
+            select(BatchIssueRedeem, IDXPersonalInfo)
+            .outerjoin(
+                IDXPersonalInfo,
+                and_(
+                    BatchIssueRedeem.account_address == IDXPersonalInfo.account_address,
+                    IDXPersonalInfo.issuer_address == issuer_address,
+                ),
+            )
+            .where(BatchIssueRedeem.upload_id == batch_id)
+        )
+        .tuples()
+        .all()
+    )
+
+    personal_info_default = {
+        "key_manager": None,
+        "name": None,
+        "postal_code": None,
+        "address": None,
+        "email": None,
+        "birth": None,
+        "is_corporate": None,
+        "tax_category": None,
+    }
 
     return json_response(
         {
             "processed": batch.processed,
             "results": [
                 {
-                    "account_address": record.account_address,
-                    "amount": record.amount,
-                    "status": record.status,
+                    "account_address": record[0].account_address,
+                    "amount": record[0].amount,
+                    "status": record[0].status,
+                    "personal_information": record[1].personal_info
+                    if record[1]
+                    else personal_info_default,
                 }
                 for record in record_list
             ],
@@ -1307,18 +1333,44 @@ def retrieve_batch_redeem(
         raise HTTPException(status_code=404, detail="batch not found")
 
     # Get Batch Records
-    record_list: Sequence[BatchIssueRedeem] = db.scalars(
-        select(BatchIssueRedeem).where(BatchIssueRedeem.upload_id == batch_id)
-    ).all()
+    record_list: Sequence[tuple[BatchIssueRedeem, IDXPersonalInfo | None]] = (
+        db.execute(
+            select(BatchIssueRedeem, IDXPersonalInfo)
+            .outerjoin(
+                IDXPersonalInfo,
+                and_(
+                    BatchIssueRedeem.account_address == IDXPersonalInfo.account_address,
+                    IDXPersonalInfo.issuer_address == issuer_address,
+                ),
+            )
+            .where(BatchIssueRedeem.upload_id == batch_id)
+        )
+        .tuples()
+        .all()
+    )
+
+    personal_info_default = {
+        "key_manager": None,
+        "name": None,
+        "postal_code": None,
+        "address": None,
+        "email": None,
+        "birth": None,
+        "is_corporate": None,
+        "tax_category": None,
+    }
 
     return json_response(
         {
             "processed": batch.processed,
             "results": [
                 {
-                    "account_address": record.account_address,
-                    "amount": record.amount,
-                    "status": record.status,
+                    "account_address": record[0].account_address,
+                    "amount": record[0].amount,
+                    "status": record[0].status,
+                    "personal_information": record[1].personal_info
+                    if record[1]
+                    else personal_info_default,
                 }
                 for record in record_list
             ],

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -31,7 +31,8 @@ RUN apt-get update -q \
  language-pack-ja-base \
  language-pack-ja \
  git \
- libyaml-cpp-dev
+ libyaml-cpp-dev \
+ liblzma-dev
 
 # remove unnessesory package files
 RUN apt clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/tests/test_app_routers_bond_tokens_{token_address}_additional_issue_batch_{batch_id}_GET.py
+++ b/tests/test_app_routers_bond_tokens_{token_address}_additional_issue_batch_{batch_id}_GET.py
@@ -21,6 +21,7 @@ from app.model.db import (
     BatchIssueRedeem,
     BatchIssueRedeemProcessingCategory,
     BatchIssueRedeemUpload,
+    IDXPersonalInfo,
     Token,
     TokenType,
 )
@@ -46,9 +47,9 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueBatchBatchIdGET:
     # Normal Case
     ###########################################################################
 
-    # Normal_1
-    # Single Record
-    def test_normal_1(self, client, db):
+    # Normal_1_1
+    # Single Record(No personal information)
+    def test_normal_1_1(self, client, db):
         issuer_account = config_eth_account("user1")
         issuer_address = issuer_account["address"]
         issuer_keyfile = issuer_account["keyfile_json"]
@@ -86,6 +87,21 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueBatchBatchIdGET:
         batch_record.status = 1
         db.add(batch_record)
 
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = self.account_list[0]["address"]
+        idx_personal_info_1.issuer_address = "other_issuer_address"
+        idx_personal_info_1._personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(idx_personal_info_1)
+
         # request target API
         resp = client.get(
             self.base_url.format(test_token_address, self.upload_id_list[0]),
@@ -101,6 +117,100 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueBatchBatchIdGET:
                     "account_address": self.account_list[0]["address"],
                     "amount": self.account_list[0]["amount"],
                     "status": 1,
+                    "personal_information": {
+                        "key_manager": None,
+                        "address": None,
+                        "birth": None,
+                        "email": None,
+                        "is_corporate": None,
+                        "name": None,
+                        "postal_code": None,
+                        "tax_category": None,
+                    },
+                }
+            ],
+        }
+
+    # Normal_1_2
+    # Single Record(With personal information)
+    def test_normal_1_2(self, client, db):
+        issuer_account = config_eth_account("user1")
+        issuer_address = issuer_account["address"]
+        issuer_keyfile = issuer_account["keyfile_json"]
+
+        test_token_address = "token_address_test"
+
+        # prepare data
+        account = Account()
+        account.issuer_address = issuer_address
+        account.keyfile = issuer_keyfile
+        account.eoa_password = E2EEUtils.encrypt("password")
+        db.add(account)
+
+        token = Token()
+        token.type = TokenType.IBET_STRAIGHT_BOND.value
+        token.tx_hash = ""
+        token.issuer_address = issuer_address
+        token.token_address = test_token_address
+        token.abi = ""
+        db.add(token)
+
+        batch_upload = BatchIssueRedeemUpload()
+        batch_upload.upload_id = self.upload_id_list[0]
+        batch_upload.issuer_address = issuer_address
+        batch_upload.token_type = TokenType.IBET_STRAIGHT_BOND.value
+        batch_upload.token_address = test_token_address
+        batch_upload.category = BatchIssueRedeemProcessingCategory.ISSUE.value
+        batch_upload.processed = True
+        db.add(batch_upload)
+
+        batch_record = BatchIssueRedeem()
+        batch_record.upload_id = self.upload_id_list[0]
+        batch_record.account_address = self.account_list[0]["address"]
+        batch_record.amount = self.account_list[0]["amount"]
+        batch_record.status = 1
+        db.add(batch_record)
+
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = self.account_list[0]["address"]
+        idx_personal_info_1.issuer_address = issuer_address
+        idx_personal_info_1._personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(idx_personal_info_1)
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(test_token_address, self.upload_id_list[0]),
+            headers={"issuer-address": issuer_address},
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "processed": True,
+            "results": [
+                {
+                    "account_address": self.account_list[0]["address"],
+                    "amount": self.account_list[0]["amount"],
+                    "status": 1,
+                    "personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test1",
+                        "postal_code": "postal_code_test1",
+                        "address": "address_test1",
+                        "email": "email_test1",
+                        "birth": "birth_test1",
+                        "is_corporate": False,
+                        "tax_category": 10,
+                    },
                 }
             ],
         }
@@ -145,6 +255,21 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueBatchBatchIdGET:
         batch_record.status = 1
         db.add(batch_record)
 
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = self.account_list[0]["address"]
+        idx_personal_info_1.issuer_address = issuer_address
+        idx_personal_info_1._personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(idx_personal_info_1)
+
         batch_record = BatchIssueRedeem()
         batch_record.upload_id = self.upload_id_list[0]
         batch_record.account_address = self.account_list[1]["address"]
@@ -167,11 +292,31 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueBatchBatchIdGET:
                     "account_address": self.account_list[0]["address"],
                     "amount": self.account_list[0]["amount"],
                     "status": 1,
+                    "personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test1",
+                        "postal_code": "postal_code_test1",
+                        "address": "address_test1",
+                        "email": "email_test1",
+                        "birth": "birth_test1",
+                        "is_corporate": False,
+                        "tax_category": 10,
+                    },
                 },
                 {
                     "account_address": self.account_list[1]["address"],
                     "amount": self.account_list[1]["amount"],
                     "status": 1,
+                    "personal_information": {
+                        "key_manager": None,
+                        "address": None,
+                        "birth": None,
+                        "email": None,
+                        "is_corporate": None,
+                        "name": None,
+                        "postal_code": None,
+                        "tax_category": None,
+                    },
                 },
             ],
         }

--- a/tests/test_app_routers_bond_tokens_{token_address}_redeem_batch_{batch_id}_GET.py
+++ b/tests/test_app_routers_bond_tokens_{token_address}_redeem_batch_{batch_id}_GET.py
@@ -21,6 +21,7 @@ from app.model.db import (
     BatchIssueRedeem,
     BatchIssueRedeemProcessingCategory,
     BatchIssueRedeemUpload,
+    IDXPersonalInfo,
     Token,
     TokenType,
 )
@@ -46,9 +47,9 @@ class TestAppRoutersBondTokensTokenAddressRedeemBatchBatchIdGET:
     # Normal Case
     ###########################################################################
 
-    # Normal_1
-    # Single Record
-    def test_normal_1(self, client, db):
+    # Normal_1_1
+    # Single Record(No personal information)
+    def test_normal_1_1(self, client, db):
         issuer_account = config_eth_account("user1")
         issuer_address = issuer_account["address"]
         issuer_keyfile = issuer_account["keyfile_json"]
@@ -86,6 +87,21 @@ class TestAppRoutersBondTokensTokenAddressRedeemBatchBatchIdGET:
         batch_record.status = 1
         db.add(batch_record)
 
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = self.account_list[0]["address"]
+        idx_personal_info_1.issuer_address = "other_issuer_address"
+        idx_personal_info_1._personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(idx_personal_info_1)
+
         # request target API
         resp = client.get(
             self.base_url.format(test_token_address, self.upload_id_list[0]),
@@ -101,6 +117,100 @@ class TestAppRoutersBondTokensTokenAddressRedeemBatchBatchIdGET:
                     "account_address": self.account_list[0]["address"],
                     "amount": self.account_list[0]["amount"],
                     "status": 1,
+                    "personal_information": {
+                        "key_manager": None,
+                        "address": None,
+                        "birth": None,
+                        "email": None,
+                        "is_corporate": None,
+                        "name": None,
+                        "postal_code": None,
+                        "tax_category": None,
+                    },
+                }
+            ],
+        }
+
+    # Normal_1_2
+    # Single Record(With personal information)
+    def test_normal_1_2(self, client, db):
+        issuer_account = config_eth_account("user1")
+        issuer_address = issuer_account["address"]
+        issuer_keyfile = issuer_account["keyfile_json"]
+
+        test_token_address = "token_address_test"
+
+        # prepare data
+        account = Account()
+        account.issuer_address = issuer_address
+        account.keyfile = issuer_keyfile
+        account.eoa_password = E2EEUtils.encrypt("password")
+        db.add(account)
+
+        token = Token()
+        token.type = TokenType.IBET_STRAIGHT_BOND.value
+        token.tx_hash = ""
+        token.issuer_address = issuer_address
+        token.token_address = test_token_address
+        token.abi = ""
+        db.add(token)
+
+        batch_upload = BatchIssueRedeemUpload()
+        batch_upload.upload_id = self.upload_id_list[0]
+        batch_upload.issuer_address = issuer_address
+        batch_upload.token_type = TokenType.IBET_STRAIGHT_BOND.value
+        batch_upload.token_address = test_token_address
+        batch_upload.category = BatchIssueRedeemProcessingCategory.REDEEM.value
+        batch_upload.processed = True
+        db.add(batch_upload)
+
+        batch_record = BatchIssueRedeem()
+        batch_record.upload_id = self.upload_id_list[0]
+        batch_record.account_address = self.account_list[0]["address"]
+        batch_record.amount = self.account_list[0]["amount"]
+        batch_record.status = 1
+        db.add(batch_record)
+
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = self.account_list[0]["address"]
+        idx_personal_info_1.issuer_address = issuer_address
+        idx_personal_info_1._personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(idx_personal_info_1)
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(test_token_address, self.upload_id_list[0]),
+            headers={"issuer-address": issuer_address},
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "processed": True,
+            "results": [
+                {
+                    "account_address": self.account_list[0]["address"],
+                    "amount": self.account_list[0]["amount"],
+                    "status": 1,
+                    "personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test1",
+                        "postal_code": "postal_code_test1",
+                        "address": "address_test1",
+                        "email": "email_test1",
+                        "birth": "birth_test1",
+                        "is_corporate": False,
+                        "tax_category": 10,
+                    },
                 }
             ],
         }
@@ -145,6 +255,21 @@ class TestAppRoutersBondTokensTokenAddressRedeemBatchBatchIdGET:
         batch_record.status = 1
         db.add(batch_record)
 
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = self.account_list[0]["address"]
+        idx_personal_info_1.issuer_address = issuer_address
+        idx_personal_info_1._personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(idx_personal_info_1)
+
         batch_record = BatchIssueRedeem()
         batch_record.upload_id = self.upload_id_list[0]
         batch_record.account_address = self.account_list[1]["address"]
@@ -167,11 +292,31 @@ class TestAppRoutersBondTokensTokenAddressRedeemBatchBatchIdGET:
                     "account_address": self.account_list[0]["address"],
                     "amount": self.account_list[0]["amount"],
                     "status": 1,
+                    "personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test1",
+                        "postal_code": "postal_code_test1",
+                        "address": "address_test1",
+                        "email": "email_test1",
+                        "birth": "birth_test1",
+                        "is_corporate": False,
+                        "tax_category": 10,
+                    },
                 },
                 {
                     "account_address": self.account_list[1]["address"],
                     "amount": self.account_list[1]["amount"],
                     "status": 1,
+                    "personal_information": {
+                        "key_manager": None,
+                        "address": None,
+                        "birth": None,
+                        "email": None,
+                        "is_corporate": None,
+                        "name": None,
+                        "postal_code": None,
+                        "tax_category": None,
+                    },
                 },
             ],
         }

--- a/tests/test_app_routers_share_tokens_{token_address}_additional_issue_batch_{batch_id}_GET.py
+++ b/tests/test_app_routers_share_tokens_{token_address}_additional_issue_batch_{batch_id}_GET.py
@@ -21,6 +21,7 @@ from app.model.db import (
     BatchIssueRedeem,
     BatchIssueRedeemProcessingCategory,
     BatchIssueRedeemUpload,
+    IDXPersonalInfo,
     Token,
     TokenType,
 )
@@ -46,9 +47,9 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueBatchBatchIdGET:
     # Normal Case
     ###########################################################################
 
-    # Normal_1
-    # Single Record
-    def test_normal_1(self, client, db):
+    # Normal_1_1
+    # Single Record(No personal information)
+    def test_normal_1_1(self, client, db):
         issuer_account = config_eth_account("user1")
         issuer_address = issuer_account["address"]
         issuer_keyfile = issuer_account["keyfile_json"]
@@ -86,6 +87,21 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueBatchBatchIdGET:
         batch_record.status = 1
         db.add(batch_record)
 
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = self.account_list[0]["address"]
+        idx_personal_info_1.issuer_address = "other_issuer_address"
+        idx_personal_info_1._personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(idx_personal_info_1)
+
         # request target API
         resp = client.get(
             self.base_url.format(test_token_address, self.upload_id_list[0]),
@@ -101,6 +117,100 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueBatchBatchIdGET:
                     "account_address": self.account_list[0]["address"],
                     "amount": self.account_list[0]["amount"],
                     "status": 1,
+                    "personal_information": {
+                        "key_manager": None,
+                        "address": None,
+                        "birth": None,
+                        "email": None,
+                        "is_corporate": None,
+                        "name": None,
+                        "postal_code": None,
+                        "tax_category": None,
+                    },
+                }
+            ],
+        }
+
+    # Normal_1_2
+    # Single Record(With personal information)
+    def test_normal_1_2(self, client, db):
+        issuer_account = config_eth_account("user1")
+        issuer_address = issuer_account["address"]
+        issuer_keyfile = issuer_account["keyfile_json"]
+
+        test_token_address = "token_address_test"
+
+        # prepare data
+        account = Account()
+        account.issuer_address = issuer_address
+        account.keyfile = issuer_keyfile
+        account.eoa_password = E2EEUtils.encrypt("password")
+        db.add(account)
+
+        token = Token()
+        token.type = TokenType.IBET_SHARE.value
+        token.tx_hash = ""
+        token.issuer_address = issuer_address
+        token.token_address = test_token_address
+        token.abi = ""
+        db.add(token)
+
+        batch_upload = BatchIssueRedeemUpload()
+        batch_upload.upload_id = self.upload_id_list[0]
+        batch_upload.issuer_address = issuer_address
+        batch_upload.token_type = TokenType.IBET_SHARE.value
+        batch_upload.token_address = test_token_address
+        batch_upload.category = BatchIssueRedeemProcessingCategory.ISSUE.value
+        batch_upload.processed = True
+        db.add(batch_upload)
+
+        batch_record = BatchIssueRedeem()
+        batch_record.upload_id = self.upload_id_list[0]
+        batch_record.account_address = self.account_list[0]["address"]
+        batch_record.amount = self.account_list[0]["amount"]
+        batch_record.status = 1
+        db.add(batch_record)
+
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = self.account_list[0]["address"]
+        idx_personal_info_1.issuer_address = issuer_address
+        idx_personal_info_1._personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(idx_personal_info_1)
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(test_token_address, self.upload_id_list[0]),
+            headers={"issuer-address": issuer_address},
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "processed": True,
+            "results": [
+                {
+                    "account_address": self.account_list[0]["address"],
+                    "amount": self.account_list[0]["amount"],
+                    "status": 1,
+                    "personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test1",
+                        "postal_code": "postal_code_test1",
+                        "address": "address_test1",
+                        "email": "email_test1",
+                        "birth": "birth_test1",
+                        "is_corporate": False,
+                        "tax_category": 10,
+                    },
                 }
             ],
         }
@@ -152,6 +262,21 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueBatchBatchIdGET:
         batch_record.status = 1
         db.add(batch_record)
 
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = self.account_list[0]["address"]
+        idx_personal_info_1.issuer_address = issuer_address
+        idx_personal_info_1._personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(idx_personal_info_1)
+
         # request target API
         resp = client.get(
             self.base_url.format(test_token_address, self.upload_id_list[0]),
@@ -167,11 +292,31 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueBatchBatchIdGET:
                     "account_address": self.account_list[0]["address"],
                     "amount": self.account_list[0]["amount"],
                     "status": 1,
+                    "personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test1",
+                        "postal_code": "postal_code_test1",
+                        "address": "address_test1",
+                        "email": "email_test1",
+                        "birth": "birth_test1",
+                        "is_corporate": False,
+                        "tax_category": 10,
+                    },
                 },
                 {
                     "account_address": self.account_list[1]["address"],
                     "amount": self.account_list[1]["amount"],
                     "status": 1,
+                    "personal_information": {
+                        "key_manager": None,
+                        "address": None,
+                        "birth": None,
+                        "email": None,
+                        "is_corporate": None,
+                        "name": None,
+                        "postal_code": None,
+                        "tax_category": None,
+                    },
                 },
             ],
         }


### PR DESCRIPTION
Close: #535 

- Added `personal_information` attribute to the response of API following.
  - GET: `/bond/tokens/{token_address}/additional_issue/batch/{batch_id}`
  - GET: `/bond/tokens/{token_address}/redeem/batch/{batch_id}`
  - GET: `/share/tokens/{token_address}/additional_issue/batch/{batch_id}`
  - GET: `/share/tokens/{token_address}/redeem/batch/{batch_id}`

- `personal_information` attribute added only to the response of APIs that authenticate by `issuer_address` in the HTTP Header.