### PR TITLE
Make `face_value_currency` required & Manage token contract versions

### DIFF
--- a/app/model/blockchain/token.py
+++ b/app/model/blockchain/token.py
@@ -49,7 +49,14 @@ from app.model.blockchain.tx_params.ibet_straight_bond import (
 from app.model.db import TokenAttrUpdate, TokenCache
 from app.utils.contract_utils import ContractUtils
 from app.utils.web3_utils import Web3Wrapper
-from config import CHAIN_ID, TOKEN_CACHE, TOKEN_CACHE_TTL, TX_GAS_LIMIT, ZERO_ADDRESS
+from config import (
+    CHAIN_ID,
+    DEFAULT_CURRENCY,
+    TOKEN_CACHE,
+    TOKEN_CACHE_TTL,
+    TX_GAS_LIMIT,
+    ZERO_ADDRESS,
+)
 
 LOG = log.get_logger()
 
@@ -500,7 +507,7 @@ class IbetStraightBondContract(IbetSecurityTokenInterface):
         # Set IbetStraightBondToken attribute
         self.face_value = ContractUtils.call_function(contract, "faceValue", (), 0)
         self.face_value_currency = ContractUtils.call_function(
-            contract, "faceValueCurrency", (), ""
+            contract, "faceValueCurrency", (), DEFAULT_CURRENCY
         )
         self.interest_rate = float(
             Decimal(str(ContractUtils.call_function(contract, "interestRate", (), 0)))

--- a/app/model/db/__init__.py
+++ b/app/model/db/__init__.py
@@ -67,7 +67,7 @@ from .ledger_template import (
 from .node import Node
 from .notification import Notification, NotificationType
 from .scheduled_events import ScheduledEvents, ScheduledEventType
-from .token import Token, TokenAttrUpdate, TokenCache, TokenType
+from .token import Token, TokenAttrUpdate, TokenCache, TokenType, TokenVersion
 from .token_holders import TokenHolder, TokenHolderBatchStatus, TokenHoldersList
 from .token_update_operation_log import (
     TokenUpdateOperationCategory,

--- a/app/model/db/token.py
+++ b/app/model/db/token.py
@@ -17,12 +17,22 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 from datetime import datetime
-from enum import Enum
+from enum import Enum, StrEnum
 
 from sqlalchemy import JSON, DateTime, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from .base import Base
+
+
+class TokenType(str, Enum):
+    IBET_STRAIGHT_BOND = "IbetStraightBond"
+    IBET_SHARE = "IbetShare"
+
+
+class TokenVersion(StrEnum):
+    V_22_12 = "22_12"
+    V_23_12 = "23_12"
 
 
 class Token(Base):
@@ -32,14 +42,16 @@ class Token(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     # token type
-    type: Mapped[str] = mapped_column(String(40), nullable=False)
+    type: Mapped[TokenType] = mapped_column(String(40), nullable=False)
     # transaction hash
     tx_hash: Mapped[str] = mapped_column(String(66), nullable=False)
     # issuer address
     issuer_address: Mapped[str] = mapped_column(String(42), nullable=True)
     # token address
     token_address: Mapped[str] = mapped_column(String(42), nullable=True)
-    # ABI
+    # contract version
+    version: Mapped[TokenVersion] = mapped_column(String(5), nullable=False)
+    # contract ABI
     abi: Mapped[dict] = mapped_column(JSON, nullable=False)
     # token processing status (pending:0, succeeded:1, failed:2)
     token_status: Mapped[int | None] = mapped_column(Integer, default=1)
@@ -56,11 +68,6 @@ class TokenAttrUpdate(Base):
     token_address: Mapped[str | None] = mapped_column(String(42), index=True)
     # datetime when token attribute updated (UTC)
     updated_datetime: Mapped[datetime] = mapped_column(DateTime, nullable=False)
-
-
-class TokenType(str, Enum):
-    IBET_STRAIGHT_BOND = "IbetStraightBond"
-    IBET_SHARE = "IbetShare"
 
 
 class TokenCache(Base):

--- a/app/model/schema/__init__.py
+++ b/app/model/schema/__init__.py
@@ -140,4 +140,3 @@ from .transfer import (
     UpdateTransferApprovalOperationType,
     UpdateTransferApprovalRequest,
 )
-from .types import ResultSet

--- a/app/model/schema/base/__init__.py
+++ b/app/model/schema/base/__init__.py
@@ -16,35 +16,12 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
-from typing import List
-
-from pydantic import BaseModel
-
-from app.model.schema.base import ResultSet
-
-############################
-# REQUEST
-############################
-
-
-############################
-# RESPONSE
-############################
-
-
-class IssueRedeemEvent(BaseModel):
-    """Issue/Redeem event"""
-
-    transaction_hash: str
-    token_address: str
-    locked_address: str
-    target_address: str
-    amount: int
-    block_timestamp: str
-
-
-class IssueRedeemHistoryResponse(BaseModel):
-    """Issue/Redeem history"""
-
-    result_set: ResultSet
-    history: List[IssueRedeemEvent]
+from .base import (
+    EMPTY_str,
+    IbetShareContractVersion,
+    IbetStraightBondContractVersion,
+    MMDD_constr,
+    ResultSet,
+    SortOrder,
+    YYYYMMDD_constr,
+)

--- a/app/model/schema/base/base.py
+++ b/app/model/schema/base/base.py
@@ -16,11 +16,24 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
-from enum import IntEnum
+from enum import IntEnum, StrEnum
 from typing import Literal, Optional
 
 from pydantic import BaseModel, Field, StringConstraints
 from typing_extensions import Annotated
+
+
+############################
+# COMMON
+############################
+class IbetStraightBondContractVersion(StrEnum):
+    V_22_12 = "22_12"
+    V_23_12 = "23_12"
+
+
+class IbetShareContractVersion(StrEnum):
+    V_22_12 = "22_12"
+
 
 MMDD_constr = Annotated[
     str, StringConstraints(pattern="^(0[1-9]|1[0-2])(0[1-9]|[12][0-9]|3[01])$")
@@ -34,6 +47,17 @@ YYYYMMDD_constr = Annotated[
 EMPTY_str = Literal[""]
 
 
+############################
+# REQUEST
+############################
+class SortOrder(IntEnum):
+    ASC = 0
+    DESC = 1
+
+
+############################
+# RESPONSE
+############################
 class ResultSet(BaseModel):
     """result set for pagination"""
 
@@ -41,8 +65,3 @@ class ResultSet(BaseModel):
     offset: Optional[int] = Field(...)
     limit: Optional[int] = Field(...)
     total: Optional[int] = Field(...)
-
-
-class SortOrder(IntEnum):
-    ASC = 0
-    DESC = 1

--- a/app/model/schema/batch_issue_redeem.py
+++ b/app/model/schema/batch_issue_redeem.py
@@ -21,9 +21,9 @@ from typing import List
 from pydantic import BaseModel, ConfigDict, Field
 
 from app.model.db import TokenType
+from app.model.schema.base import ResultSet
 
 from .personal_info import PersonalInfo
-from .types import ResultSet
 
 ############################
 # RESPONSE

--- a/app/model/schema/bc_explorer.py
+++ b/app/model/schema/bc_explorer.py
@@ -23,7 +23,7 @@ from pydantic import BaseModel, Field, NonNegativeInt, RootModel, field_validato
 from pydantic.dataclasses import dataclass
 from web3 import Web3
 
-from .types import ResultSet, SortOrder
+from app.model.schema.base import ResultSet, SortOrder
 
 ############################
 # COMMON

--- a/app/model/schema/e2e_messaging.py
+++ b/app/model/schema/e2e_messaging.py
@@ -21,10 +21,9 @@ from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel, Field, field_validator
 
+from app.model.schema.base import ResultSet
 from app.utils.check_utils import check_value_is_encrypted
 from config import E2EE_REQUEST_ENABLED
-
-from .types import ResultSet
 
 
 ############################

--- a/app/model/schema/file.py
+++ b/app/model/schema/file.py
@@ -18,13 +18,12 @@ SPDX-License-Identifier: Apache-2.0
 """
 import base64
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import List, Optional
 
 from pydantic import BaseModel, Field, field_validator
 
+from app.model.schema.base import ResultSet
 from config import MAX_UPLOAD_FILE_SIZE
-
-from .types import ResultSet
 
 ############################
 # REQUEST

--- a/app/model/schema/ledger.py
+++ b/app/model/schema/ledger.py
@@ -22,8 +22,7 @@ from typing import List, Optional
 from pydantic import BaseModel, Field, field_validator
 
 from app.model.db import LedgerDetailsDataType, TokenType
-
-from .types import ResultSet
+from app.model.schema.base import ResultSet
 
 ############################
 # REQUEST

--- a/app/model/schema/notification.py
+++ b/app/model/schema/notification.py
@@ -16,15 +16,13 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
-
 from typing import List, Literal, Optional, Union
 
 from pydantic import BaseModel, Field, RootModel
 from typing_extensions import Annotated
 
 from app.model.db import BatchIssueRedeemProcessingCategory, NotificationType, TokenType
-
-from .types import ResultSet
+from app.model.schema.base import ResultSet
 
 
 class IssueErrorMetaInfo(BaseModel):

--- a/app/model/schema/personal_info.py
+++ b/app/model/schema/personal_info.py
@@ -23,7 +23,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 from web3 import Web3
 
 from app.model.db import BatchRegisterPersonalInfoUploadStatus
-from app.model.schema.types import ResultSet
+from app.model.schema.base import ResultSet
 
 
 class PersonalInfo(BaseModel):

--- a/app/model/schema/position.py
+++ b/app/model/schema/position.py
@@ -25,8 +25,7 @@ from pydantic.dataclasses import dataclass
 from web3 import Web3
 
 from app.model.db import TokenType
-
-from .types import ResultSet, SortOrder
+from app.model.schema.base import ResultSet, SortOrder
 
 ############################
 # COMMON

--- a/app/model/schema/token.py
+++ b/app/model/schema/token.py
@@ -40,7 +40,7 @@ class IbetStraightBondCreate(BaseModel):
     name: str = Field(max_length=100)
     total_supply: int = Field(..., ge=0, le=1_000_000_000_000)
     face_value: int = Field(..., ge=0, le=5_000_000_000)
-    face_value_currency: Optional[str] = Field(default=None, min_length=3, max_length=3)
+    face_value_currency: str = Field(..., min_length=3, max_length=3)
     purpose: str = Field(max_length=2000)
     symbol: Optional[str] = Field(default=None, max_length=100)
     redemption_date: Optional[YYYYMMDD_constr] = None

--- a/app/model/schema/token.py
+++ b/app/model/schema/token.py
@@ -26,9 +26,18 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 from pydantic.dataclasses import dataclass
 from web3 import Web3
 
+from app.model.schema.base import (
+    EMPTY_str,
+    IbetShareContractVersion,
+    IbetStraightBondContractVersion,
+    MMDD_constr,
+    ResultSet,
+    SortOrder,
+    YYYYMMDD_constr,
+)
+
 from . import LockEventCategory
 from .position import LockEvent
-from .types import EMPTY_str, MMDD_constr, ResultSet, SortOrder, YYYYMMDD_constr
 
 
 ############################
@@ -539,6 +548,7 @@ class IbetStraightBondResponse(BaseModel):
     token_status: int
     transfer_approval_required: bool
     memo: str
+    contract_version: IbetStraightBondContractVersion
 
 
 class IbetShareResponse(BaseModel):
@@ -567,6 +577,7 @@ class IbetShareResponse(BaseModel):
     token_status: int
     is_canceled: bool
     memo: str
+    contract_version: IbetShareContractVersion
 
 
 class TokenOperationLogResponse(BaseModel):

--- a/app/model/schema/token_holders.py
+++ b/app/model/schema/token_holders.py
@@ -23,8 +23,8 @@ from fastapi import Query
 from pydantic import BaseModel, ConfigDict, Field, NonNegativeInt, field_validator
 
 from app.model.db import TokenHolderBatchStatus
+from app.model.schema.base import ResultSet, SortOrder
 from app.model.schema.personal_info import PersonalInfoIndex
-from app.model.schema.types import ResultSet, SortOrder
 
 
 ############################

--- a/app/model/schema/transfer.py
+++ b/app/model/schema/transfer.py
@@ -23,8 +23,9 @@ from fastapi import Query
 from pydantic import BaseModel, Field, NonNegativeInt
 from pydantic.dataclasses import dataclass
 
+from app.model.schema.base import ResultSet
+
 from .personal_info import PersonalInfo
-from .types import ResultSet
 
 ############################
 # COMMON

--- a/app/routers/bond.py
+++ b/app/routers/bond.py
@@ -55,7 +55,6 @@ from app.model.blockchain import (
     IbetSecurityTokenEscrow,
     IbetStraightBondContract,
     PersonalInfoContract,
-    TokenListContract,
 )
 from app.model.blockchain.tx_params.ibet_security_token_escrow import (
     ApproveTransferParams as EscrowApproveTransferParams,
@@ -229,7 +228,7 @@ def issue_token(
 
     # Check need update
     update_items = [
-        "face_value_currency",
+        "face_value_currency",  # Required field
         "redemption_value_currency",
         "interest_rate",
         "interest_payment_date",
@@ -246,59 +245,22 @@ def issue_token(
         "transfer_approval_required",
     ]
     token_dict = token.__dict__
-    is_update = False
     for key in update_items:
         item = token_dict.get(key)
         if item is not None:
-            is_update = True
             break
 
-    if is_update:
-        # Register token for the update batch
-        _update_token = UpdateToken()
-        _update_token.token_address = contract_address
-        _update_token.issuer_address = issuer_address
-        _update_token.type = TokenType.IBET_STRAIGHT_BOND.value
-        _update_token.arguments = token_dict
-        _update_token.status = 0  # pending
-        _update_token.trigger = "Issue"
-        db.add(_update_token)
+    # Register token for the update batch
+    _update_token = UpdateToken()
+    _update_token.token_address = contract_address
+    _update_token.issuer_address = issuer_address
+    _update_token.type = TokenType.IBET_STRAIGHT_BOND.value
+    _update_token.arguments = token_dict
+    _update_token.status = 0  # pending
+    _update_token.trigger = "Issue"
+    db.add(_update_token)
 
-        token_status = 0  # processing
-    else:
-        # Register token_address token list
-        try:
-            TokenListContract(config.TOKEN_LIST_CONTRACT_ADDRESS).register(
-                token_address=contract_address,
-                token_template=TokenType.IBET_STRAIGHT_BOND.value,
-                tx_from=issuer_address,
-                private_key=private_key,
-            )
-        except SendTransactionError:
-            raise SendTransactionError("failed to register token address token list")
-
-        # Insert initial position data
-        _position = IDXPosition()
-        _position.token_address = contract_address
-        _position.account_address = issuer_address
-        _position.balance = token.total_supply
-        _position.exchange_balance = 0
-        _position.exchange_commitment = 0
-        _position.pending_transfer = 0
-        db.add(_position)
-
-        # Insert issuer's UTXO data
-        block = ContractUtils.get_block_by_transaction_hash(tx_hash)
-        _utxo = UTXO()
-        _utxo.transaction_hash = tx_hash
-        _utxo.account_address = issuer_address
-        _utxo.token_address = contract_address
-        _utxo.amount = token.total_supply
-        _utxo.block_number = block["number"]
-        _utxo.block_timestamp = datetime.utcfromtimestamp(block["timestamp"])
-        db.add(_utxo)
-
-        token_status = 1  # succeeded
+    token_status = 0  # processing (Since `face_value_currency` is a required field, an update transaction is always executed.)
 
     # Register token data
     _token = Token()

--- a/app/routers/bond.py
+++ b/app/routers/bond.py
@@ -93,6 +93,7 @@ from app.model.db import (
     TokenType,
     TokenUpdateOperationCategory,
     TokenUpdateOperationLog,
+    TokenVersion,
     TransferApprovalHistory,
     TransferApprovalOperationType,
     UpdateToken,
@@ -267,6 +268,7 @@ def issue_token(
     _token.token_address = contract_address
     _token.abi = abi
     _token.token_status = token_status
+    _token.version = TokenVersion.V_23_12
     db.add(_token)
 
     # Register operation log
@@ -329,6 +331,7 @@ def list_all_tokens(
             local_tz
         ).isoformat()
         bond_token["token_status"] = token.token_status
+        bond_token["contract_version"] = token.version
         bond_token.pop("contract_name")
         bond_tokens.append(bond_token)
 
@@ -365,6 +368,7 @@ def retrieve_token(db: DBSession, token_address: str):
     issue_datetime_utc = timezone("UTC").localize(_token.created)
     bond_token["issue_datetime"] = issue_datetime_utc.astimezone(local_tz).isoformat()
     bond_token["token_status"] = _token.token_status
+    bond_token["contract_version"] = _token.version
     bond_token.pop("contract_name")
 
     return json_response(bond_token)

--- a/app/routers/bond.py
+++ b/app/routers/bond.py
@@ -68,7 +68,6 @@ from app.model.blockchain.tx_params.ibet_straight_bond import (
     UpdateParams,
 )
 from app.model.db import (
-    UTXO,
     Account,
     BatchIssueRedeem,
     BatchIssueRedeemProcessingCategory,
@@ -134,7 +133,6 @@ from app.model.schema import (
     TransferApprovalHistoryResponse,
     TransferApprovalsResponse,
     TransferApprovalTokenDetailResponse,
-    TransferApprovalTokenResponse,
     TransferHistoryResponse,
     UpdateTransferApprovalOperationType,
     UpdateTransferApprovalRequest,
@@ -145,7 +143,6 @@ from app.utils.check_utils import (
     eoa_password_is_encrypted_value,
     validate_headers,
 )
-from app.utils.contract_utils import ContractUtils
 from app.utils.docs_utils import get_routers_responses
 from app.utils.fastapi_utils import json_response
 

--- a/app/routers/share.py
+++ b/app/routers/share.py
@@ -95,11 +95,12 @@ from app.model.db import (
     Token,
     TokenType,
     TokenUpdateOperationLog,
+    TokenVersion,
     TransferApprovalHistory,
     TransferApprovalOperationType,
     UpdateToken,
 )
-from app.model.schema import (  # Request; Response
+from app.model.schema import (
     BatchIssueRedeemUploadIdResponse,
     BatchRegisterPersonalInfoUploadResponse,
     BulkTransferResponse,
@@ -135,7 +136,6 @@ from app.model.schema import (  # Request; Response
     TransferApprovalHistoryResponse,
     TransferApprovalsResponse,
     TransferApprovalTokenDetailResponse,
-    TransferApprovalTokenResponse,
     TransferHistoryResponse,
     UpdateTransferApprovalOperationType,
     UpdateTransferApprovalRequest,
@@ -304,6 +304,7 @@ def issue_token(
     _token.token_address = contract_address
     _token.abi = abi
     _token.token_status = token_status
+    _token.version = TokenVersion.V_22_12
     db.add(_token)
 
     # Register operation log
@@ -361,6 +362,7 @@ def list_all_tokens(
             local_tz
         ).isoformat()
         share_token["token_status"] = token.token_status
+        share_token["contract_version"] = token.version
         share_token.pop("contract_name")
         share_tokens.append(share_token)
 
@@ -397,6 +399,7 @@ def retrieve_token(db: DBSession, token_address: str):
     issue_datetime_utc = timezone("UTC").localize(_token.created)
     share_token["issue_datetime"] = issue_datetime_utc.astimezone(local_tz).isoformat()
     share_token["token_status"] = _token.token_status
+    share_token["contract_version"] = _token.version
     share_token.pop("contract_name")
 
     return json_response(share_token)

--- a/cmd/explorer/src/connector/__init__.py
+++ b/cmd/explorer/src/connector/__init__.py
@@ -22,7 +22,6 @@ from dataclasses import asdict
 from typing import Any
 
 from aiohttp import ClientSession
-
 from cache import AsyncTTL
 
 path = os.path.join(os.path.dirname(__file__), "../../../../")

--- a/cmd/explorer/src/gui/screen/block.py
+++ b/cmd/explorer/src/gui/screen/block.py
@@ -49,7 +49,7 @@ from app.model.schema import (
     ListBlockDataQuery,
     ListTxDataQuery,
 )
-from app.model.schema.types import SortOrder
+from app.model.schema.base import SortOrder
 
 
 class BlockScreen(TuiScreen):

--- a/cmd/explorer/src/gui/widget/query_panel.py
+++ b/cmd/explorer/src/gui/widget/query_panel.py
@@ -31,7 +31,7 @@ from textual.message import Message
 from textual.widgets import Button, Input, Label
 
 from app.model.schema import ListBlockDataQuery
-from app.model.schema.types import SortOrder
+from app.model.schema.base import SortOrder
 
 if TYPE_CHECKING:
     from src.gui.explorer import ExplorerApp

--- a/config.py
+++ b/config.py
@@ -28,6 +28,9 @@ SERVER_NAME = "ibet-Prime"
 # System timezone for REST API
 TZ = os.environ.get("TZ") or "Asia/Tokyo"
 
+# Default currency code
+DEFAULT_CURRENCY = os.environ.get("DEFAULT_CURRENCY") or "JPY"
+
 # Blockchain network
 NETWORK = os.environ.get("NETWORK") or "IBET"  # IBET or IBETFIN
 

--- a/migrations/versions/679359eceb76_v23_12_0_feature_562.py
+++ b/migrations/versions/679359eceb76_v23_12_0_feature_562.py
@@ -1,0 +1,44 @@
+"""v23_12_0_feature_562
+
+Revision ID: 679359eceb76
+Revises: 380a311952f4
+Create Date: 2023-11-25 23:50:48.724937
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import update
+
+from app.database import get_db_schema
+from app.model.db import Token, TokenVersion
+
+# revision identifiers, used by Alembic.
+revision = "679359eceb76"
+down_revision = "380a311952f4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Add column
+    op.add_column(
+        "token",
+        sa.Column("version", sa.String(length=5), nullable=True),
+        schema=get_db_schema(),
+    )
+
+    # Set default value
+    op.get_bind().execute(update(Token).values(version=TokenVersion.V_22_12))
+
+    # Change column to nullable=False
+    op.alter_column(
+        "token",
+        "version",
+        existing_type=sa.String(length=5),
+        nullable=False,
+        schema=get_db_schema(),
+    )
+
+
+def downgrade():
+    op.drop_column("token", "version", schema=get_db_schema())

--- a/tests/model/blockchain/test_token_IbetStraightBond.py
+++ b/tests/model/blockchain/test_token_IbetStraightBond.py
@@ -48,7 +48,7 @@ from app.model.blockchain.tx_params.ibet_straight_bond import (
 )
 from app.model.db import TokenAttrUpdate, TokenCache
 from app.utils.contract_utils import ContractUtils
-from config import TOKEN_CACHE_TTL, ZERO_ADDRESS
+from config import DEFAULT_CURRENCY, TOKEN_CACHE_TTL, ZERO_ADDRESS
 from tests.account_config import config_eth_account
 from tests.utils.contract_utils import (
     IbetSecurityTokenContractTestUtils,
@@ -604,7 +604,7 @@ class TestGet:
         assert bond_contract.is_offering is False
         assert bond_contract.transfer_approval_required is False
         assert bond_contract.face_value == 0
-        assert bond_contract.face_value_currency == ""
+        assert bond_contract.face_value_currency == DEFAULT_CURRENCY
         assert bond_contract.interest_rate == 0
         assert bond_contract.interest_payment_date == [
             "",

--- a/tests/test_app_routers_blockchain_explorer_tx_data_{hash}_GET.py
+++ b/tests/test_app_routers_blockchain_explorer_tx_data_{hash}_GET.py
@@ -22,7 +22,7 @@ from eth_utils import to_checksum_address
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
-from app.model.db import IDXTxData, Token
+from app.model.db import IDXTxData, Token, TokenVersion
 
 
 class TestGetTxData:
@@ -69,6 +69,7 @@ class TestGetTxData:
         token.issuer_address = ""
         token.token_address = token_info.get("token_address")
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         session.add(token)
         session.commit()
 

--- a/tests/test_app_routers_bond_bulk_transfer_POST.py
+++ b/tests/test_app_routers_bond_bulk_transfer_POST.py
@@ -27,6 +27,7 @@ from app.model.db import (
     BulkTransferUpload,
     Token,
     TokenType,
+    TokenVersion,
 )
 from app.utils.e2ee_utils import E2EEUtils
 from tests.account_config import config_eth_account
@@ -81,6 +82,7 @@ class TestAppRoutersBondBulkTransferPOST:
             _token.issuer_address = self.admin_address
             _token.token_address = _t
             _token.abi = ""
+            _token.version = TokenVersion.V_23_12
             db.add(_token)
 
         # request target API
@@ -165,6 +167,7 @@ class TestAppRoutersBondBulkTransferPOST:
             _token.issuer_address = self.admin_address
             _token.token_address = _t
             _token.abi = ""
+            _token.version = TokenVersion.V_23_12
             db.add(_token)
 
         # request target API
@@ -554,6 +557,7 @@ class TestAppRoutersBondBulkTransferPOST:
         _token.token_address = self.req_tokens[0]
         _token.abi = ""
         _token.token_status = 0
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # request target API

--- a/tests/test_app_routers_bond_lock_events_GET.py
+++ b/tests/test_app_routers_bond_lock_events_GET.py
@@ -24,7 +24,7 @@ import pytest
 from sqlalchemy.orm import Session
 
 from app.model.blockchain import IbetStraightBondContract
-from app.model.db import IDXLock, IDXUnlock, Token, TokenType
+from app.model.db import IDXLock, IDXUnlock, Token, TokenType, TokenVersion
 
 
 class TestAppRoutersBondLockEvents:
@@ -55,6 +55,7 @@ class TestAppRoutersBondLockEvents:
         _token.tx_hash = ""
         _token.abi = ""
         _token.token_status = token_status
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Token
@@ -65,6 +66,7 @@ class TestAppRoutersBondLockEvents:
         _token.tx_hash = ""
         _token.abi = ""
         _token.token_status = token_status
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Lock events
@@ -204,6 +206,7 @@ class TestAppRoutersBondLockEvents:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # request target api

--- a/tests/test_app_routers_bond_tokens_GET.py
+++ b/tests/test_app_routers_bond_tokens_GET.py
@@ -22,7 +22,7 @@ import pytz
 from web3.datastructures import AttributeDict
 
 from app.model.blockchain import IbetStraightBondContract
-from app.model.db import Token, TokenType
+from app.model.db import Token, TokenType, TokenVersion
 from config import TZ
 from tests.account_config import config_eth_account
 
@@ -57,6 +57,7 @@ class TestAppRoutersBondTokensGET:
         token.issuer_address = issuer_address_1
         token.token_address = "token_address_test1"
         token.abi = "abi_test1"
+        token.version = TokenVersion.V_23_12
         db.add(token)
         db.commit()
         _issue_datetime = (
@@ -160,6 +161,7 @@ class TestAppRoutersBondTokensGET:
                 "token_status": 1,
                 "transfer_approval_required": True,
                 "memo": "memo_test1",
+                "contract_version": TokenVersion.V_23_12,
             }
         ]
 
@@ -182,6 +184,7 @@ class TestAppRoutersBondTokensGET:
         token_1.issuer_address = issuer_address_1
         token_1.token_address = "token_address_test1"
         token_1.abi = "abi_test1"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
         db.commit()
         _issue_datetime_1 = (
@@ -245,6 +248,7 @@ class TestAppRoutersBondTokensGET:
         token_2.token_address = "token_address_test2"
         token_2.abi = "abi_test2"
         token_2.token_status = 0
+        token_2.version = TokenVersion.V_23_12
         db.add(token_2)
         db.commit()
         _issue_datetime_2 = (
@@ -351,6 +355,7 @@ class TestAppRoutersBondTokensGET:
                 "token_status": 1,
                 "transfer_approval_required": True,
                 "memo": "memo_test1",
+                "contract_version": TokenVersion.V_23_12,
             },
             {
                 "issuer_address": token_2.issuer_address,
@@ -395,6 +400,7 @@ class TestAppRoutersBondTokensGET:
                 "token_status": 0,
                 "transfer_approval_required": False,
                 "memo": "memo_test2",
+                "contract_version": TokenVersion.V_23_12,
             },
         ]
 
@@ -416,6 +422,7 @@ class TestAppRoutersBondTokensGET:
         token.issuer_address = issuer_address_1
         token.token_address = "token_address_test1"
         token.abi = "abi_test1"
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         resp = client.get(self.apiurl, headers={"issuer-address": issuer_address_2})
@@ -438,6 +445,7 @@ class TestAppRoutersBondTokensGET:
         token_1.issuer_address = issuer_address_1
         token_1.token_address = "token_address_test1"
         token_1.abi = "abi_test1"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
         db.commit()
         _issue_datetime = (
@@ -502,6 +510,7 @@ class TestAppRoutersBondTokensGET:
         token_2.issuer_address = issuer_address_2
         token_2.token_address = "token_address_test1"
         token_2.abi = "abi_test1"
+        token_2.version = TokenVersion.V_23_12
         db.add(token_2)
 
         resp = client.get(self.apiurl, headers={"issuer-address": issuer_address_1})
@@ -550,6 +559,7 @@ class TestAppRoutersBondTokensGET:
                 "token_status": 1,
                 "transfer_approval_required": True,
                 "memo": "memo_test1",
+                "contract_version": TokenVersion.V_23_12,
             }
         ]
 
@@ -572,6 +582,7 @@ class TestAppRoutersBondTokensGET:
         token_1.issuer_address = issuer_address_1
         token_1.token_address = "token_address_test1"
         token_1.abi = "abi_test1"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
         db.commit()
         _issue_datetime_1 = (
@@ -635,6 +646,7 @@ class TestAppRoutersBondTokensGET:
         token_2.token_address = "token_address_test2"
         token_2.abi = "abi_test2"
         token_2.token_status = 0
+        token_2.version = TokenVersion.V_23_12
         db.add(token_2)
         db.commit()
         _issue_datetime_2 = (
@@ -702,6 +714,7 @@ class TestAppRoutersBondTokensGET:
         token_3.issuer_address = issuer_address_2
         token_3.token_address = "token_address_test1"
         token_3.abi = "abi_test1"
+        token_3.version = TokenVersion.V_23_12
         db.add(token_3)
 
         resp = client.get(self.apiurl, headers={"issuer-address": issuer_address_1})
@@ -750,6 +763,7 @@ class TestAppRoutersBondTokensGET:
                 "token_status": 1,
                 "transfer_approval_required": True,
                 "memo": "memo_test1",
+                "contract_version": TokenVersion.V_23_12,
             },
             {
                 "issuer_address": token_2.issuer_address,
@@ -794,6 +808,7 @@ class TestAppRoutersBondTokensGET:
                 "token_status": 0,
                 "transfer_approval_required": False,
                 "memo": "memo_test2",
+                "contract_version": TokenVersion.V_23_12,
             },
         ]
 

--- a/tests/test_app_routers_bond_tokens_POST.py
+++ b/tests/test_app_routers_bond_tokens_POST.py
@@ -37,6 +37,7 @@ from app.model.db import (
     Token,
     TokenType,
     TokenUpdateOperationLog,
+    TokenVersion,
     UpdateToken,
 )
 from app.utils.contract_utils import ContractUtils
@@ -157,6 +158,7 @@ class TestAppRoutersBondTokensPOST:
             assert token_1.token_address == "contract_address_test1"
             assert token_1.abi == "abi_test1"
             assert token_1.token_status == 0
+            assert token_1.version == TokenVersion.V_23_12
 
             position = db.scalars(select(IDXPosition).limit(1)).first()
             assert position is None
@@ -173,9 +175,9 @@ class TestAppRoutersBondTokensPOST:
             assert update_token.status == 0
             assert update_token.trigger == "Issue"
 
-    # <Normal_3>
+    # <Normal_2>
     # Authorization by auth token
-    def test_normal_3(self, client, db):
+    def test_normal_2(self, client, db):
         test_account = config_eth_account("user1")
 
         # prepare data
@@ -251,6 +253,7 @@ class TestAppRoutersBondTokensPOST:
             assert token_1.token_address == "contract_address_test1"
             assert token_1.abi == "abi_test1"
             assert token_1.token_status == 0
+            assert token_1.version == TokenVersion.V_23_12
 
             position = db.scalars(select(IDXPosition).limit(1)).first()
             assert position is None

--- a/tests/test_app_routers_bond_tokens_POST.py
+++ b/tests/test_app_routers_bond_tokens_POST.py
@@ -29,7 +29,6 @@ from web3.middleware import geth_poa_middleware
 import config
 from app.exceptions import SendTransactionError
 from app.model.blockchain.token import IbetStraightBondContract
-from app.model.blockchain.token_list import TokenListContract
 from app.model.db import (
     UTXO,
     Account,
@@ -57,7 +56,7 @@ class TestAppRoutersBondTokensPOST:
     ###########################################################################
 
     # <Normal_1>
-    # create only
+    # Authorization by eoa password
     def test_normal_1(self, client, db):
         test_account = config_eth_account("user1")
 
@@ -75,10 +74,6 @@ class TestAppRoutersBondTokensPOST:
             target="app.model.blockchain.token.IbetStraightBondContract.create",
             return_value=("contract_address_test1", "abi_test1", "tx_hash_test1"),
         )
-        TokenListContract_register = patch(
-            target="app.model.blockchain.token_list.TokenListContract.register",
-            return_value=None,
-        )
         ContractUtils_get_block_by_transaction_hash = patch(
             target="app.utils.contract_utils.ContractUtils.get_block_by_transaction_hash",
             return_value={
@@ -91,122 +86,19 @@ class TestAppRoutersBondTokensPOST:
 
         with (
             IbetStraightBondContract_create
-        ), TokenListContract_register, ContractUtils_get_block_by_transaction_hash:
-            # request target api
-            req_param = {
-                "name": "name_test1",
-                "total_supply": 10000,
-                "face_value": 200,
-                "purpose": "purpose_test1",
-            }
-            resp = client.post(
-                self.apiurl,
-                json=req_param,
-                headers={
-                    "issuer-address": test_account["address"],
-                    "eoa-password": E2EEUtils.encrypt("password"),
-                },
-            )
-
-            # assertion
-            IbetStraightBondContract.create.assert_called_with(
-                args=["name_test1", "", 10000, 200, "", 0, "", "", "purpose_test1"],
-                tx_from=test_account["address"],
-                private_key=ANY,
-            )
-            TokenListContract.register.assert_called_with(
-                token_address="contract_address_test1",
-                token_template=TokenType.IBET_STRAIGHT_BOND.value,
-                tx_from=test_account["address"],
-                private_key=ANY,
-            )
-            ContractUtils.get_block_by_transaction_hash(tx_hash="tx_hash_test1")
-
-            assert resp.status_code == 200
-            assert resp.json()["token_address"] == "contract_address_test1"
-            assert resp.json()["token_status"] == 1
-
-            token_after = db.scalars(select(Token)).all()
-            assert 0 == len(token_before)
-            assert 1 == len(token_after)
-            token_1 = token_after[0]
-            assert token_1.id == 1
-            assert token_1.type == TokenType.IBET_STRAIGHT_BOND.value
-            assert token_1.tx_hash == "tx_hash_test1"
-            assert token_1.issuer_address == test_account["address"]
-            assert token_1.token_address == "contract_address_test1"
-            assert token_1.abi == "abi_test1"
-            assert token_1.token_status == 1
-
-            position = db.scalars(select(IDXPosition).limit(1)).first()
-            assert position.token_address == "contract_address_test1"
-            assert position.account_address == test_account["address"]
-            assert position.balance == req_param["total_supply"]
-            assert position.exchange_balance == 0
-            assert position.exchange_commitment == 0
-            assert position.pending_transfer == 0
-
-            utxo = db.scalars(select(UTXO).limit(1)).first()
-            assert utxo.transaction_hash == "tx_hash_test1"
-            assert utxo.account_address == test_account["address"]
-            assert utxo.token_address == "contract_address_test1"
-            assert utxo.amount == req_param["total_supply"]
-            assert utxo.block_number == 12345
-            assert utxo.block_timestamp == datetime(2021, 4, 27, 12, 34, 56)
-
-            operation_log = db.scalars(select(TokenUpdateOperationLog).limit(1)).first()
-            assert operation_log.token_address == "contract_address_test1"
-            assert operation_log.type == TokenType.IBET_STRAIGHT_BOND.value
-            assert operation_log.operation_category == "Issue"
-
-    # <Normal_2>
-    # include updates
-    def test_normal_2(self, client, db):
-        test_account = config_eth_account("user1")
-
-        # prepare data
-        account = Account()
-        account.issuer_address = test_account["address"]
-        account.keyfile = test_account["keyfile_json"]
-        account.eoa_password = E2EEUtils.encrypt("password")
-        db.add(account)
-
-        token_before = db.scalars(select(Token)).all()
-
-        # mock
-        IbetStraightBondContract_create = patch(
-            target="app.model.blockchain.token.IbetStraightBondContract.create",
-            return_value=("contract_address_test1", "abi_test1", "tx_hash_test1"),
-        )
-        TokenListContract_register = patch(
-            target="app.model.blockchain.token_list.TokenListContract.register",
-            return_value=None,
-        )
-        ContractUtils_get_block_by_transaction_hash = patch(
-            target="app.utils.contract_utils.ContractUtils.get_block_by_transaction_hash",
-            return_value={
-                "number": 12345,
-                "timestamp": datetime(
-                    2021, 4, 27, 12, 34, 56, tzinfo=timezone.utc
-                ).timestamp(),
-            },
-        )
-
-        with (
-            IbetStraightBondContract_create
-        ), TokenListContract_register, ContractUtils_get_block_by_transaction_hash:
+        ), ContractUtils_get_block_by_transaction_hash:
             # request target api
             req_param = {
                 "name": "name_test1",
                 "symbol": "symbol_test1",
                 "total_supply": 10000,
                 "face_value": 200,
+                "face_value_currency": "JPY",  # update
                 "redemption_date": "20211231",
                 "redemption_value": 4000,
                 "return_date": "20211231",
                 "return_amount": "return_amount_test1",
                 "purpose": "purpose_test1",
-                "face_value_currency": "JPY",  # update
                 "redemption_value_currency": "JPY",  # update
                 "interest_rate": 0.0001,  # update
                 "interest_payment_date": ["0331", "0930"],  # update
@@ -248,8 +140,6 @@ class TestAppRoutersBondTokensPOST:
                 tx_from=test_account["address"],
                 private_key=ANY,
             )
-
-            TokenListContract.register.assert_not_called()
             ContractUtils.get_block_by_transaction_hash.assert_not_called()
 
             assert resp.status_code == 200
@@ -308,10 +198,6 @@ class TestAppRoutersBondTokensPOST:
             target="app.model.blockchain.token.IbetStraightBondContract.create",
             return_value=("contract_address_test1", "abi_test1", "tx_hash_test1"),
         )
-        TokenListContract_register = patch(
-            target="app.model.blockchain.token_list.TokenListContract.register",
-            return_value=None,
-        )
         ContractUtils_get_block_by_transaction_hash = patch(
             target="app.utils.contract_utils.ContractUtils.get_block_by_transaction_hash",
             return_value={
@@ -324,12 +210,13 @@ class TestAppRoutersBondTokensPOST:
 
         with (
             IbetStraightBondContract_create
-        ), TokenListContract_register, ContractUtils_get_block_by_transaction_hash:
+        ), ContractUtils_get_block_by_transaction_hash:
             # request target api
             req_param = {
                 "name": "name_test1",
                 "total_supply": 10000,
                 "face_value": 200,
+                "face_value_currency": "JPY",
                 "purpose": "purpose_test1",
             }
             resp = client.post(
@@ -347,17 +234,11 @@ class TestAppRoutersBondTokensPOST:
                 tx_from=test_account["address"],
                 private_key=ANY,
             )
-            TokenListContract.register.assert_called_with(
-                token_address="contract_address_test1",
-                token_template=TokenType.IBET_STRAIGHT_BOND.value,
-                tx_from=test_account["address"],
-                private_key=ANY,
-            )
             ContractUtils.get_block_by_transaction_hash(tx_hash="tx_hash_test1")
 
             assert resp.status_code == 200
             assert resp.json()["token_address"] == "contract_address_test1"
-            assert resp.json()["token_status"] == 1
+            assert resp.json()["token_status"] == 0
 
             token_after = db.scalars(select(Token)).all()
             assert 0 == len(token_before)
@@ -369,23 +250,13 @@ class TestAppRoutersBondTokensPOST:
             assert token_1.issuer_address == test_account["address"]
             assert token_1.token_address == "contract_address_test1"
             assert token_1.abi == "abi_test1"
-            assert token_1.token_status == 1
+            assert token_1.token_status == 0
 
             position = db.scalars(select(IDXPosition).limit(1)).first()
-            assert position.token_address == "contract_address_test1"
-            assert position.account_address == test_account["address"]
-            assert position.balance == req_param["total_supply"]
-            assert position.exchange_balance == 0
-            assert position.exchange_commitment == 0
-            assert position.pending_transfer == 0
+            assert position is None
 
             utxo = db.scalars(select(UTXO).limit(1)).first()
-            assert utxo.transaction_hash == "tx_hash_test1"
-            assert utxo.account_address == test_account["address"]
-            assert utxo.token_address == "contract_address_test1"
-            assert utxo.amount == req_param["total_supply"]
-            assert utxo.block_number == 12345
-            assert utxo.block_timestamp == datetime(2021, 4, 27, 12, 34, 56)
+            assert utxo is None
 
             operation_log = db.scalars(select(TokenUpdateOperationLog).limit(1)).first()
             assert operation_log.token_address == "contract_address_test1"
@@ -477,6 +348,41 @@ class TestAppRoutersBondTokensPOST:
             "meta": {"code": 1, "title": "RequestValidationError"},
             "detail": [
                 {
+                    "type": "missing",
+                    "loc": ["body", "face_value_currency"],
+                    "msg": "Field required",
+                    "input": {
+                        "name": "name_test1",
+                        "symbol": "symbol_test1",
+                        "total_supply": 10000,
+                        "face_value": 200,
+                        "redemption_date": "20211231",
+                        "redemption_value": 4000,
+                        "return_date": "20211231",
+                        "return_amount": "return_amount_test1",
+                        "purpose": "purpose_test1",
+                        "base_fx_rate": 123.4567899,
+                        "interest_rate": 12.34567,
+                        "interest_payment_date": [
+                            "0101",
+                            "0201",
+                            "0301",
+                            "0401",
+                            "0501",
+                            "0601",
+                            "0701",
+                            "0801",
+                            "0901",
+                            "1001",
+                            "1101",
+                            "1201",
+                            "1231",
+                        ],
+                        "tradable_exchange_contract_address": "0x0",
+                        "personal_info_contract_address": "0x0",
+                    },
+                },
+                {
                     "type": "value_error",
                     "loc": ["body", "interest_rate"],
                     "msg": "Value error, interest_rate must be less than or equal to four decimal places",
@@ -538,6 +444,7 @@ class TestAppRoutersBondTokensPOST:
             "symbol": "symbol_test1",
             "total_supply": 10000,
             "face_value": 200,
+            "face_value_currency": "JPY",
             "redemption_date": "20211231",
             "redemption_value": 4000,
             "return_date": "20211231",
@@ -581,6 +488,7 @@ class TestAppRoutersBondTokensPOST:
             "symbol": "symbol_test1",
             "total_supply": 10000,
             "face_value": 200,
+            "face_value_currency": "JPY",
             "redemption_date": "20211231",
             "redemption_value": 4000,
             "return_date": "20211231",
@@ -620,6 +528,7 @@ class TestAppRoutersBondTokensPOST:
             "symbol": "symbol_test1",
             "total_supply": 10000,
             "face_value": 200,
+            "face_value_currency": "JPY",
             "redemption_date": "20211231",
             "redemption_value": 4000,
             "return_date": "20211231",
@@ -658,6 +567,7 @@ class TestAppRoutersBondTokensPOST:
             "symbol": "symbol_test1",
             "total_supply": -1,
             "face_value": -1,
+            "face_value_currency": "JPY",
             "redemption_date": "20211231",
             "redemption_value": -1,
             "return_date": "20211231",
@@ -874,6 +784,7 @@ class TestAppRoutersBondTokensPOST:
             "symbol": "symbol_test1",
             "total_supply": 10000,
             "face_value": 200,
+            "face_value_currency": "JPY",
             "redemption_date": "invalid_date",
             "redemption_value": 4000,
             "return_date": "invalid_date",
@@ -940,6 +851,7 @@ class TestAppRoutersBondTokensPOST:
             "symbol": "symbol_test1",
             "total_supply": 10000,
             "face_value": 200,
+            "face_value_currency": "JPY",
             "redemption_date": "20211231",
             "redemption_value": 4000,
             "return_date": "20211231",
@@ -980,6 +892,7 @@ class TestAppRoutersBondTokensPOST:
             "symbol": "symbol_test1",
             "total_supply": 10000,
             "face_value": 200,
+            "face_value_currency": "JPY",
             "redemption_date": "20211231",
             "redemption_value": 4000,
             "return_date": "20211231",
@@ -1029,6 +942,7 @@ class TestAppRoutersBondTokensPOST:
                 "symbol": "symbol_test1",
                 "total_supply": 10000,
                 "face_value": 200,
+                "face_value_currency": "JPY",
                 "redemption_date": "20211231",
                 "redemption_value": 4000,
                 "return_date": "20211231",
@@ -1049,58 +963,6 @@ class TestAppRoutersBondTokensPOST:
             assert resp.json() == {
                 "meta": {"code": 2, "title": "SendTransactionError"},
                 "detail": "failed to send transaction",
-            }
-
-    # <Error_5>
-    # Send Transaction Error
-    # TokenListContract.register
-    def test_error_5(self, client, db):
-        test_account = config_eth_account("user1")
-
-        # prepare data
-        account = Account()
-        account.issuer_address = test_account["address"]
-        account.keyfile = test_account["keyfile_json"]
-        account.eoa_password = E2EEUtils.encrypt("password")
-        db.add(account)
-
-        # mock
-        IbetStraightBondContract_create = patch(
-            target="app.model.blockchain.token.IbetStraightBondContract.create",
-            return_value=("contract_address_test1", "abi_test1", "tx_hash_test1"),
-        )
-        TokenListContract_register = patch(
-            target="app.model.blockchain.token_list.TokenListContract.register",
-            side_effect=SendTransactionError(),
-        )
-
-        with IbetStraightBondContract_create, TokenListContract_register:
-            # request target api
-            req_param = {
-                "name": "name_test1",
-                "symbol": "symbol_test1",
-                "total_supply": 10000,
-                "face_value": 200,
-                "redemption_date": "20211231",
-                "redemption_value": 4000,
-                "return_date": "20211231",
-                "return_amount": "return_amount_test1",
-                "purpose": "purpose_test1",
-            }
-            resp = client.post(
-                self.apiurl,
-                json=req_param,
-                headers={
-                    "issuer-address": test_account["address"],
-                    "eoa-password": E2EEUtils.encrypt("password"),
-                },
-            )
-
-            # assertion
-            assert resp.status_code == 400
-            assert resp.json() == {
-                "meta": {"code": 2, "title": "SendTransactionError"},
-                "detail": "failed to register token address token list",
             }
 
 

--- a/tests/test_app_routers_bond_tokens_{token_address}_GET.py
+++ b/tests/test_app_routers_bond_tokens_{token_address}_GET.py
@@ -21,7 +21,7 @@ from unittest import mock
 import pytz
 
 from app.model.blockchain import IbetStraightBondContract
-from app.model.db import Token, TokenType
+from app.model.db import Token, TokenType, TokenVersion
 from config import TZ
 
 
@@ -45,6 +45,7 @@ class TestAppRoutersBondTokensTokenAddressGET:
         token.issuer_address = "issuer_address_test1"
         token.token_address = "token_address_test1"
         token.abi = "abi_test1"
+        token.version = TokenVersion.V_23_12
         db.add(token)
         db.commit()
         _issue_datetime = (
@@ -149,6 +150,7 @@ class TestAppRoutersBondTokensTokenAddressGET:
             "token_status": 1,
             "transfer_approval_required": True,
             "memo": "memo_test1",
+            "contract_version": TokenVersion.V_23_12,
         }
 
         assert resp.status_code == 200
@@ -165,6 +167,7 @@ class TestAppRoutersBondTokensTokenAddressGET:
         token.issuer_address = "issuer_address_test1"
         token.token_address = "token_address_test1"
         token.abi = "abi_test1"
+        token.version = TokenVersion.V_23_12
         db.add(token)
         db.commit()
         _issue_datetime = (
@@ -269,6 +272,7 @@ class TestAppRoutersBondTokensTokenAddressGET:
             "token_status": 1,
             "transfer_approval_required": True,
             "memo": "memo_test1",
+            "contract_version": TokenVersion.V_23_12,
         }
 
         assert resp.status_code == 200
@@ -300,6 +304,7 @@ class TestAppRoutersBondTokensTokenAddressGET:
         token.token_address = "token_address_test1"
         token.abi = "abi_test1"
         token.token_status = 0
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         resp = client.get(self.base_apiurl + "token_address_test1")

--- a/tests/test_app_routers_bond_tokens_{token_address}_POST.py
+++ b/tests/test_app_routers_bond_tokens_{token_address}_POST.py
@@ -35,6 +35,7 @@ from app.model.db import (
     TokenAttrUpdate,
     TokenType,
     TokenUpdateOperationLog,
+    TokenVersion,
     UpdateToken,
 )
 from app.utils.contract_utils import ContractUtils
@@ -102,6 +103,7 @@ class TestAppRoutersBondTokensTokenAddressPOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         db.commit()
@@ -234,6 +236,7 @@ class TestAppRoutersBondTokensTokenAddressPOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API
@@ -298,6 +301,7 @@ class TestAppRoutersBondTokensTokenAddressPOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API
@@ -1047,6 +1051,7 @@ class TestAppRoutersBondTokensTokenAddressPOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # mock
@@ -1166,6 +1171,7 @@ class TestAppRoutersBondTokensTokenAddressPOST:
         token.token_address = _token_address
         token.abi = ""
         token.token_status = 0
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API
@@ -1211,6 +1217,7 @@ class TestAppRoutersBondTokensTokenAddressPOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API

--- a/tests/test_app_routers_bond_tokens_{token_address}_additional_issue_GET.py
+++ b/tests/test_app_routers_bond_tokens_{token_address}_additional_issue_GET.py
@@ -27,6 +27,7 @@ from app.model.db import (
     IDXIssueRedeemSortItem,
     Token,
     TokenType,
+    TokenVersion,
 )
 
 local_tz = timezone(config.TZ)
@@ -72,6 +73,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: IDXIssueRedeem
@@ -105,6 +107,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: IDXIssueRedeem
@@ -183,6 +186,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: IDXIssueRedeem
@@ -267,6 +271,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: IDXIssueRedeem
@@ -351,6 +356,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueGET:
         _token.token_address = self.test_token_address
         _token.abi = {}
         _token.token_status = 0
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # request target API

--- a/tests/test_app_routers_bond_tokens_{token_address}_additional_issue_POST.py
+++ b/tests/test_app_routers_bond_tokens_{token_address}_additional_issue_POST.py
@@ -22,7 +22,7 @@ from unittest.mock import ANY, MagicMock
 
 from app.exceptions import SendTransactionError
 from app.model.blockchain.tx_params.ibet_straight_bond import AdditionalIssueParams
-from app.model.db import Account, AuthToken, Token, TokenType
+from app.model.db import Account, AuthToken, Token, TokenType, TokenVersion
 from app.utils.e2ee_utils import E2EEUtils
 from tests.account_config import config_eth_account
 
@@ -57,6 +57,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssuePOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # mock
@@ -111,6 +112,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssuePOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # mock
@@ -156,6 +158,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssuePOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API
@@ -200,6 +203,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssuePOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API
@@ -244,6 +248,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssuePOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API
@@ -382,6 +387,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssuePOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API
@@ -489,6 +495,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssuePOST:
         token.token_address = _token_address
         token.abi = ""
         token.token_status = 0
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API
@@ -534,6 +541,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssuePOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API

--- a/tests/test_app_routers_bond_tokens_{token_address}_additional_issue_batch_GET.py
+++ b/tests/test_app_routers_bond_tokens_{token_address}_additional_issue_batch_GET.py
@@ -24,6 +24,7 @@ from app.model.db import (
     BatchIssueRedeemUpload,
     Token,
     TokenType,
+    TokenVersion,
 )
 from tests.account_config import config_eth_account
 
@@ -50,6 +51,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueBatchGET:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API
@@ -75,6 +77,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueBatchGET:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         additional_issue_upload1 = BatchIssueRedeemUpload()
@@ -121,6 +124,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueBatchGET:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         additional_issue_upload1 = BatchIssueRedeemUpload()
@@ -235,6 +239,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueBatchGET:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         additional_issue_upload1 = BatchIssueRedeemUpload()
@@ -336,6 +341,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueBatchGET:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         additional_issue_upload1 = BatchIssueRedeemUpload()
@@ -443,6 +449,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueBatchGET:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         additional_issue_upload1 = BatchIssueRedeemUpload()
@@ -542,6 +549,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueBatchGET:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         additional_issue_upload1 = BatchIssueRedeemUpload()
@@ -662,6 +670,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueBatchGET:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API

--- a/tests/test_app_routers_bond_tokens_{token_address}_additional_issue_batch_POST.py
+++ b/tests/test_app_routers_bond_tokens_{token_address}_additional_issue_batch_POST.py
@@ -27,6 +27,7 @@ from app.model.db import (
     BatchIssueRedeemUpload,
     Token,
     TokenType,
+    TokenVersion,
 )
 from app.utils.e2ee_utils import E2EEUtils
 from tests.account_config import config_eth_account
@@ -64,6 +65,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueBatchPOST:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API
@@ -126,6 +128,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueBatchPOST:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API
@@ -198,6 +201,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueBatchPOST:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API
@@ -247,6 +251,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueBatchPOST:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API
@@ -299,6 +304,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueBatchPOST:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API
@@ -351,6 +357,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueBatchPOST:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API
@@ -403,6 +410,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueBatchPOST:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API
@@ -449,6 +457,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueBatchPOST:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API
@@ -495,6 +504,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueBatchPOST:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API
@@ -539,6 +549,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueBatchPOST:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API
@@ -583,6 +594,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueBatchPOST:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API
@@ -666,6 +678,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueBatchPOST:
         token.token_address = token_address
         token.abi = ""
         token.token_status = 0
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API

--- a/tests/test_app_routers_bond_tokens_{token_address}_additional_issue_batch_{batch_id}_GET.py
+++ b/tests/test_app_routers_bond_tokens_{token_address}_additional_issue_batch_{batch_id}_GET.py
@@ -24,6 +24,7 @@ from app.model.db import (
     IDXPersonalInfo,
     Token,
     TokenType,
+    TokenVersion,
 )
 from app.utils.e2ee_utils import E2EEUtils
 from tests.account_config import config_eth_account
@@ -69,6 +70,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueBatchBatchIdGET:
         token.issuer_address = issuer_address
         token.token_address = test_token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         batch_upload = BatchIssueRedeemUpload()
@@ -153,6 +155,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueBatchBatchIdGET:
         token.issuer_address = issuer_address
         token.token_address = test_token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         batch_upload = BatchIssueRedeemUpload()
@@ -237,6 +240,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueBatchBatchIdGET:
         token.issuer_address = issuer_address
         token.token_address = test_token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         batch_upload = BatchIssueRedeemUpload()
@@ -347,6 +351,7 @@ class TestAppRoutersBondTokensTokenAddressAdditionalIssueBatchBatchIdGET:
         token.issuer_address = issuer_address
         token.token_address = test_token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         batch_upload = BatchIssueRedeemUpload()

--- a/tests/test_app_routers_bond_tokens_{token_address}_history_GET.py
+++ b/tests/test_app_routers_bond_tokens_{token_address}_history_GET.py
@@ -36,6 +36,7 @@ from app.model.db import (
     TokenType,
     TokenUpdateOperationCategory,
     TokenUpdateOperationLog,
+    TokenVersion,
 )
 from app.model.schema import IbetStraightBondCreate
 from app.utils.contract_utils import ContractUtils
@@ -263,6 +264,7 @@ class TestAppRoutersBondTokensTokenAddressHistoryGET:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # request target api
@@ -312,6 +314,7 @@ class TestAppRoutersBondTokensTokenAddressHistoryGET:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
         db.commit()
 
@@ -400,6 +403,7 @@ class TestAppRoutersBondTokensTokenAddressHistoryGET:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
         db.commit()
 
@@ -486,6 +490,7 @@ class TestAppRoutersBondTokensTokenAddressHistoryGET:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
         db.commit()
 
@@ -563,6 +568,7 @@ class TestAppRoutersBondTokensTokenAddressHistoryGET:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         _operation_log_1 = TokenUpdateOperationLog()
@@ -665,6 +671,7 @@ class TestAppRoutersBondTokensTokenAddressHistoryGET:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         _operation_log_1 = TokenUpdateOperationLog()
@@ -753,6 +760,7 @@ class TestAppRoutersBondTokensTokenAddressHistoryGET:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
         db.commit()
 
@@ -845,6 +853,7 @@ class TestAppRoutersBondTokensTokenAddressHistoryGET:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
         db.commit()
 
@@ -938,6 +947,7 @@ class TestAppRoutersBondTokensTokenAddressHistoryGET:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
         db.commit()
 
@@ -1015,6 +1025,7 @@ class TestAppRoutersBondTokensTokenAddressHistoryGET:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
         db.commit()
 

--- a/tests/test_app_routers_bond_tokens_{token_address}_holders_GET.py
+++ b/tests/test_app_routers_bond_tokens_{token_address}_holders_GET.py
@@ -25,6 +25,7 @@ from app.model.db import (
     IDXPosition,
     Token,
     TokenType,
+    TokenVersion,
 )
 from tests.account_config import config_eth_account
 
@@ -55,6 +56,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API
@@ -87,6 +89,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # prepare data: Position
@@ -198,6 +201,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # prepare data: account_address_1
@@ -422,6 +426,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # prepare data: account_address_1
@@ -552,6 +557,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         idx_position_1 = IDXPosition()
@@ -775,6 +781,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
         token.token_address = _token_address
         token.abi = ""
         token.token_status = 0
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API

--- a/tests/test_app_routers_bond_tokens_{token_address}_holders_count_GET.py
+++ b/tests/test_app_routers_bond_tokens_{token_address}_holders_count_GET.py
@@ -16,7 +16,14 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
-from app.model.db import Account, IDXLockedPosition, IDXPosition, Token, TokenType
+from app.model.db import (
+    Account,
+    IDXLockedPosition,
+    IDXPosition,
+    Token,
+    TokenType,
+    TokenVersion,
+)
 from tests.account_config import config_eth_account
 
 
@@ -47,6 +54,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersCountGET:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API
@@ -79,6 +87,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersCountGET:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         idx_position_1 = IDXPosition()
@@ -120,6 +129,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersCountGET:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         idx_position_1 = IDXPosition()
@@ -179,6 +189,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersCountGET:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         idx_position_1 = IDXPosition()
@@ -230,6 +241,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersCountGET:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         idx_position_1 = IDXPosition()
@@ -392,6 +404,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersCountGET:
         token.token_address = _token_address
         token.abi = ""
         token.token_status = 0
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API

--- a/tests/test_app_routers_bond_tokens_{token_address}_holders_{account_address}_GET.py
+++ b/tests/test_app_routers_bond_tokens_{token_address}_holders_{account_address}_GET.py
@@ -25,6 +25,7 @@ from app.model.db import (
     IDXPosition,
     Token,
     TokenType,
+    TokenVersion,
 )
 from tests.account_config import config_eth_account
 
@@ -58,6 +59,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersAccountAddressGET:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # prepare data: Personal Info
@@ -125,6 +127,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersAccountAddressGET:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # prepare data: Position
@@ -203,6 +206,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersAccountAddressGET:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # prepare data: Position
@@ -300,6 +304,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersAccountAddressGET:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         idx_position_1 = IDXPosition()
@@ -359,6 +364,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersAccountAddressGET:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         idx_position_1 = IDXPosition()
@@ -510,6 +516,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersAccountAddressGET:
         token.token_address = _token_address
         token.abi = ""
         token.token_status = 0
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API

--- a/tests/test_app_routers_bond_tokens_{token_address}_personal_info_POST.py
+++ b/tests/test_app_routers_bond_tokens_{token_address}_personal_info_POST.py
@@ -21,7 +21,7 @@ from unittest.mock import patch
 
 from app.exceptions import SendTransactionError
 from app.model.blockchain import IbetStraightBondContract, PersonalInfoContract
-from app.model.db import Account, AuthToken, Token, TokenType
+from app.model.db import Account, AuthToken, Token, TokenType, TokenVersion
 from app.utils.e2ee_utils import E2EEUtils
 from tests.account_config import config_eth_account
 
@@ -58,6 +58,7 @@ class TestAppRoutersBondTokensTokenAddressPersonalInfoPOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # mock
@@ -141,6 +142,7 @@ class TestAppRoutersBondTokensTokenAddressPersonalInfoPOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # mock
@@ -230,6 +232,7 @@ class TestAppRoutersBondTokensTokenAddressPersonalInfoPOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # mock
@@ -687,6 +690,7 @@ class TestAppRoutersBondTokensTokenAddressPersonalInfoPOST:
         token.token_address = _token_address
         token.abi = ""
         token.token_status = 0
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API
@@ -742,6 +746,7 @@ class TestAppRoutersBondTokensTokenAddressPersonalInfoPOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # mock

--- a/tests/test_app_routers_bond_tokens_{token_address}_personal_info_batch_GET.py
+++ b/tests/test_app_routers_bond_tokens_{token_address}_personal_info_batch_GET.py
@@ -23,6 +23,7 @@ from app.model.db import (
     BatchRegisterPersonalInfoUploadStatus,
     Token,
     TokenType,
+    TokenVersion,
 )
 from tests.account_config import config_eth_account
 
@@ -59,6 +60,7 @@ class TestAppRoutersBondTokensTokenAddressPersonalInfoBatchGET:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API
@@ -89,6 +91,7 @@ class TestAppRoutersBondTokensTokenAddressPersonalInfoBatchGET:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # Prepare data : BatchRegisterPersonalInfoUpload
@@ -145,6 +148,7 @@ class TestAppRoutersBondTokensTokenAddressPersonalInfoBatchGET:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # Prepare data : BatchRegisterPersonalInfoUpload
@@ -197,6 +201,7 @@ class TestAppRoutersBondTokensTokenAddressPersonalInfoBatchGET:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # Prepare data : BatchRegisterPersonalInfoUpload
@@ -249,6 +254,7 @@ class TestAppRoutersBondTokensTokenAddressPersonalInfoBatchGET:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # Prepare data : BatchRegisterPersonalInfoUpload
@@ -310,6 +316,7 @@ class TestAppRoutersBondTokensTokenAddressPersonalInfoBatchGET:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API
@@ -350,6 +357,7 @@ class TestAppRoutersBondTokensTokenAddressPersonalInfoBatchGET:
         token.issuer_address = _issuer_address_2
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # Prepare data : BatchRegisterPersonalInfoUpload

--- a/tests/test_app_routers_bond_tokens_{token_address}_personal_info_batch_POST.py
+++ b/tests/test_app_routers_bond_tokens_{token_address}_personal_info_batch_POST.py
@@ -30,6 +30,7 @@ from app.model.db import (
     BatchRegisterPersonalInfoUploadStatus,
     Token,
     TokenType,
+    TokenVersion,
 )
 from app.utils.e2ee_utils import E2EEUtils
 from tests.account_config import config_eth_account
@@ -68,6 +69,7 @@ class TestAppRoutersBondTokensTokenAddressPersonalInfoBatchPOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         personal_info = {
@@ -142,6 +144,7 @@ class TestAppRoutersBondTokensTokenAddressPersonalInfoBatchPOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         personal_info = {
@@ -783,6 +786,7 @@ class TestAppRoutersBondTokensTokenAddressPersonalInfoBatchPOST:
         token.token_address = _token_address
         token.abi = ""
         token.token_status = 0
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API
@@ -842,6 +846,7 @@ class TestAppRoutersBondTokensTokenAddressPersonalInfoBatchPOST:
         token.token_address = _token_address
         token.abi = ""
         token.token_status = 1
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API

--- a/tests/test_app_routers_bond_tokens_{token_address}_personal_info_batch_{batch_id}_GET.py
+++ b/tests/test_app_routers_bond_tokens_{token_address}_personal_info_batch_{batch_id}_GET.py
@@ -23,6 +23,7 @@ from app.model.db import (
     BatchRegisterPersonalInfoUploadStatus,
     Token,
     TokenType,
+    TokenVersion,
 )
 from app.utils.e2ee_utils import E2EEUtils
 from tests.account_config import config_eth_account
@@ -93,6 +94,7 @@ class TestAppRoutersBondTokensTokenAddressPersonalInfoBatchBatchIdGET:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # Prepare data : BatchRegisterPersonalInfoUpload

--- a/tests/test_app_routers_bond_tokens_{token_address}_redeem_GET.py
+++ b/tests/test_app_routers_bond_tokens_{token_address}_redeem_GET.py
@@ -27,6 +27,7 @@ from app.model.db import (
     IDXIssueRedeemSortItem,
     Token,
     TokenType,
+    TokenVersion,
 )
 
 local_tz = timezone(config.TZ)
@@ -72,6 +73,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: IDXIssueRedeem
@@ -105,6 +107,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: IDXIssueRedeem
@@ -183,6 +186,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: IDXIssueRedeem
@@ -267,6 +271,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: IDXIssueRedeem
@@ -351,6 +356,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemGET:
         _token.token_address = self.test_token_address
         _token.abi = {}
         _token.token_status = 0
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # request target API

--- a/tests/test_app_routers_bond_tokens_{token_address}_redeem_POST.py
+++ b/tests/test_app_routers_bond_tokens_{token_address}_redeem_POST.py
@@ -22,7 +22,7 @@ from unittest.mock import ANY, MagicMock
 
 from app.exceptions import SendTransactionError
 from app.model.blockchain.tx_params.ibet_straight_bond import RedeemParams
-from app.model.db import Account, AuthToken, Token, TokenType
+from app.model.db import Account, AuthToken, Token, TokenType, TokenVersion
 from app.utils.e2ee_utils import E2EEUtils
 from tests.account_config import config_eth_account
 
@@ -57,6 +57,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemPOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # mock
@@ -109,6 +110,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemPOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # mock
@@ -152,6 +154,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemPOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API
@@ -196,6 +199,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemPOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API
@@ -240,6 +244,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemPOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API
@@ -378,6 +383,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemPOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API
@@ -485,6 +491,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemPOST:
         token.token_address = _token_address
         token.abi = ""
         token.token_status = 0
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API
@@ -530,6 +537,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemPOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API

--- a/tests/test_app_routers_bond_tokens_{token_address}_redeem_batch_GET.py
+++ b/tests/test_app_routers_bond_tokens_{token_address}_redeem_batch_GET.py
@@ -24,6 +24,7 @@ from app.model.db import (
     BatchIssueRedeemUpload,
     Token,
     TokenType,
+    TokenVersion,
 )
 from tests.account_config import config_eth_account
 
@@ -50,6 +51,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemBatchGET:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API
@@ -75,6 +77,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemBatchGET:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         redeem_upload1 = BatchIssueRedeemUpload()
@@ -119,6 +122,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemBatchGET:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         redeem_upload1 = BatchIssueRedeemUpload()
@@ -223,6 +227,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemBatchGET:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         redeem_upload1 = BatchIssueRedeemUpload()
@@ -314,6 +319,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemBatchGET:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         redeem_upload1 = BatchIssueRedeemUpload()
@@ -411,6 +417,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemBatchGET:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         redeem_upload1 = BatchIssueRedeemUpload()
@@ -500,6 +507,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemBatchGET:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         additional_issue_upload1 = BatchIssueRedeemUpload()
@@ -620,6 +628,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemBatchGET:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API

--- a/tests/test_app_routers_bond_tokens_{token_address}_redeem_batch_POST.py
+++ b/tests/test_app_routers_bond_tokens_{token_address}_redeem_batch_POST.py
@@ -27,6 +27,7 @@ from app.model.db import (
     BatchIssueRedeemUpload,
     Token,
     TokenType,
+    TokenVersion,
 )
 from app.utils.e2ee_utils import E2EEUtils
 from tests.account_config import config_eth_account
@@ -64,6 +65,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemBatchPOST:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API
@@ -126,6 +128,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemBatchPOST:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API
@@ -198,6 +201,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemBatchPOST:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API
@@ -247,6 +251,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemBatchPOST:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API
@@ -299,6 +304,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemBatchPOST:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API
@@ -351,6 +357,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemBatchPOST:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API
@@ -403,6 +410,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemBatchPOST:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API
@@ -449,6 +457,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemBatchPOST:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API
@@ -495,6 +504,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemBatchPOST:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API
@@ -539,6 +549,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemBatchPOST:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API
@@ -583,6 +594,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemBatchPOST:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API
@@ -666,6 +678,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemBatchPOST:
         token.token_address = token_address
         token.abi = ""
         token.token_status = 0
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API

--- a/tests/test_app_routers_bond_tokens_{token_address}_redeem_batch_{batch_id}_GET.py
+++ b/tests/test_app_routers_bond_tokens_{token_address}_redeem_batch_{batch_id}_GET.py
@@ -24,6 +24,7 @@ from app.model.db import (
     IDXPersonalInfo,
     Token,
     TokenType,
+    TokenVersion,
 )
 from app.utils.e2ee_utils import E2EEUtils
 from tests.account_config import config_eth_account
@@ -69,6 +70,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemBatchBatchIdGET:
         token.issuer_address = issuer_address
         token.token_address = test_token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         batch_upload = BatchIssueRedeemUpload()
@@ -153,6 +155,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemBatchBatchIdGET:
         token.issuer_address = issuer_address
         token.token_address = test_token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         batch_upload = BatchIssueRedeemUpload()
@@ -237,6 +240,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemBatchBatchIdGET:
         token.issuer_address = issuer_address
         token.token_address = test_token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         batch_upload = BatchIssueRedeemUpload()
@@ -347,6 +351,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemBatchBatchIdGET:
         token.issuer_address = issuer_address
         token.token_address = test_token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         batch_upload = BatchIssueRedeemUpload()

--- a/tests/test_app_routers_bond_tokens_{token_address}_scheduled_events_POST.py
+++ b/tests/test_app_routers_bond_tokens_{token_address}_scheduled_events_POST.py
@@ -21,7 +21,14 @@ from datetime import datetime, timezone
 from pytz import timezone as tz
 from sqlalchemy import and_, select
 
-from app.model.db import Account, ScheduledEvents, ScheduledEventType, Token, TokenType
+from app.model.db import (
+    Account,
+    ScheduledEvents,
+    ScheduledEventType,
+    Token,
+    TokenType,
+    TokenVersion,
+)
 from app.utils.e2ee_utils import E2EEUtils
 from tests.account_config import config_eth_account
 
@@ -55,6 +62,7 @@ class TestAppRoutersBondTokensTokenAddressScheduledEventsPOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # test data
@@ -138,6 +146,7 @@ class TestAppRoutersBondTokensTokenAddressScheduledEventsPOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # test data
@@ -346,6 +355,7 @@ class TestAppRoutersBondTokensTokenAddressScheduledEventsPOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # test data
@@ -488,6 +498,7 @@ class TestAppRoutersBondTokensTokenAddressScheduledEventsPOST:
         token.token_address = _token_address
         token.abi = ""
         token.token_status = 0
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # test data

--- a/tests/test_app_routers_bond_transfer_approvals_GET.py
+++ b/tests/test_app_routers_bond_transfer_approvals_GET.py
@@ -25,6 +25,7 @@ from app.model.db import (
     IDXTransferApproval,
     Token,
     TokenType,
+    TokenVersion,
     TransferApprovalHistory,
     TransferApprovalOperationType,
 )
@@ -98,6 +99,7 @@ class TestAppRoutersBondTransferApprovalsGET:
         _token.token_address = self.test_token_address_1
         _token.abi = {}
         _token.token_status = 2
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Token(share)
@@ -107,6 +109,7 @@ class TestAppRoutersBondTransferApprovalsGET:
         _token.issuer_address = self.test_issuer_address_1
         _token.token_address = self.test_token_address_2
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: IDXTransferApproval(failed token)
@@ -201,6 +204,7 @@ class TestAppRoutersBondTransferApprovalsGET:
         _token.issuer_address = self.test_issuer_address_1
         _token.token_address = self.test_token_address_1
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: IDXTransferApproval(ApplyFor(unapproved))
@@ -385,6 +389,7 @@ class TestAppRoutersBondTransferApprovalsGET:
         _token.issuer_address = self.test_issuer_address_1
         _token.token_address = self.test_token_address_1
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Token(issuer-1)
@@ -394,6 +399,7 @@ class TestAppRoutersBondTransferApprovalsGET:
         _token.issuer_address = self.test_issuer_address_1
         _token.token_address = self.test_token_address_2
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Token(issuer-2)
@@ -403,6 +409,7 @@ class TestAppRoutersBondTransferApprovalsGET:
         _token.issuer_address = self.test_issuer_address_2
         _token.token_address = self.test_token_address_3
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: IDXTransferApproval(issuer-1 token-1)
@@ -567,6 +574,7 @@ class TestAppRoutersBondTransferApprovalsGET:
         _token.issuer_address = self.test_issuer_address_1
         _token.token_address = self.test_token_address_1
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Token(issuer-1)
@@ -576,6 +584,7 @@ class TestAppRoutersBondTransferApprovalsGET:
         _token.issuer_address = self.test_issuer_address_1
         _token.token_address = self.test_token_address_2
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Token(issuer-2)
@@ -585,6 +594,7 @@ class TestAppRoutersBondTransferApprovalsGET:
         _token.issuer_address = self.test_issuer_address_2
         _token.token_address = self.test_token_address_3
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: IDXTransferApproval(issuer-1 token-1)
@@ -757,6 +767,7 @@ class TestAppRoutersBondTransferApprovalsGET:
         _token.issuer_address = self.test_issuer_address_1
         _token.token_address = self.test_token_address_1
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Token(issuer-1)
@@ -766,6 +777,7 @@ class TestAppRoutersBondTransferApprovalsGET:
         _token.issuer_address = self.test_issuer_address_1
         _token.token_address = self.test_token_address_2
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Token(issuer-1)
@@ -775,6 +787,7 @@ class TestAppRoutersBondTransferApprovalsGET:
         _token.issuer_address = self.test_issuer_address_1
         _token.token_address = self.test_token_address_3
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Token(issuer-1)
@@ -784,6 +797,7 @@ class TestAppRoutersBondTransferApprovalsGET:
         _token.issuer_address = self.test_issuer_address_1
         _token.token_address = self.test_token_address_4
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: IDXTransferApproval(issuer-1 token-1)

--- a/tests/test_app_routers_bond_transfer_approvals_{token_address}_GET.py
+++ b/tests/test_app_routers_bond_transfer_approvals_{token_address}_GET.py
@@ -26,6 +26,7 @@ from app.model.db import (
     IDXTransferApproval,
     Token,
     TokenType,
+    TokenVersion,
     TransferApprovalHistory,
     TransferApprovalOperationType,
 )
@@ -108,6 +109,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # request target API
@@ -131,6 +133,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -322,6 +325,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -439,6 +443,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -640,6 +645,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -750,6 +756,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -861,6 +868,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -1004,6 +1012,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -1147,6 +1156,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: IDXTransferApproval
@@ -1378,6 +1388,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -1595,6 +1606,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -1844,6 +1856,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -2041,6 +2054,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -2278,6 +2292,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -2515,6 +2530,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -2717,6 +2733,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -2917,6 +2934,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -3153,6 +3171,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -3396,6 +3415,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -3635,6 +3655,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -4193,6 +4214,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressGET:
         _token.token_address = self.test_token_address
         _token.abi = {}
         _token.token_status = 0
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # request target API

--- a/tests/test_app_routers_bond_transfer_approvals_{token_address}_{id}_GET.py
+++ b/tests/test_app_routers_bond_transfer_approvals_{token_address}_{id}_GET.py
@@ -26,6 +26,7 @@ from app.model.db import (
     IDXTransferApproval,
     Token,
     TokenType,
+    TokenVersion,
     TransferApprovalHistory,
     TransferApprovalOperationType,
 )
@@ -94,6 +95,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressIdGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -204,6 +206,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressIdGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: IDXTransferApproval
@@ -266,6 +269,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressIdGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: IDXTransferApproval
@@ -373,6 +377,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressIdGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: IDXTransferApproval
@@ -482,6 +487,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressIdGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -593,6 +599,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressIdGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: IDXTransferApproval
@@ -702,6 +709,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressIdGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: IDXTransferApproval
@@ -833,6 +841,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressIdGET:
         _token.token_address = self.test_token_address
         _token.abi = {}
         _token.token_status = 0
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # request target API
@@ -858,6 +867,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressIdGET:
         _token.token_address = self.test_token_address
         _token.abi = {}
         _token.token_status = 1
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # request target API

--- a/tests/test_app_routers_bond_transfer_approvals_{token_address}_{id}_POST.py
+++ b/tests/test_app_routers_bond_transfer_approvals_{token_address}_{id}_POST.py
@@ -41,6 +41,7 @@ from app.model.db import (
     IDXTransferApproval,
     Token,
     TokenType,
+    TokenVersion,
     TransferApprovalHistory,
     TransferApprovalOperationType,
 )
@@ -91,6 +92,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressIdPOST:
         _token.issuer_address = issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         id = 10
@@ -222,6 +224,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressIdPOST:
         _token.issuer_address = issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         id = 10
@@ -354,6 +357,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressIdPOST:
         _token.issuer_address = issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         id = 10
@@ -490,6 +494,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressIdPOST:
         _token.issuer_address = issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         id = 10
@@ -814,6 +819,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressIdPOST:
         _token.issuer_address = issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         id = 10
@@ -856,6 +862,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressIdPOST:
         _token.token_address = self.test_token_address
         _token.abi = {}
         _token.token_status = 0
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         id = 10
@@ -897,6 +904,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressIdPOST:
         _token.issuer_address = issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         id = 10
@@ -959,6 +967,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressIdPOST:
         _token.issuer_address = issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         id = 10
@@ -1021,6 +1030,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressIdPOST:
         _token.issuer_address = issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         id = 10
@@ -1081,6 +1091,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressIdPOST:
         _token.issuer_address = issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         id = 10
@@ -1141,6 +1152,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressIdPOST:
         _token.issuer_address = issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         id = 10
@@ -1214,6 +1226,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressIdPOST:
         _token.issuer_address = issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         id = 10
@@ -1304,6 +1317,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressIdPOST:
         _token.issuer_address = issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         id = 10
@@ -1411,6 +1425,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressIdPOST:
         _token.issuer_address = issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         id = 10
@@ -1502,6 +1517,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressIdPOST:
         _token.issuer_address = issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         id = 10
@@ -1604,6 +1620,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressIdPOST:
         _token.issuer_address = issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         id = 10
@@ -1694,6 +1711,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressIdPOST:
         _token.issuer_address = issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         id = 10
@@ -1789,6 +1807,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressIdPOST:
         _token.issuer_address = issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         id = 10
@@ -1854,6 +1873,7 @@ class TestAppRoutersBondTransferApprovalsTokenAddressIdPOST:
         _token.issuer_address = issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         id = 10

--- a/tests/test_app_routers_bond_transfers_POST.py
+++ b/tests/test_app_routers_bond_transfers_POST.py
@@ -22,7 +22,7 @@ from unittest.mock import ANY, MagicMock
 
 from app.exceptions import SendTransactionError
 from app.model.blockchain.tx_params.ibet_straight_bond import TransferParams
-from app.model.db import Account, AuthToken, Token, TokenType
+from app.model.db import Account, AuthToken, Token, TokenType, TokenVersion
 from app.utils.e2ee_utils import E2EEUtils
 from tests.account_config import config_eth_account
 
@@ -64,6 +64,7 @@ class TestAppRoutersBondTransfersPOST:
         token.issuer_address = _admin_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # mock
@@ -136,6 +137,7 @@ class TestAppRoutersBondTransfersPOST:
         token.issuer_address = _admin_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # mock
@@ -522,6 +524,7 @@ class TestAppRoutersBondTransfersPOST:
         token.token_address = _token_address
         token.abi = ""
         token.token_status = 0
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API
@@ -579,6 +582,7 @@ class TestAppRoutersBondTransfersPOST:
         token.issuer_address = _admin_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API

--- a/tests/test_app_routers_bond_transfers_{token_address}_GET.py
+++ b/tests/test_app_routers_bond_transfers_{token_address}_GET.py
@@ -27,6 +27,7 @@ from app.model.db import (
     IDXTransferSourceEventType,
     Token,
     TokenType,
+    TokenVersion,
 )
 
 local_tz = timezone(config.TZ)
@@ -66,6 +67,7 @@ class TestAppRoutersBondTransfersGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: IDXTransfer
@@ -139,6 +141,7 @@ class TestAppRoutersBondTransfersGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -239,6 +242,7 @@ class TestAppRoutersBondTransfersGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -352,6 +356,7 @@ class TestAppRoutersBondTransfersGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -464,6 +469,7 @@ class TestAppRoutersBondTransfersGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -628,6 +634,7 @@ class TestAppRoutersBondTransfersGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -786,6 +793,7 @@ class TestAppRoutersBondTransfersGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -944,6 +952,7 @@ class TestAppRoutersBondTransfersGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -1148,6 +1157,7 @@ class TestAppRoutersBondTransfersGET:
         _token.token_address = self.test_token_address
         _token.abi = {}
         _token.token_status = 0
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # request target API

--- a/tests/test_app_routers_ledger_{token_address}_details_data_GET.py
+++ b/tests/test_app_routers_ledger_{token_address}_details_data_GET.py
@@ -18,7 +18,7 @@ SPDX-License-Identifier: Apache-2.0
 """
 from datetime import datetime
 
-from app.model.db import LedgerDetailsData, Token, TokenType
+from app.model.db import LedgerDetailsData, Token, TokenType, TokenVersion
 from tests.account_config import config_eth_account
 
 
@@ -44,6 +44,7 @@ class TestAppRoutersLedgerTokenAddressDetailsDataGET:
         _token.issuer_address = issuer_address
         _token.token_address = token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         _details_data_1_1 = LedgerDetailsData()
@@ -157,6 +158,7 @@ class TestAppRoutersLedgerTokenAddressDetailsDataGET:
         _token.issuer_address = issuer_address
         _token.token_address = token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         _details_data_1_1 = LedgerDetailsData()
@@ -267,6 +269,7 @@ class TestAppRoutersLedgerTokenAddressDetailsDataGET:
         _token.issuer_address = issuer_address
         _token.token_address = token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         _details_data_1_1 = LedgerDetailsData()
@@ -406,6 +409,7 @@ class TestAppRoutersLedgerTokenAddressDetailsDataGET:
         _token.token_address = token_address
         _token.abi = {}
         _token.token_status = 2
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # request target API
@@ -464,6 +468,7 @@ class TestAppRoutersLedgerTokenAddressDetailsDataGET:
         _token.token_address = token_address
         _token.abi = {}
         _token.token_status = 0
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # request target API

--- a/tests/test_app_routers_ledger_{token_address}_details_data_POST.py
+++ b/tests/test_app_routers_ledger_{token_address}_details_data_POST.py
@@ -18,7 +18,7 @@ SPDX-License-Identifier: Apache-2.0
 """
 from sqlalchemy import select
 
-from app.model.db import LedgerDetailsData, Token, TokenType
+from app.model.db import LedgerDetailsData, Token, TokenType, TokenVersion
 from tests.account_config import config_eth_account
 
 
@@ -43,6 +43,7 @@ class TestAppRoutersLedgerTokenAddressDetailsDataPOST:
         _token.issuer_address = issuer_address
         _token.token_address = token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # request target API
@@ -351,6 +352,7 @@ class TestAppRoutersLedgerTokenAddressDetailsDataPOST:
         _token.token_address = token_address
         _token.abi = {}
         _token.token_status = 0
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # request target API

--- a/tests/test_app_routers_ledger_{token_address}_details_data_{data_id}_DELETE.py
+++ b/tests/test_app_routers_ledger_{token_address}_details_data_{data_id}_DELETE.py
@@ -18,7 +18,7 @@ SPDX-License-Identifier: Apache-2.0
 """
 from sqlalchemy import select
 
-from app.model.db import LedgerDetailsData, Token, TokenType
+from app.model.db import LedgerDetailsData, Token, TokenType, TokenVersion
 from tests.account_config import config_eth_account
 
 
@@ -44,6 +44,7 @@ class TestAppRoutersLedgerTokenAddressDetailsDataDataIdDELETE:
         _token.issuer_address = issuer_address
         _token.token_address = token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         _details_1_data_1 = LedgerDetailsData()
@@ -192,6 +193,7 @@ class TestAppRoutersLedgerTokenAddressDetailsDataDataIdDELETE:
         _token.token_address = token_address
         _token.abi = {}
         _token.token_status = 0
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # request target API

--- a/tests/test_app_routers_ledger_{token_address}_details_data_{data_id}_GET.py
+++ b/tests/test_app_routers_ledger_{token_address}_details_data_{data_id}_GET.py
@@ -16,7 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
-from app.model.db import LedgerDetailsData, Token, TokenType
+from app.model.db import LedgerDetailsData, Token, TokenType, TokenVersion
 from tests.account_config import config_eth_account
 
 
@@ -43,6 +43,7 @@ class TestAppRoutersLedgerTokenAddressDetailsDataDataIdGET:
         _token.issuer_address = issuer_address
         _token.token_address = token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         _details_1_data_1 = LedgerDetailsData()
@@ -123,6 +124,7 @@ class TestAppRoutersLedgerTokenAddressDetailsDataDataIdGET:
         _token.issuer_address = issuer_address
         _token.token_address = token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         _details_1_data_1 = LedgerDetailsData()
@@ -200,6 +202,7 @@ class TestAppRoutersLedgerTokenAddressDetailsDataDataIdGET:
         _token.issuer_address = issuer_address
         _token.token_address = token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         _details_1_data_1 = LedgerDetailsData()
@@ -316,6 +319,7 @@ class TestAppRoutersLedgerTokenAddressDetailsDataDataIdGET:
         _token.token_address = token_address
         _token.abi = {}
         _token.token_status = 2
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # request target API
@@ -368,6 +372,7 @@ class TestAppRoutersLedgerTokenAddressDetailsDataDataIdGET:
         _token.token_address = token_address
         _token.abi = {}
         _token.token_status = 0
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # request target API

--- a/tests/test_app_routers_ledger_{token_address}_details_data_{data_id}_POST.py
+++ b/tests/test_app_routers_ledger_{token_address}_details_data_{data_id}_POST.py
@@ -20,7 +20,7 @@ from unittest import mock
 
 from sqlalchemy import select
 
-from app.model.db import LedgerDetailsData, Token, TokenType
+from app.model.db import LedgerDetailsData, Token, TokenType, TokenVersion
 from tests.account_config import config_eth_account
 
 
@@ -47,6 +47,7 @@ class TestAppRoutersLedgerTokenAddressDetailsDataDataIdPOST:
         _token.issuer_address = issuer_address
         _token.token_address = token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         _details_1_data_1 = LedgerDetailsData()
@@ -373,6 +374,7 @@ class TestAppRoutersLedgerTokenAddressDetailsDataDataIdPOST:
         _token.token_address = token_address
         _token.abi = {}
         _token.token_status = 0
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # request target API

--- a/tests/test_app_routers_ledger_{token_address}_history_GET.py
+++ b/tests/test_app_routers_ledger_{token_address}_history_GET.py
@@ -18,7 +18,7 @@ SPDX-License-Identifier: Apache-2.0
 """
 from datetime import datetime
 
-from app.model.db import Ledger, Token, TokenType
+from app.model.db import Ledger, Token, TokenType, TokenVersion
 from tests.account_config import config_eth_account
 
 
@@ -44,6 +44,7 @@ class TestAppRoutersLedgerTokenAddressHistoryGET:
         _token.issuer_address = issuer_address
         _token.token_address = token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         _ledger_1 = Ledger()
@@ -106,6 +107,7 @@ class TestAppRoutersLedgerTokenAddressHistoryGET:
         _token.issuer_address = issuer_address
         _token.token_address = token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         _ledger_1 = Ledger()
@@ -165,6 +167,7 @@ class TestAppRoutersLedgerTokenAddressHistoryGET:
         _token.issuer_address = issuer_address
         _token.token_address = token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         _ledger_1 = Ledger()
@@ -281,6 +284,7 @@ class TestAppRoutersLedgerTokenAddressHistoryGET:
         _token.token_address = token_address
         _token.abi = {}
         _token.token_status = 2
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # request target API
@@ -339,6 +343,7 @@ class TestAppRoutersLedgerTokenAddressHistoryGET:
         _token.token_address = token_address
         _token.abi = {}
         _token.token_status = 0
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # request target API

--- a/tests/test_app_routers_ledger_{token_address}_history_{ledger_id}_GET.py
+++ b/tests/test_app_routers_ledger_{token_address}_history_{ledger_id}_GET.py
@@ -28,6 +28,7 @@ from app.model.db import (
     LedgerDetailsTemplate,
     Token,
     TokenType,
+    TokenVersion,
 )
 from tests.account_config import config_eth_account
 
@@ -56,6 +57,7 @@ class TestAppRoutersLedgerTokenAddressHistoryLedgerIdGET:
         _token.issuer_address = issuer_address
         _token.token_address = token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         _ledger_1 = Ledger()
@@ -298,6 +300,7 @@ class TestAppRoutersLedgerTokenAddressHistoryLedgerIdGET:
         _token.issuer_address = issuer_address
         _token.token_address = token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         _ledger_1 = Ledger()
@@ -540,6 +543,7 @@ class TestAppRoutersLedgerTokenAddressHistoryLedgerIdGET:
         _token.issuer_address = issuer_address
         _token.token_address = token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         _ledger_1 = Ledger()
@@ -843,6 +847,7 @@ class TestAppRoutersLedgerTokenAddressHistoryLedgerIdGET:
         _token.issuer_address = issuer_address
         _token.token_address = token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         _ledger_1 = Ledger()
@@ -1143,6 +1148,7 @@ class TestAppRoutersLedgerTokenAddressHistoryLedgerIdGET:
         _token.issuer_address = issuer_address
         _token.token_address = token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         _ledger_1 = Ledger()
@@ -1412,6 +1418,7 @@ class TestAppRoutersLedgerTokenAddressHistoryLedgerIdGET:
         _token.issuer_address = issuer_address
         _token.token_address = token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         _ledger_1 = Ledger()
@@ -1755,6 +1762,7 @@ class TestAppRoutersLedgerTokenAddressHistoryLedgerIdGET:
         _token.token_address = token_address
         _token.abi = {}
         _token.token_status = 2
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # request target API
@@ -1811,6 +1819,7 @@ class TestAppRoutersLedgerTokenAddressHistoryLedgerIdGET:
         _token.token_address = token_address
         _token.abi = {}
         _token.token_status = 0
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # request target API
@@ -1845,6 +1854,7 @@ class TestAppRoutersLedgerTokenAddressHistoryLedgerIdGET:
         _token.issuer_address = issuer_address
         _token.token_address = token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # request target API
@@ -1881,6 +1891,7 @@ class TestAppRoutersLedgerTokenAddressHistoryLedgerIdGET:
         _token.issuer_address = issuer_address
         _token.token_address = token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         _ledger_1 = Ledger()

--- a/tests/test_app_routers_ledger_{token_address}_template_DELETE.py
+++ b/tests/test_app_routers_ledger_{token_address}_template_DELETE.py
@@ -24,6 +24,7 @@ from app.model.db import (
     LedgerTemplate,
     Token,
     TokenType,
+    TokenVersion,
 )
 from tests.account_config import config_eth_account
 
@@ -49,6 +50,7 @@ class TestAppRoutersLedgerTokenAddressTemplateDELETE:
         _token.issuer_address = issuer_address
         _token.token_address = token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         _template = LedgerTemplate()
@@ -227,6 +229,7 @@ class TestAppRoutersLedgerTokenAddressTemplateDELETE:
         _token.token_address = token_address
         _token.abi = {}
         _token.token_status = 0
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # request target API
@@ -258,6 +261,7 @@ class TestAppRoutersLedgerTokenAddressTemplateDELETE:
         _token.issuer_address = issuer_address
         _token.token_address = token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # request target API

--- a/tests/test_app_routers_ledger_{token_address}_template_GET.py
+++ b/tests/test_app_routers_ledger_{token_address}_template_GET.py
@@ -22,6 +22,7 @@ from app.model.db import (
     LedgerTemplate,
     Token,
     TokenType,
+    TokenVersion,
 )
 from tests.account_config import config_eth_account
 
@@ -48,6 +49,7 @@ class TestAppRoutersLedgerTokenAddressTemplateGET:
         _token.issuer_address = issuer_address
         _token.token_address = token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         _template = LedgerTemplate()
@@ -210,6 +212,7 @@ class TestAppRoutersLedgerTokenAddressTemplateGET:
         _token.issuer_address = issuer_address
         _token.token_address = token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         _template = LedgerTemplate()
@@ -369,6 +372,7 @@ class TestAppRoutersLedgerTokenAddressTemplateGET:
         _token.issuer_address = issuer_address
         _token.token_address = token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         _template = LedgerTemplate()
@@ -464,6 +468,7 @@ class TestAppRoutersLedgerTokenAddressTemplateGET:
         _token.token_address = token_address
         _token.abi = {}
         _token.token_status = 2
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # request target API
@@ -514,6 +519,7 @@ class TestAppRoutersLedgerTokenAddressTemplateGET:
         _token.token_address = token_address
         _token.abi = {}
         _token.token_status = 0
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # request target API
@@ -545,6 +551,7 @@ class TestAppRoutersLedgerTokenAddressTemplateGET:
         _token.issuer_address = issuer_address
         _token.token_address = token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # request target API

--- a/tests/test_app_routers_ledger_{token_address}_template_POST.py
+++ b/tests/test_app_routers_ledger_{token_address}_template_POST.py
@@ -26,6 +26,7 @@ from app.model.db import (
     LedgerTemplate,
     Token,
     TokenType,
+    TokenVersion,
 )
 from tests.account_config import config_eth_account
 
@@ -53,6 +54,7 @@ class TestAppRoutersLedgerTokenAddressTemplatePOST:
         _token.issuer_address = issuer_address
         _token.token_address = token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # request target API
@@ -244,6 +246,7 @@ class TestAppRoutersLedgerTokenAddressTemplatePOST:
         _token.issuer_address = issuer_address
         _token.token_address = token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         _template = LedgerTemplate()
@@ -902,6 +905,7 @@ class TestAppRoutersLedgerTokenAddressTemplatePOST:
         _token.issuer_address = issuer_address
         _token.token_address = token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # request target API
@@ -1090,6 +1094,7 @@ class TestAppRoutersLedgerTokenAddressTemplatePOST:
         _token.token_address = token_address
         _token.abi = {}
         _token.token_status = 0
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # request target API

--- a/tests/test_app_routers_positions_{account_address}_GET.py
+++ b/tests/test_app_routers_positions_{account_address}_GET.py
@@ -19,7 +19,7 @@ SPDX-License-Identifier: Apache-2.0
 from unittest import mock
 
 from app.model.blockchain import IbetShareContract, IbetStraightBondContract
-from app.model.db import IDXLockedPosition, IDXPosition, Token, TokenType
+from app.model.db import IDXLockedPosition, IDXPosition, Token, TokenType, TokenVersion
 
 
 class TestAppRoutersPositionsAccountAddressGET:
@@ -42,6 +42,7 @@ class TestAppRoutersPositionsAccountAddressGET:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Position
@@ -89,6 +90,7 @@ class TestAppRoutersPositionsAccountAddressGET:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Position
@@ -181,6 +183,7 @@ class TestAppRoutersPositionsAccountAddressGET:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Position 1
@@ -219,6 +222,7 @@ class TestAppRoutersPositionsAccountAddressGET:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Position-2
@@ -257,6 +261,7 @@ class TestAppRoutersPositionsAccountAddressGET:
         _token.type = TokenType.IBET_SHARE.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Position-3
@@ -369,6 +374,7 @@ class TestAppRoutersPositionsAccountAddressGET:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Position 1
@@ -388,6 +394,7 @@ class TestAppRoutersPositionsAccountAddressGET:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Position 2
@@ -417,6 +424,7 @@ class TestAppRoutersPositionsAccountAddressGET:
         _token.type = TokenType.IBET_SHARE.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Position 3
@@ -505,6 +513,7 @@ class TestAppRoutersPositionsAccountAddressGET:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Position
@@ -526,6 +535,7 @@ class TestAppRoutersPositionsAccountAddressGET:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Position
@@ -545,6 +555,7 @@ class TestAppRoutersPositionsAccountAddressGET:
         _token.type = TokenType.IBET_SHARE.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Position
@@ -623,6 +634,7 @@ class TestAppRoutersPositionsAccountAddressGET:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Position
@@ -642,6 +654,7 @@ class TestAppRoutersPositionsAccountAddressGET:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Position
@@ -661,6 +674,7 @@ class TestAppRoutersPositionsAccountAddressGET:
         _token.type = TokenType.IBET_SHARE.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Position
@@ -736,6 +750,7 @@ class TestAppRoutersPositionsAccountAddressGET:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Position
@@ -755,6 +770,7 @@ class TestAppRoutersPositionsAccountAddressGET:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Position
@@ -774,6 +790,7 @@ class TestAppRoutersPositionsAccountAddressGET:
         _token.type = TokenType.IBET_SHARE.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Position
@@ -838,6 +855,7 @@ class TestAppRoutersPositionsAccountAddressGET:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Position
@@ -857,6 +875,7 @@ class TestAppRoutersPositionsAccountAddressGET:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Position
@@ -876,6 +895,7 @@ class TestAppRoutersPositionsAccountAddressGET:
         _token.type = TokenType.IBET_SHARE.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Position
@@ -895,6 +915,7 @@ class TestAppRoutersPositionsAccountAddressGET:
         _token.type = TokenType.IBET_SHARE.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Position
@@ -998,6 +1019,7 @@ class TestAppRoutersPositionsAccountAddressGET:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Position
@@ -1017,6 +1039,7 @@ class TestAppRoutersPositionsAccountAddressGET:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Position
@@ -1036,6 +1059,7 @@ class TestAppRoutersPositionsAccountAddressGET:
         _token.type = TokenType.IBET_SHARE.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Position
@@ -1055,6 +1079,7 @@ class TestAppRoutersPositionsAccountAddressGET:
         _token.type = TokenType.IBET_SHARE.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Position

--- a/tests/test_app_routers_positions_{account_address}_forceunlock_POST.py
+++ b/tests/test_app_routers_positions_{account_address}_forceunlock_POST.py
@@ -22,7 +22,7 @@ from unittest.mock import ANY, MagicMock
 
 from app.exceptions import ContractRevertError, SendTransactionError
 from app.model.blockchain.tx_params.ibet_security_token import ForceUnlockParams
-from app.model.db import Account, AuthToken, Token, TokenType
+from app.model.db import Account, AuthToken, Token, TokenType, TokenVersion
 from app.utils.e2ee_utils import E2EEUtils
 from tests.account_config import config_eth_account
 
@@ -63,6 +63,7 @@ class TestAppRoutersForceUnlockPOST:
         token.issuer_address = _admin_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # mock
@@ -136,6 +137,7 @@ class TestAppRoutersForceUnlockPOST:
         token.issuer_address = _admin_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # mock
@@ -513,6 +515,7 @@ class TestAppRoutersForceUnlockPOST:
         token.issuer_address = _admin_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API
@@ -612,6 +615,7 @@ class TestAppRoutersForceUnlockPOST:
         token.token_address = _token_address
         token.abi = ""
         token.token_status = 0
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API
@@ -668,6 +672,7 @@ class TestAppRoutersForceUnlockPOST:
         token.issuer_address = _admin_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API
@@ -724,6 +729,7 @@ class TestAppRoutersForceUnlockPOST:
         token.issuer_address = _admin_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         # request target API

--- a/tests/test_app_routers_positions_{account_address}_lock_GET.py
+++ b/tests/test_app_routers_positions_{account_address}_lock_GET.py
@@ -19,7 +19,7 @@ SPDX-License-Identifier: Apache-2.0
 from unittest import mock
 
 from app.model.blockchain import IbetShareContract, IbetStraightBondContract
-from app.model.db import IDXLockedPosition, Token, TokenType
+from app.model.db import IDXLockedPosition, Token, TokenType, TokenVersion
 
 
 class TestAppRoutersLockedPositions:
@@ -42,6 +42,7 @@ class TestAppRoutersLockedPositions:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # request target api
@@ -83,6 +84,7 @@ class TestAppRoutersLockedPositions:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         _token = Token()
@@ -91,6 +93,7 @@ class TestAppRoutersLockedPositions:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Locked Position
@@ -180,6 +183,7 @@ class TestAppRoutersLockedPositions:
         _token.type = TokenType.IBET_SHARE.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         _token = Token()
@@ -188,6 +192,7 @@ class TestAppRoutersLockedPositions:
         _token.type = TokenType.IBET_SHARE.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Locked Position
@@ -271,6 +276,7 @@ class TestAppRoutersLockedPositions:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Locked Position
@@ -323,6 +329,7 @@ class TestAppRoutersLockedPositions:
         _token.tx_hash = ""
         _token.abi = ""
         _token.token_status = 2
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         _token = Token()
@@ -331,6 +338,7 @@ class TestAppRoutersLockedPositions:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Locked Position
@@ -403,6 +411,7 @@ class TestAppRoutersLockedPositions:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         _token = Token()
@@ -411,6 +420,7 @@ class TestAppRoutersLockedPositions:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Locked Position
@@ -485,6 +495,7 @@ class TestAppRoutersLockedPositions:
         _token.type = TokenType.IBET_SHARE.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         _token = Token()
@@ -493,6 +504,7 @@ class TestAppRoutersLockedPositions:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Locked Position
@@ -565,6 +577,7 @@ class TestAppRoutersLockedPositions:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Locked Position

--- a/tests/test_app_routers_positions_{account_address}_lock_events_GET.py
+++ b/tests/test_app_routers_positions_{account_address}_lock_events_GET.py
@@ -21,7 +21,7 @@ from unittest import mock
 from unittest.mock import ANY
 
 from app.model.blockchain import IbetShareContract, IbetStraightBondContract
-from app.model.db import IDXLock, IDXUnlock, Token, TokenType
+from app.model.db import IDXLock, IDXUnlock, Token, TokenType, TokenVersion
 
 
 class TestAppRoutersLockEvents:
@@ -44,6 +44,7 @@ class TestAppRoutersLockEvents:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # request target api
@@ -84,6 +85,7 @@ class TestAppRoutersLockEvents:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Lock events
@@ -183,6 +185,7 @@ class TestAppRoutersLockEvents:
         _token.type = TokenType.IBET_SHARE.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Lock events
@@ -283,6 +286,7 @@ class TestAppRoutersLockEvents:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Lock events
@@ -353,6 +357,7 @@ class TestAppRoutersLockEvents:
         _token.tx_hash = ""
         _token.abi = ""
         _token.token_status = 2
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Lock events
@@ -423,6 +428,7 @@ class TestAppRoutersLockEvents:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         _token = Token()
@@ -431,6 +437,7 @@ class TestAppRoutersLockEvents:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Lock events
@@ -556,6 +563,7 @@ class TestAppRoutersLockEvents:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Lock events
@@ -642,6 +650,7 @@ class TestAppRoutersLockEvents:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         _token = Token()
@@ -650,6 +659,7 @@ class TestAppRoutersLockEvents:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Lock events
@@ -736,6 +746,7 @@ class TestAppRoutersLockEvents:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value  # bond
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         _token = Token()
@@ -744,6 +755,7 @@ class TestAppRoutersLockEvents:
         _token.type = TokenType.IBET_SHARE.value  # share
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Lock events
@@ -829,6 +841,7 @@ class TestAppRoutersLockEvents:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value  # bond
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Lock events
@@ -915,6 +928,7 @@ class TestAppRoutersLockEvents:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value  # bond
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Lock events
@@ -1000,6 +1014,7 @@ class TestAppRoutersLockEvents:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value  # bond
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Lock events
@@ -1086,6 +1101,7 @@ class TestAppRoutersLockEvents:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Lock events
@@ -1238,6 +1254,7 @@ class TestAppRoutersLockEvents:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Lock events

--- a/tests/test_app_routers_positions_{account_address}_{token_address}_GET.py
+++ b/tests/test_app_routers_positions_{account_address}_{token_address}_GET.py
@@ -19,7 +19,7 @@ SPDX-License-Identifier: Apache-2.0
 from unittest import mock
 
 from app.model.blockchain import IbetShareContract, IbetStraightBondContract
-from app.model.db import IDXLockedPosition, IDXPosition, Token, TokenType
+from app.model.db import IDXLockedPosition, IDXPosition, Token, TokenType, TokenVersion
 
 
 class TestAppRoutersPositionsAccountAddressTokenAddressGET:
@@ -47,6 +47,7 @@ class TestAppRoutersPositionsAccountAddressTokenAddressGET:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Position
@@ -129,6 +130,7 @@ class TestAppRoutersPositionsAccountAddressTokenAddressGET:
         _token.type = TokenType.IBET_SHARE.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Position
@@ -209,6 +211,7 @@ class TestAppRoutersPositionsAccountAddressTokenAddressGET:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Position
@@ -263,6 +266,7 @@ class TestAppRoutersPositionsAccountAddressTokenAddressGET:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Locked Position
@@ -317,6 +321,7 @@ class TestAppRoutersPositionsAccountAddressTokenAddressGET:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Position
@@ -382,6 +387,7 @@ class TestAppRoutersPositionsAccountAddressTokenAddressGET:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Position
@@ -436,6 +442,7 @@ class TestAppRoutersPositionsAccountAddressTokenAddressGET:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Position
@@ -556,6 +563,7 @@ class TestAppRoutersPositionsAccountAddressTokenAddressGET:
         _token.type = TokenType.IBET_STRAIGHT_BOND.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Position
@@ -598,6 +606,7 @@ class TestAppRoutersPositionsAccountAddressTokenAddressGET:
         _token.tx_hash = ""
         _token.abi = ""
         _token.token_status = 0
+        _token.version = TokenVersion.V_23_12
         db.add(_token)
 
         # prepare data: Position

--- a/tests/test_app_routers_share_bulk_transfer_POST.py
+++ b/tests/test_app_routers_share_bulk_transfer_POST.py
@@ -27,6 +27,7 @@ from app.model.db import (
     BulkTransferUpload,
     Token,
     TokenType,
+    TokenVersion,
 )
 from app.utils.e2ee_utils import E2EEUtils
 from tests.account_config import config_eth_account
@@ -82,6 +83,7 @@ class TestAppRoutersShareBulkTransferPOST:
             _token.issuer_address = self.admin_address
             _token.token_address = _t
             _token.abi = ""
+            _token.version = TokenVersion.V_22_12
             db.add(_token)
 
         # request target API
@@ -166,6 +168,7 @@ class TestAppRoutersShareBulkTransferPOST:
             _token.issuer_address = self.admin_address
             _token.token_address = _t
             _token.abi = ""
+            _token.version = TokenVersion.V_22_12
             db.add(_token)
 
         # request target API
@@ -556,6 +559,7 @@ class TestAppRoutersShareBulkTransferPOST:
         _token.token_address = self.req_tokens[0]
         _token.abi = ""
         _token.token_status = 0
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # request target API

--- a/tests/test_app_routers_share_lock_events_GET.py
+++ b/tests/test_app_routers_share_lock_events_GET.py
@@ -24,7 +24,7 @@ import pytest
 from sqlalchemy.orm import Session
 
 from app.model.blockchain import IbetShareContract
-from app.model.db import IDXLock, IDXUnlock, Token, TokenType
+from app.model.db import IDXLock, IDXUnlock, Token, TokenType, TokenVersion
 
 
 class TestAppRoutersShareLockEvents:
@@ -55,6 +55,7 @@ class TestAppRoutersShareLockEvents:
         _token.tx_hash = ""
         _token.abi = ""
         _token.token_status = token_status
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: Token
@@ -65,6 +66,7 @@ class TestAppRoutersShareLockEvents:
         _token.tx_hash = ""
         _token.abi = ""
         _token.token_status = token_status
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: Lock events
@@ -204,6 +206,7 @@ class TestAppRoutersShareLockEvents:
         _token.type = TokenType.IBET_SHARE.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # request target api

--- a/tests/test_app_routers_share_tokens_GET.py
+++ b/tests/test_app_routers_share_tokens_GET.py
@@ -17,12 +17,11 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 from unittest import mock
-from unittest.mock import call
 
 from pytz import timezone
 
 from app.model.blockchain import IbetShareContract
-from app.model.db import Token, TokenType
+from app.model.db import Token, TokenType, TokenVersion
 from config import TZ
 from tests.account_config import config_eth_account
 
@@ -57,6 +56,7 @@ class TestAppRoutersShareTokensGET:
         token.issuer_address = issuer_address_1
         token.token_address = "token_address_test1"
         token.abi = "abi_test1"
+        token.version = TokenVersion.V_22_12
         db.add(token)
         db.commit()
         _issue_datetime = (
@@ -122,6 +122,7 @@ class TestAppRoutersShareTokensGET:
                 "issue_datetime": _issue_datetime,
                 "token_status": 1,
                 "memo": "memo_test1",
+                "contract_version": TokenVersion.V_22_12,
             }
         ]
 
@@ -143,6 +144,7 @@ class TestAppRoutersShareTokensGET:
         token_1.issuer_address = issuer_address_1
         token_1.token_address = "token_address_test1"
         token_1.abi = "abi_test1"
+        token_1.version = TokenVersion.V_22_12
         db.add(token_1)
         db.commit()
         _issue_datetime_1 = (
@@ -187,6 +189,7 @@ class TestAppRoutersShareTokensGET:
         token_2.token_address = "token_address_test2"
         token_2.abi = "abi_test2"
         token_2.token_status = 0
+        token_2.version = TokenVersion.V_22_12
         db.add(token_2)
         db.commit()
         _issue_datetime_2 = (
@@ -252,6 +255,7 @@ class TestAppRoutersShareTokensGET:
                 "issue_datetime": _issue_datetime_1,
                 "token_status": 1,
                 "memo": "memo_test1",
+                "contract_version": TokenVersion.V_22_12,
             },
             {
                 "issuer_address": issuer_address_2,
@@ -277,6 +281,7 @@ class TestAppRoutersShareTokensGET:
                 "issue_datetime": _issue_datetime_2,
                 "token_status": 0,
                 "memo": "memo_test2",
+                "contract_version": TokenVersion.V_22_12,
             },
         ]
 
@@ -295,6 +300,7 @@ class TestAppRoutersShareTokensGET:
         token.issuer_address = "issuer_address_test1"
         token.token_address = "token_address_test1"
         token.abi = "abi_test1"
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         resp = client.get(self.apiurl, headers={"issuer-address": issuer_address_1})
@@ -317,6 +323,7 @@ class TestAppRoutersShareTokensGET:
         token_1.issuer_address = issuer_address_1
         token_1.token_address = "token_address_test1"
         token_1.abi = "abi_test1"
+        token_1.version = TokenVersion.V_22_12
         db.add(token_1)
         db.commit()
         _issue_datetime = (
@@ -361,6 +368,7 @@ class TestAppRoutersShareTokensGET:
         token_2.issuer_address = issuer_address_2
         token_2.token_address = "token_address_test1"
         token_2.abi = "abi_test1"
+        token_2.version = TokenVersion.V_22_12
         db.add(token_2)
 
         resp = client.get(self.apiurl, headers={"issuer-address": issuer_address_1})
@@ -390,6 +398,7 @@ class TestAppRoutersShareTokensGET:
                 "issue_datetime": _issue_datetime,
                 "token_status": 1,
                 "memo": "memo_test1",
+                "contract_version": TokenVersion.V_22_12,
             }
         ]
 
@@ -411,6 +420,7 @@ class TestAppRoutersShareTokensGET:
         token_1.issuer_address = issuer_address_1
         token_1.token_address = "token_address_test1"
         token_1.abi = "abi_test1"
+        token_1.version = TokenVersion.V_22_12
         db.add(token_1)
         db.commit()
         _issue_datetime_1 = (
@@ -455,6 +465,7 @@ class TestAppRoutersShareTokensGET:
         token_2.token_address = "token_address_test2"
         token_2.abi = "abi_test2"
         token_2.token_status = 0
+        token_2.version = TokenVersion.V_22_12
         db.add(token_2)
         db.commit()
         _issue_datetime_2 = (
@@ -500,6 +511,7 @@ class TestAppRoutersShareTokensGET:
         token_3.issuer_address = issuer_address_2
         token_3.token_address = "token_address_test1"
         token_3.abi = "abi_test1"
+        token_3.version = TokenVersion.V_22_12
         db.add(token_3)
 
         resp = client.get(self.apiurl, headers={"issuer-address": issuer_address_1})
@@ -529,6 +541,7 @@ class TestAppRoutersShareTokensGET:
                 "issue_datetime": _issue_datetime_1,
                 "token_status": 1,
                 "memo": "memo_test1",
+                "contract_version": TokenVersion.V_22_12,
             },
             {
                 "issuer_address": issuer_address_1,
@@ -554,6 +567,7 @@ class TestAppRoutersShareTokensGET:
                 "issue_datetime": _issue_datetime_2,
                 "token_status": 0,
                 "memo": "memo_test2",
+                "contract_version": TokenVersion.V_22_12,
             },
         ]
 

--- a/tests/test_app_routers_share_tokens_POST.py
+++ b/tests/test_app_routers_share_tokens_POST.py
@@ -39,6 +39,7 @@ from app.model.db import (
     Token,
     TokenType,
     TokenUpdateOperationLog,
+    TokenVersion,
     UpdateToken,
 )
 from app.utils.contract_utils import ContractUtils
@@ -153,6 +154,7 @@ class TestAppRoutersShareTokensPOST:
             assert token_1.token_address == "contract_address_test1"
             assert token_1.abi == "abi_test1"
             assert token_1.token_status == 1
+            assert token_1.version == TokenVersion.V_22_12
 
             position = db.scalars(select(IDXPosition).limit(1)).first()
             assert position.token_address == "contract_address_test1"
@@ -261,6 +263,7 @@ class TestAppRoutersShareTokensPOST:
             assert token_1.token_address == "contract_address_test1"
             assert token_1.abi == "abi_test1"
             assert token_1.token_status == 1
+            assert token_1.version == TokenVersion.V_22_12
 
             position = db.scalars(select(IDXPosition).limit(1)).first()
             assert position.token_address == "contract_address_test1"
@@ -387,6 +390,7 @@ class TestAppRoutersShareTokensPOST:
             assert token_1.token_address == "contract_address_test1"
             assert token_1.abi == "abi_test1"
             assert token_1.token_status == 0
+            assert token_1.version == TokenVersion.V_22_12
 
             position = db.scalars(select(IDXPosition).limit(1)).first()
             assert position is None
@@ -505,6 +509,7 @@ class TestAppRoutersShareTokensPOST:
             assert token_1.token_address == "contract_address_test1"
             assert token_1.abi == "abi_test1"
             assert token_1.token_status == 1
+            assert token_1.version == TokenVersion.V_22_12
 
             position = db.scalars(select(IDXPosition).limit(1)).first()
             assert position.token_address == "contract_address_test1"

--- a/tests/test_app_routers_share_tokens_{token_address}_GET.py
+++ b/tests/test_app_routers_share_tokens_{token_address}_GET.py
@@ -21,7 +21,7 @@ from unittest import mock
 from pytz import timezone
 
 from app.model.blockchain import IbetShareContract
-from app.model.db import Token, TokenType
+from app.model.db import Token, TokenType, TokenVersion
 from config import TZ
 
 
@@ -45,6 +45,7 @@ class TestAppRoutersShareTokensTokenAddressGET:
         token.issuer_address = "issuer_address_test1"
         token.token_address = "token_address_test1"
         token.abi = "abi_test1"
+        token.version = TokenVersion.V_22_12
         db.add(token)
         db.commit()
         _issue_time = (
@@ -110,6 +111,7 @@ class TestAppRoutersShareTokensTokenAddressGET:
             "issue_datetime": _issue_time,
             "token_status": 1,
             "memo": "memo_test1",
+            "contract_version": TokenVersion.V_22_12,
         }
 
         assert resp.status_code == 200
@@ -126,6 +128,7 @@ class TestAppRoutersShareTokensTokenAddressGET:
         token.issuer_address = "issuer_address_test1"
         token.token_address = "token_address_test1"
         token.abi = "abi_test1"
+        token.version = TokenVersion.V_22_12
         db.add(token)
         db.commit()
         _issue_time = (
@@ -191,6 +194,7 @@ class TestAppRoutersShareTokensTokenAddressGET:
             "issue_datetime": _issue_time,
             "token_status": 1,
             "memo": "memo_test1",
+            "contract_version": TokenVersion.V_22_12,
         }
 
         assert resp.status_code == 200
@@ -222,6 +226,7 @@ class TestAppRoutersShareTokensTokenAddressGET:
         token.token_address = "token_address_test1"
         token.abi = "abi_test1"
         token.token_status = 0
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         resp = client.get(self.base_apiurl + "token_address_test1")

--- a/tests/test_app_routers_share_tokens_{token_address}_POST.py
+++ b/tests/test_app_routers_share_tokens_{token_address}_POST.py
@@ -36,6 +36,7 @@ from app.model.db import (
     TokenType,
     TokenUpdateOperationCategory,
     TokenUpdateOperationLog,
+    TokenVersion,
 )
 from app.utils.contract_utils import ContractUtils
 from app.utils.e2ee_utils import E2EEUtils
@@ -105,6 +106,7 @@ class TestAppRoutersShareTokensTokenAddressPOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API
@@ -222,6 +224,7 @@ class TestAppRoutersShareTokensTokenAddressPOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API
@@ -286,6 +289,7 @@ class TestAppRoutersShareTokensTokenAddressPOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API
@@ -404,6 +408,7 @@ class TestAppRoutersShareTokensTokenAddressPOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API
@@ -500,6 +505,7 @@ class TestAppRoutersShareTokensTokenAddressPOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API
@@ -1006,6 +1012,7 @@ class TestAppRoutersShareTokensTokenAddressPOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # mock
@@ -1125,6 +1132,7 @@ class TestAppRoutersShareTokensTokenAddressPOST:
         token.token_address = _token_address
         token.abi = ""
         token.token_status = 0
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API
@@ -1170,6 +1178,7 @@ class TestAppRoutersShareTokensTokenAddressPOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API

--- a/tests/test_app_routers_share_tokens_{token_address}_additional_issue_GET.py
+++ b/tests/test_app_routers_share_tokens_{token_address}_additional_issue_GET.py
@@ -27,6 +27,7 @@ from app.model.db import (
     IDXIssueRedeemSortItem,
     Token,
     TokenType,
+    TokenVersion,
 )
 
 local_tz = timezone(config.TZ)
@@ -72,6 +73,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: IDXIssueRedeem
@@ -105,6 +107,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: IDXIssueRedeem
@@ -183,6 +186,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: IDXIssueRedeem
@@ -267,6 +271,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: IDXIssueRedeem
@@ -351,6 +356,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueGET:
         _token.token_address = self.test_token_address
         _token.abi = {}
         _token.token_status = 0
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # request target API

--- a/tests/test_app_routers_share_tokens_{token_address}_additional_issue_POST.py
+++ b/tests/test_app_routers_share_tokens_{token_address}_additional_issue_POST.py
@@ -22,7 +22,7 @@ from unittest.mock import ANY, MagicMock
 
 from app.exceptions import SendTransactionError
 from app.model.blockchain.tx_params.ibet_share import AdditionalIssueParams
-from app.model.db import Account, AuthToken, Token, TokenType
+from app.model.db import Account, AuthToken, Token, TokenType, TokenVersion
 from app.utils.e2ee_utils import E2EEUtils
 from tests.account_config import config_eth_account
 
@@ -57,6 +57,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssuePOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # mock
@@ -111,6 +112,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssuePOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # mock
@@ -280,6 +282,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssuePOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API
@@ -320,6 +323,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssuePOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API
@@ -427,6 +431,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssuePOST:
         token.token_address = _token_address
         token.abi = ""
         token.token_status = 0
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API
@@ -472,6 +477,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssuePOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API

--- a/tests/test_app_routers_share_tokens_{token_address}_additional_issue_batch_GET.py
+++ b/tests/test_app_routers_share_tokens_{token_address}_additional_issue_batch_GET.py
@@ -24,6 +24,7 @@ from app.model.db import (
     BatchIssueRedeemUpload,
     Token,
     TokenType,
+    TokenVersion,
 )
 from tests.account_config import config_eth_account
 
@@ -50,6 +51,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueBatchGET:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API
@@ -75,6 +77,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueBatchGET:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         additional_issue_upload1 = BatchIssueRedeemUpload()
@@ -121,6 +124,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueBatchGET:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         additional_issue_upload1 = BatchIssueRedeemUpload()
@@ -235,6 +239,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueBatchGET:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         additional_issue_upload1 = BatchIssueRedeemUpload()
@@ -336,6 +341,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueBatchGET:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         additional_issue_upload1 = BatchIssueRedeemUpload()
@@ -443,6 +449,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueBatchGET:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         additional_issue_upload1 = BatchIssueRedeemUpload()
@@ -542,6 +549,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueBatchGET:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         additional_issue_upload1 = BatchIssueRedeemUpload()
@@ -662,6 +670,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueBatchGET:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API

--- a/tests/test_app_routers_share_tokens_{token_address}_additional_issue_batch_POST.py
+++ b/tests/test_app_routers_share_tokens_{token_address}_additional_issue_batch_POST.py
@@ -27,6 +27,7 @@ from app.model.db import (
     BatchIssueRedeemUpload,
     Token,
     TokenType,
+    TokenVersion,
 )
 from app.utils.e2ee_utils import E2EEUtils
 from tests.account_config import config_eth_account
@@ -64,6 +65,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueBatchPOST:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API
@@ -126,6 +128,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueBatchPOST:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API
@@ -198,6 +201,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueBatchPOST:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API
@@ -247,6 +251,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueBatchPOST:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API
@@ -299,6 +304,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueBatchPOST:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API
@@ -351,6 +357,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueBatchPOST:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API
@@ -403,6 +410,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueBatchPOST:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API
@@ -449,6 +457,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueBatchPOST:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API
@@ -495,6 +504,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueBatchPOST:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API
@@ -539,6 +549,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueBatchPOST:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API
@@ -583,6 +594,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueBatchPOST:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API
@@ -666,6 +678,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueBatchPOST:
         token.token_address = token_address
         token.abi = ""
         token.token_status = 0
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API

--- a/tests/test_app_routers_share_tokens_{token_address}_additional_issue_batch_{batch_id}_GET.py
+++ b/tests/test_app_routers_share_tokens_{token_address}_additional_issue_batch_{batch_id}_GET.py
@@ -24,6 +24,7 @@ from app.model.db import (
     IDXPersonalInfo,
     Token,
     TokenType,
+    TokenVersion,
 )
 from app.utils.e2ee_utils import E2EEUtils
 from tests.account_config import config_eth_account
@@ -69,6 +70,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueBatchBatchIdGET:
         token.issuer_address = issuer_address
         token.token_address = test_token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         batch_upload = BatchIssueRedeemUpload()
@@ -153,6 +155,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueBatchBatchIdGET:
         token.issuer_address = issuer_address
         token.token_address = test_token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         batch_upload = BatchIssueRedeemUpload()
@@ -237,6 +240,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueBatchBatchIdGET:
         token.issuer_address = issuer_address
         token.token_address = test_token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         batch_upload = BatchIssueRedeemUpload()
@@ -347,6 +351,7 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueBatchBatchIdGET:
         token.issuer_address = issuer_address
         token.token_address = test_token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         batch_upload = BatchIssueRedeemUpload()

--- a/tests/test_app_routers_share_tokens_{token_address}_history_GET.py
+++ b/tests/test_app_routers_share_tokens_{token_address}_history_GET.py
@@ -35,6 +35,7 @@ from app.model.db import (
     TokenType,
     TokenUpdateOperationCategory,
     TokenUpdateOperationLog,
+    TokenVersion,
 )
 from app.model.schema import IbetShareCreate
 from app.utils.contract_utils import ContractUtils
@@ -226,6 +227,7 @@ class TestAppRoutersShareTokensTokenAddressHistoryGET:
         _token.type = TokenType.IBET_SHARE.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # request target api
@@ -275,6 +277,7 @@ class TestAppRoutersShareTokensTokenAddressHistoryGET:
         _token.type = TokenType.IBET_SHARE.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
         db.commit()
 
@@ -375,6 +378,7 @@ class TestAppRoutersShareTokensTokenAddressHistoryGET:
         _token.type = TokenType.IBET_SHARE.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
         db.commit()
 
@@ -473,6 +477,7 @@ class TestAppRoutersShareTokensTokenAddressHistoryGET:
         _token.type = TokenType.IBET_SHARE.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
         db.commit()
 
@@ -558,6 +563,7 @@ class TestAppRoutersShareTokensTokenAddressHistoryGET:
         _token.type = TokenType.IBET_SHARE.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         _operation_log_1 = TokenUpdateOperationLog()
@@ -657,6 +663,7 @@ class TestAppRoutersShareTokensTokenAddressHistoryGET:
         _token.type = TokenType.IBET_SHARE.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         _operation_log_1 = TokenUpdateOperationLog()
@@ -748,6 +755,7 @@ class TestAppRoutersShareTokensTokenAddressHistoryGET:
         _token.type = TokenType.IBET_SHARE.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
         db.commit()
 
@@ -852,6 +860,7 @@ class TestAppRoutersShareTokensTokenAddressHistoryGET:
         _token.type = TokenType.IBET_SHARE.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
         db.commit()
 
@@ -957,6 +966,7 @@ class TestAppRoutersShareTokensTokenAddressHistoryGET:
         _token.type = TokenType.IBET_SHARE.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
         db.commit()
 
@@ -1042,6 +1052,7 @@ class TestAppRoutersShareTokensTokenAddressHistoryGET:
         _token.type = TokenType.IBET_SHARE.value
         _token.tx_hash = ""
         _token.abi = ""
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
         db.commit()
 

--- a/tests/test_app_routers_share_tokens_{token_address}_holders_GET.py
+++ b/tests/test_app_routers_share_tokens_{token_address}_holders_GET.py
@@ -25,6 +25,7 @@ from app.model.db import (
     IDXPosition,
     Token,
     TokenType,
+    TokenVersion,
 )
 from tests.account_config import config_eth_account
 
@@ -55,6 +56,7 @@ class TestAppRoutersShareTokensTokenAddressHoldersGET:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API
@@ -87,6 +89,7 @@ class TestAppRoutersShareTokensTokenAddressHoldersGET:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # prepare data: Position
@@ -187,6 +190,7 @@ class TestAppRoutersShareTokensTokenAddressHoldersGET:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # prepare data: account_address_1
@@ -411,6 +415,7 @@ class TestAppRoutersShareTokensTokenAddressHoldersGET:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # prepare data: account_address_1
@@ -555,6 +560,7 @@ class TestAppRoutersShareTokensTokenAddressHoldersGET:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         idx_position_1 = IDXPosition()
@@ -773,6 +779,7 @@ class TestAppRoutersShareTokensTokenAddressHoldersGET:
         token.token_address = _token_address
         token.abi = ""
         token.token_status = 0
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # prepare data

--- a/tests/test_app_routers_share_tokens_{token_address}_holders_count_GET.py
+++ b/tests/test_app_routers_share_tokens_{token_address}_holders_count_GET.py
@@ -16,7 +16,14 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
-from app.model.db import Account, IDXLockedPosition, IDXPosition, Token, TokenType
+from app.model.db import (
+    Account,
+    IDXLockedPosition,
+    IDXPosition,
+    Token,
+    TokenType,
+    TokenVersion,
+)
 from tests.account_config import config_eth_account
 
 
@@ -47,6 +54,7 @@ class TestAppRoutersShareTokensTokenAddressHoldersCountGET:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API
@@ -79,6 +87,7 @@ class TestAppRoutersShareTokensTokenAddressHoldersCountGET:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         idx_position_1 = IDXPosition()
@@ -120,6 +129,7 @@ class TestAppRoutersShareTokensTokenAddressHoldersCountGET:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         idx_position_1 = IDXPosition()
@@ -179,6 +189,7 @@ class TestAppRoutersShareTokensTokenAddressHoldersCountGET:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         idx_position_1 = IDXPosition()
@@ -230,6 +241,7 @@ class TestAppRoutersShareTokensTokenAddressHoldersCountGET:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         idx_position_1 = IDXPosition()
@@ -392,6 +404,7 @@ class TestAppRoutersShareTokensTokenAddressHoldersCountGET:
         token.token_address = _token_address
         token.abi = ""
         token.token_status = 0
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API

--- a/tests/test_app_routers_share_tokens_{token_address}_holders_{account_address}_GET.py
+++ b/tests/test_app_routers_share_tokens_{token_address}_holders_{account_address}_GET.py
@@ -25,6 +25,7 @@ from app.model.db import (
     IDXPosition,
     Token,
     TokenType,
+    TokenVersion,
 )
 from tests.account_config import config_eth_account
 
@@ -58,6 +59,7 @@ class TestAppRoutersShareTokensTokenAddressHoldersAccountAddressGET:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # prepare data: Personal Info
@@ -125,6 +127,7 @@ class TestAppRoutersShareTokensTokenAddressHoldersAccountAddressGET:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # prepare data: Position
@@ -203,6 +206,7 @@ class TestAppRoutersShareTokensTokenAddressHoldersAccountAddressGET:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # prepare data: Position
@@ -300,6 +304,7 @@ class TestAppRoutersShareTokensTokenAddressHoldersAccountAddressGET:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         idx_position_1 = IDXPosition()
@@ -359,6 +364,7 @@ class TestAppRoutersShareTokensTokenAddressHoldersAccountAddressGET:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         idx_position_1 = IDXPosition()
@@ -510,6 +516,7 @@ class TestAppRoutersShareTokensTokenAddressHoldersAccountAddressGET:
         token.token_address = _token_address
         token.abi = ""
         token.token_status = 0
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API

--- a/tests/test_app_routers_share_tokens_{token_address}_personal_info_POST.py
+++ b/tests/test_app_routers_share_tokens_{token_address}_personal_info_POST.py
@@ -21,7 +21,7 @@ from unittest.mock import patch
 
 from app.exceptions import SendTransactionError
 from app.model.blockchain import IbetShareContract, PersonalInfoContract
-from app.model.db import Account, AuthToken, Token, TokenType
+from app.model.db import Account, AuthToken, Token, TokenType, TokenVersion
 from app.utils.e2ee_utils import E2EEUtils
 from tests.account_config import config_eth_account
 
@@ -58,6 +58,7 @@ class TestAppRoutersShareTokensTokenAddressPersonalInfoPOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # mock
@@ -141,6 +142,7 @@ class TestAppRoutersShareTokensTokenAddressPersonalInfoPOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # mock
@@ -230,6 +232,7 @@ class TestAppRoutersShareTokensTokenAddressPersonalInfoPOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # mock
@@ -687,6 +690,7 @@ class TestAppRoutersShareTokensTokenAddressPersonalInfoPOST:
         token.token_address = _token_address
         token.abi = ""
         token.token_status = 0
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API
@@ -742,6 +746,7 @@ class TestAppRoutersShareTokensTokenAddressPersonalInfoPOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # mock

--- a/tests/test_app_routers_share_tokens_{token_address}_personal_info_batch_GET.py
+++ b/tests/test_app_routers_share_tokens_{token_address}_personal_info_batch_GET.py
@@ -23,6 +23,7 @@ from app.model.db import (
     BatchRegisterPersonalInfoUploadStatus,
     Token,
     TokenType,
+    TokenVersion,
 )
 from tests.account_config import config_eth_account
 
@@ -59,6 +60,7 @@ class TestAppRoutersShareTokensTokenAddressPersonalInfoBatchGET:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API
@@ -89,6 +91,7 @@ class TestAppRoutersShareTokensTokenAddressPersonalInfoBatchGET:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # Prepare data : BatchRegisterPersonalInfoUpload
@@ -145,6 +148,7 @@ class TestAppRoutersShareTokensTokenAddressPersonalInfoBatchGET:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # Prepare data : BatchRegisterPersonalInfoUpload
@@ -197,6 +201,7 @@ class TestAppRoutersShareTokensTokenAddressPersonalInfoBatchGET:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # Prepare data : BatchRegisterPersonalInfoUpload
@@ -249,6 +254,7 @@ class TestAppRoutersShareTokensTokenAddressPersonalInfoBatchGET:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # Prepare data : BatchRegisterPersonalInfoUpload
@@ -310,6 +316,7 @@ class TestAppRoutersShareTokensTokenAddressPersonalInfoBatchGET:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API
@@ -350,6 +357,7 @@ class TestAppRoutersShareTokensTokenAddressPersonalInfoBatchGET:
         token.issuer_address = _issuer_address_2
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # Prepare data : BatchRegisterPersonalInfoUpload

--- a/tests/test_app_routers_share_tokens_{token_address}_personal_info_batch_POST.py
+++ b/tests/test_app_routers_share_tokens_{token_address}_personal_info_batch_POST.py
@@ -30,6 +30,7 @@ from app.model.db import (
     BatchRegisterPersonalInfoUploadStatus,
     Token,
     TokenType,
+    TokenVersion,
 )
 from app.utils.e2ee_utils import E2EEUtils
 from tests.account_config import config_eth_account
@@ -68,6 +69,7 @@ class TestAppRoutersShareTokensTokenAddressPersonalInfoBatchPOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         personal_info = {
@@ -142,6 +144,7 @@ class TestAppRoutersShareTokensTokenAddressPersonalInfoBatchPOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         personal_info = {
@@ -664,6 +667,7 @@ class TestAppRoutersShareTokensTokenAddressPersonalInfoBatchPOST:
         token.token_address = _token_address
         token.abi = ""
         token.token_status = 0
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API
@@ -723,6 +727,7 @@ class TestAppRoutersShareTokensTokenAddressPersonalInfoBatchPOST:
         token.token_address = _token_address
         token.abi = ""
         token.token_status = 1
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API

--- a/tests/test_app_routers_share_tokens_{token_address}_personal_info_batch_{batch_id}_GET.py
+++ b/tests/test_app_routers_share_tokens_{token_address}_personal_info_batch_{batch_id}_GET.py
@@ -23,6 +23,7 @@ from app.model.db import (
     BatchRegisterPersonalInfoUploadStatus,
     Token,
     TokenType,
+    TokenVersion,
 )
 from app.utils.e2ee_utils import E2EEUtils
 from tests.account_config import config_eth_account
@@ -92,6 +93,7 @@ class TestAppRoutersShareTokensTokenAddressPersonalInfoBatchBatchIdGET:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # Prepare data : BatchRegisterPersonalInfoUpload

--- a/tests/test_app_routers_share_tokens_{token_address}_redeem_GET.py
+++ b/tests/test_app_routers_share_tokens_{token_address}_redeem_GET.py
@@ -27,6 +27,7 @@ from app.model.db import (
     IDXIssueRedeemSortItem,
     Token,
     TokenType,
+    TokenVersion,
 )
 
 local_tz = timezone(config.TZ)
@@ -72,6 +73,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: IDXIssueRedeem
@@ -105,6 +107,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: IDXIssueRedeem
@@ -183,6 +186,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: IDXIssueRedeem
@@ -267,6 +271,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: IDXIssueRedeem
@@ -351,6 +356,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemGET:
         _token.token_address = self.test_token_address
         _token.abi = {}
         _token.token_status = 0
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # request target API

--- a/tests/test_app_routers_share_tokens_{token_address}_redeem_POST.py
+++ b/tests/test_app_routers_share_tokens_{token_address}_redeem_POST.py
@@ -22,7 +22,7 @@ from unittest.mock import ANY, MagicMock
 
 from app.exceptions import SendTransactionError
 from app.model.blockchain.tx_params.ibet_share import RedeemParams
-from app.model.db import Account, AuthToken, Token, TokenType
+from app.model.db import Account, AuthToken, Token, TokenType, TokenVersion
 from app.utils.e2ee_utils import E2EEUtils
 from tests.account_config import config_eth_account
 
@@ -57,6 +57,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemPOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # mock
@@ -109,6 +110,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemPOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # mock
@@ -276,6 +278,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemPOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API
@@ -316,6 +319,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemPOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API
@@ -423,6 +427,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemPOST:
         token.token_address = _token_address
         token.abi = ""
         token.token_status = 0
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API
@@ -468,6 +473,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemPOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API

--- a/tests/test_app_routers_share_tokens_{token_address}_redeem_batch_GET.py
+++ b/tests/test_app_routers_share_tokens_{token_address}_redeem_batch_GET.py
@@ -24,6 +24,7 @@ from app.model.db import (
     BatchIssueRedeemUpload,
     Token,
     TokenType,
+    TokenVersion,
 )
 from tests.account_config import config_eth_account
 
@@ -50,6 +51,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemBatchGET:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API
@@ -75,6 +77,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemBatchGET:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         redeem_upload1 = BatchIssueRedeemUpload()
@@ -119,6 +122,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemBatchGET:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         redeem_upload1 = BatchIssueRedeemUpload()
@@ -223,6 +227,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemBatchGET:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         redeem_upload1 = BatchIssueRedeemUpload()
@@ -314,6 +319,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemBatchGET:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         redeem_upload1 = BatchIssueRedeemUpload()
@@ -411,6 +417,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemBatchGET:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         redeem_upload1 = BatchIssueRedeemUpload()
@@ -500,6 +507,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemBatchGET:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         additional_issue_upload1 = BatchIssueRedeemUpload()
@@ -620,6 +628,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemBatchGET:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API

--- a/tests/test_app_routers_share_tokens_{token_address}_redeem_batch_POST.py
+++ b/tests/test_app_routers_share_tokens_{token_address}_redeem_batch_POST.py
@@ -27,6 +27,7 @@ from app.model.db import (
     BatchIssueRedeemUpload,
     Token,
     TokenType,
+    TokenVersion,
 )
 from app.utils.e2ee_utils import E2EEUtils
 from tests.account_config import config_eth_account
@@ -64,6 +65,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemBatchPOST:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API
@@ -126,6 +128,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemBatchPOST:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API
@@ -198,6 +201,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemBatchPOST:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API
@@ -247,6 +251,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemBatchPOST:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API
@@ -299,6 +304,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemBatchPOST:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API
@@ -351,6 +357,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemBatchPOST:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API
@@ -403,6 +410,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemBatchPOST:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API
@@ -449,6 +457,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemBatchPOST:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API
@@ -495,6 +504,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemBatchPOST:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API
@@ -539,6 +549,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemBatchPOST:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API
@@ -583,6 +594,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemBatchPOST:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API
@@ -666,6 +678,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemBatchPOST:
         token.token_address = token_address
         token.abi = ""
         token.token_status = 0
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API

--- a/tests/test_app_routers_share_tokens_{token_address}_redeem_batch_{batch_id}_GET.py
+++ b/tests/test_app_routers_share_tokens_{token_address}_redeem_batch_{batch_id}_GET.py
@@ -24,6 +24,7 @@ from app.model.db import (
     IDXPersonalInfo,
     Token,
     TokenType,
+    TokenVersion,
 )
 from app.utils.e2ee_utils import E2EEUtils
 from tests.account_config import config_eth_account
@@ -69,6 +70,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemBatchBatchIdGET:
         token.issuer_address = issuer_address
         token.token_address = test_token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         batch_upload = BatchIssueRedeemUpload()
@@ -153,6 +155,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemBatchBatchIdGET:
         token.issuer_address = issuer_address
         token.token_address = test_token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         batch_upload = BatchIssueRedeemUpload()
@@ -237,6 +240,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemBatchBatchIdGET:
         token.issuer_address = issuer_address
         token.token_address = test_token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         batch_upload = BatchIssueRedeemUpload()
@@ -347,6 +351,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemBatchBatchIdGET:
         token.issuer_address = issuer_address
         token.token_address = test_token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         batch_upload = BatchIssueRedeemUpload()

--- a/tests/test_app_routers_share_tokens_{token_address}_scheduled_events_POST.py
+++ b/tests/test_app_routers_share_tokens_{token_address}_scheduled_events_POST.py
@@ -21,7 +21,14 @@ from datetime import datetime, timezone
 from pytz import timezone as tz
 from sqlalchemy import and_, select
 
-from app.model.db import Account, ScheduledEvents, ScheduledEventType, Token, TokenType
+from app.model.db import (
+    Account,
+    ScheduledEvents,
+    ScheduledEventType,
+    Token,
+    TokenType,
+    TokenVersion,
+)
 from app.utils.e2ee_utils import E2EEUtils
 from tests.account_config import config_eth_account
 
@@ -55,6 +62,7 @@ class TestAppRoutersShareTokensTokenAddressScheduledEventsPOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # test data
@@ -135,6 +143,7 @@ class TestAppRoutersShareTokensTokenAddressScheduledEventsPOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # test data
@@ -334,6 +343,7 @@ class TestAppRoutersShareTokensTokenAddressScheduledEventsPOST:
         token.issuer_address = _issuer_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # test data
@@ -476,6 +486,7 @@ class TestAppRoutersShareTokensTokenAddressScheduledEventsPOST:
         token.token_address = _token_address
         token.abi = ""
         token.token_status = 0
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # test data

--- a/tests/test_app_routers_share_transfer_approvals_GET.py
+++ b/tests/test_app_routers_share_transfer_approvals_GET.py
@@ -25,6 +25,7 @@ from app.model.db import (
     IDXTransferApproval,
     Token,
     TokenType,
+    TokenVersion,
     TransferApprovalHistory,
     TransferApprovalOperationType,
 )
@@ -98,6 +99,7 @@ class TestAppRoutersShareTransferApprovalsGET:
         _token.token_address = self.test_token_address_1
         _token.abi = {}
         _token.token_status = 2
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: Token(bond)
@@ -107,6 +109,7 @@ class TestAppRoutersShareTransferApprovalsGET:
         _token.issuer_address = self.test_issuer_address_1
         _token.token_address = self.test_token_address_2
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: IDXTransferApproval(failed token)
@@ -195,6 +198,7 @@ class TestAppRoutersShareTransferApprovalsGET:
         _token.issuer_address = self.test_issuer_address_1
         _token.token_address = self.test_token_address_1
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: IDXTransferApproval(ApplyFor(unapproved))
@@ -379,6 +383,7 @@ class TestAppRoutersShareTransferApprovalsGET:
         _token.issuer_address = self.test_issuer_address_1
         _token.token_address = self.test_token_address_1
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: Token(issuer-1)
@@ -388,6 +393,7 @@ class TestAppRoutersShareTransferApprovalsGET:
         _token.issuer_address = self.test_issuer_address_1
         _token.token_address = self.test_token_address_2
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: Token(issuer-2)
@@ -397,6 +403,7 @@ class TestAppRoutersShareTransferApprovalsGET:
         _token.issuer_address = self.test_issuer_address_2
         _token.token_address = self.test_token_address_3
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: IDXTransferApproval(issuer-1 token-1)
@@ -559,6 +566,7 @@ class TestAppRoutersShareTransferApprovalsGET:
         _token.issuer_address = self.test_issuer_address_1
         _token.token_address = self.test_token_address_1
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: Token(issuer-1)
@@ -568,6 +576,7 @@ class TestAppRoutersShareTransferApprovalsGET:
         _token.issuer_address = self.test_issuer_address_1
         _token.token_address = self.test_token_address_2
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: Token(issuer-2)
@@ -577,6 +586,7 @@ class TestAppRoutersShareTransferApprovalsGET:
         _token.issuer_address = self.test_issuer_address_2
         _token.token_address = self.test_token_address_3
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: IDXTransferApproval(issuer-1 token-1)
@@ -746,6 +756,7 @@ class TestAppRoutersShareTransferApprovalsGET:
         _token.issuer_address = self.test_issuer_address_1
         _token.token_address = self.test_token_address_1
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: Token(issuer-1)
@@ -755,6 +766,7 @@ class TestAppRoutersShareTransferApprovalsGET:
         _token.issuer_address = self.test_issuer_address_1
         _token.token_address = self.test_token_address_2
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: Token(issuer-1)
@@ -764,6 +776,7 @@ class TestAppRoutersShareTransferApprovalsGET:
         _token.issuer_address = self.test_issuer_address_1
         _token.token_address = self.test_token_address_3
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: Token(issuer-1)
@@ -773,6 +786,7 @@ class TestAppRoutersShareTransferApprovalsGET:
         _token.issuer_address = self.test_issuer_address_1
         _token.token_address = self.test_token_address_4
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: IDXTransferApproval(issuer-1 token-1)

--- a/tests/test_app_routers_share_transfer_approvals_{token_address}_GET.py
+++ b/tests/test_app_routers_share_transfer_approvals_{token_address}_GET.py
@@ -26,6 +26,7 @@ from app.model.db import (
     IDXTransferApproval,
     Token,
     TokenType,
+    TokenVersion,
     TransferApprovalHistory,
     TransferApprovalOperationType,
 )
@@ -108,6 +109,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # request target API
@@ -131,6 +133,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -322,6 +325,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -439,6 +443,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -640,6 +645,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -750,6 +756,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -861,6 +868,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -1004,6 +1012,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -1147,6 +1156,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: IDXTransferApproval
@@ -1378,6 +1388,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -1595,6 +1606,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -1844,6 +1856,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -2041,6 +2054,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -2278,6 +2292,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -2515,6 +2530,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -2717,6 +2733,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -2917,6 +2934,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -3153,6 +3171,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -3396,6 +3415,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -3635,6 +3655,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -4193,6 +4214,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressGET:
         _token.token_address = self.test_token_address
         _token.abi = {}
         _token.token_status = 0
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # request target API

--- a/tests/test_app_routers_share_transfer_approvals_{token_address}_{id}_GET.py
+++ b/tests/test_app_routers_share_transfer_approvals_{token_address}_{id}_GET.py
@@ -26,6 +26,7 @@ from app.model.db import (
     IDXTransferApproval,
     Token,
     TokenType,
+    TokenVersion,
     TransferApprovalHistory,
     TransferApprovalOperationType,
 )
@@ -94,6 +95,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressIdGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -204,6 +206,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressIdGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: IDXTransferApproval
@@ -266,6 +269,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressIdGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: IDXTransferApproval
@@ -373,6 +377,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressIdGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: IDXTransferApproval
@@ -482,6 +487,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressIdGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -593,6 +599,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressIdGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: IDXTransferApproval
@@ -702,6 +709,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressIdGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: IDXTransferApproval
@@ -833,6 +841,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressIdGET:
         _token.token_address = self.test_token_address
         _token.abi = {}
         _token.token_status = 0
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # request target API
@@ -858,6 +867,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressIdGET:
         _token.token_address = self.test_token_address
         _token.abi = {}
         _token.token_status = 1
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # request target API

--- a/tests/test_app_routers_share_transfer_approvals_{token_address}_{id}_POST.py
+++ b/tests/test_app_routers_share_transfer_approvals_{token_address}_{id}_POST.py
@@ -41,6 +41,7 @@ from app.model.db import (
     IDXTransferApproval,
     Token,
     TokenType,
+    TokenVersion,
     TransferApprovalHistory,
     TransferApprovalOperationType,
 )
@@ -91,6 +92,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressIdPOST:
         _token.issuer_address = issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         id = 10
@@ -222,6 +224,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressIdPOST:
         _token.issuer_address = issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         id = 10
@@ -354,6 +357,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressIdPOST:
         _token.issuer_address = issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         id = 10
@@ -490,6 +494,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressIdPOST:
         _token.issuer_address = issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         id = 10
@@ -814,6 +819,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressIdPOST:
         _token.issuer_address = issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         id = 10
@@ -856,6 +862,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressIdPOST:
         _token.token_address = self.test_token_address
         _token.abi = {}
         _token.token_status = 0
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         id = 10
@@ -897,6 +904,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressIdPOST:
         _token.issuer_address = issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         id = 10
@@ -959,6 +967,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressIdPOST:
         _token.issuer_address = issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         id = 10
@@ -1021,6 +1030,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressIdPOST:
         _token.issuer_address = issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         id = 10
@@ -1081,6 +1091,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressIdPOST:
         _token.issuer_address = issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         id = 10
@@ -1141,6 +1152,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressIdPOST:
         _token.issuer_address = issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         id = 10
@@ -1214,6 +1226,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressIdPOST:
         _token.issuer_address = issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         id = 10
@@ -1304,6 +1317,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressIdPOST:
         _token.issuer_address = issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         id = 10
@@ -1411,6 +1425,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressIdPOST:
         _token.issuer_address = issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         id = 10
@@ -1502,6 +1517,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressIdPOST:
         _token.issuer_address = issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         id = 10
@@ -1604,6 +1620,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressIdPOST:
         _token.issuer_address = issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         id = 10
@@ -1694,6 +1711,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressIdPOST:
         _token.issuer_address = issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         id = 10
@@ -1789,6 +1807,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressIdPOST:
         _token.issuer_address = issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         id = 10
@@ -1854,6 +1873,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressIdPOST:
         _token.issuer_address = issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         id = 10

--- a/tests/test_app_routers_share_transfers_POST.py
+++ b/tests/test_app_routers_share_transfers_POST.py
@@ -22,7 +22,7 @@ from unittest.mock import ANY, MagicMock
 
 from app.exceptions import SendTransactionError
 from app.model.blockchain.tx_params.ibet_share import TransferParams
-from app.model.db import Account, AuthToken, Token, TokenType
+from app.model.db import Account, AuthToken, Token, TokenType, TokenVersion
 from app.utils.e2ee_utils import E2EEUtils
 from tests.account_config import config_eth_account
 
@@ -64,6 +64,7 @@ class TestAppRoutersShareTransfersPOST:
         token.issuer_address = _admin_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # mock
@@ -136,6 +137,7 @@ class TestAppRoutersShareTransfersPOST:
         token.issuer_address = _admin_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # mock
@@ -536,6 +538,7 @@ class TestAppRoutersShareTransfersPOST:
         token.token_address = _token_address
         token.abi = ""
         token.token_status = 0
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API
@@ -593,6 +596,7 @@ class TestAppRoutersShareTransfersPOST:
         token.issuer_address = _admin_address
         token.token_address = _token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API

--- a/tests/test_app_routers_share_transfers_{token_address}_GET.py
+++ b/tests/test_app_routers_share_transfers_{token_address}_GET.py
@@ -27,6 +27,7 @@ from app.model.db import (
     IDXTransferSourceEventType,
     Token,
     TokenType,
+    TokenVersion,
 )
 
 local_tz = timezone(config.TZ)
@@ -66,6 +67,7 @@ class TestAppRoutersShareTransfersGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: IDXTransfer
@@ -139,6 +141,7 @@ class TestAppRoutersShareTransfersGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -239,6 +242,7 @@ class TestAppRoutersShareTransfersGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -352,6 +356,7 @@ class TestAppRoutersShareTransfersGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -464,6 +469,7 @@ class TestAppRoutersShareTransfersGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -628,6 +634,7 @@ class TestAppRoutersShareTransfersGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -786,6 +793,7 @@ class TestAppRoutersShareTransfersGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -944,6 +952,7 @@ class TestAppRoutersShareTransfersGET:
         _token.issuer_address = self.test_issuer_address
         _token.token_address = self.test_token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # prepare data: IDXPersonalInfo
@@ -1148,6 +1157,7 @@ class TestAppRoutersShareTransfersGET:
         _token.token_address = self.test_token_address
         _token.abi = {}
         _token.token_status = 0
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # request target API

--- a/tests/test_app_routers_token_holders_{token_address}_GET.py
+++ b/tests/test_app_routers_token_holders_{token_address}_GET.py
@@ -19,7 +19,13 @@ SPDX-License-Identifier: Apache-2.0
 import uuid
 from unittest import mock
 
-from app.model.db import Token, TokenHolderBatchStatus, TokenHoldersList, TokenType
+from app.model.db import (
+    Token,
+    TokenHolderBatchStatus,
+    TokenHoldersList,
+    TokenType,
+    TokenVersion,
+)
 from tests.account_config import config_eth_account
 
 
@@ -45,6 +51,7 @@ class TestAppRoutersTokenHoldersGET:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API
@@ -70,6 +77,7 @@ class TestAppRoutersTokenHoldersGET:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         token_holder_list1 = TokenHoldersList()
@@ -110,6 +118,7 @@ class TestAppRoutersTokenHoldersGET:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         token_holder_list1 = TokenHoldersList()
@@ -211,6 +220,7 @@ class TestAppRoutersTokenHoldersGET:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         db.commit()
@@ -317,6 +327,7 @@ class TestAppRoutersTokenHoldersGET:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         token_holder_list1 = TokenHoldersList()
@@ -388,6 +399,7 @@ class TestAppRoutersTokenHoldersGET:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         db.commit()
@@ -470,6 +482,7 @@ class TestAppRoutersTokenHoldersGET:
         token.issuer_address = issuer_address
         token.token_address = token_address
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         token_holder_list1 = TokenHoldersList()
@@ -611,6 +624,7 @@ class TestAppRoutersTokenHoldersGET:
         token.token_address = token_address
         token.token_status = 0
         token.abi = ""
+        token.version = TokenVersion.V_22_12
         db.add(token)
 
         # request target API

--- a/tests/test_app_routers_token_holders_{token_address}_collection_POST.py
+++ b/tests/test_app_routers_token_holders_{token_address}_collection_POST.py
@@ -24,7 +24,13 @@ from web3 import Web3
 from web3.middleware import geth_poa_middleware
 
 import config
-from app.model.db import Token, TokenHolderBatchStatus, TokenHoldersList, TokenType
+from app.model.db import (
+    Token,
+    TokenHolderBatchStatus,
+    TokenHoldersList,
+    TokenType,
+    TokenVersion,
+)
 from tests.account_config import config_eth_account
 
 web3 = Web3(Web3.HTTPProvider(config.WEB3_HTTP_PROVIDER))
@@ -55,6 +61,7 @@ class TestAppRoutersHoldersTokenAddressCollectionPOST:
         _token.issuer_address = issuer_address
         _token.token_address = token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         list_id = str(uuid.uuid4())
@@ -99,6 +106,7 @@ class TestAppRoutersHoldersTokenAddressCollectionPOST:
         _token.issuer_address = issuer_address
         _token.token_address = token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         for i in range(2):
@@ -136,6 +144,7 @@ class TestAppRoutersHoldersTokenAddressCollectionPOST:
         _token.issuer_address = issuer_address
         _token.token_address = token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # request target API
@@ -189,6 +198,7 @@ class TestAppRoutersHoldersTokenAddressCollectionPOST:
         _token.issuer_address = issuer_address
         _token.token_address = token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # request target API
@@ -230,6 +240,7 @@ class TestAppRoutersHoldersTokenAddressCollectionPOST:
         _token.issuer_address = issuer_address
         _token.token_address = token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # request target API
@@ -265,6 +276,7 @@ class TestAppRoutersHoldersTokenAddressCollectionPOST:
         _token.issuer_address = issuer_address
         _token.token_address = token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # request target API
@@ -308,6 +320,7 @@ class TestAppRoutersHoldersTokenAddressCollectionPOST:
         _token.issuer_address = issuer_address
         _token.token_address = token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         # request target API
@@ -343,6 +356,7 @@ class TestAppRoutersHoldersTokenAddressCollectionPOST:
         _token1.issuer_address = issuer_address
         _token1.token_address = token_address1
         _token1.abi = {}
+        _token1.version = TokenVersion.V_22_12
         db.add(_token1)
 
         # request target API
@@ -369,6 +383,7 @@ class TestAppRoutersHoldersTokenAddressCollectionPOST:
         _token2.issuer_address = issuer_address
         _token2.token_address = token_address2
         _token2.abi = {}
+        _token2.version = TokenVersion.V_22_12
         db.add(_token2)
 
         # request target API with same list id as in the past
@@ -406,6 +421,7 @@ class TestAppRoutersHoldersTokenAddressCollectionPOST:
         _token.token_address = token_address
         _token.abi = {}
         _token.token_status = 0
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         list_id = str(uuid.uuid4())
@@ -444,6 +460,7 @@ class TestAppRoutersHoldersTokenAddressCollectionPOST:
         _token.issuer_address = issuer_address
         _token.token_address = token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         list_id = str(uuid.uuid4())

--- a/tests/test_app_routers_token_holders_{token_address}_collection_{collection_id}_GET.py
+++ b/tests/test_app_routers_token_holders_{token_address}_collection_{collection_id}_GET.py
@@ -30,6 +30,7 @@ from app.model.db import (
     TokenHolderBatchStatus,
     TokenHoldersList,
     TokenType,
+    TokenVersion,
 )
 from tests.account_config import config_eth_account
 
@@ -62,6 +63,7 @@ class TestAppRoutersHoldersTokenAddressCollectionIdGET:
         _token.issuer_address = issuer_address
         _token.token_address = token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         list_id = str(uuid.uuid4())
@@ -102,6 +104,7 @@ class TestAppRoutersHoldersTokenAddressCollectionIdGET:
         _token.issuer_address = issuer_address
         _token.token_address = token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         list_id = str(uuid.uuid4())
@@ -183,6 +186,7 @@ class TestAppRoutersHoldersTokenAddressCollectionIdGET:
         # set status pending
         _token.token_status = 0
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         list_id = str(uuid.uuid4())
@@ -222,6 +226,7 @@ class TestAppRoutersHoldersTokenAddressCollectionIdGET:
         _token.issuer_address = issuer_address
         _token.token_address = token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         list_id = str(uuid.uuid4())
@@ -261,6 +266,7 @@ class TestAppRoutersHoldersTokenAddressCollectionIdGET:
         _token.issuer_address = issuer_address
         _token.token_address = token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         list_id = str(uuid.uuid4())
@@ -294,6 +300,7 @@ class TestAppRoutersHoldersTokenAddressCollectionIdGET:
         _token1.issuer_address = issuer_address
         _token1.token_address = token_address1
         _token1.abi = {}
+        _token1.version = TokenVersion.V_22_12
         db.add(_token1)
         _token2 = Token()
         _token2.type = TokenType.IBET_STRAIGHT_BOND.value
@@ -301,6 +308,7 @@ class TestAppRoutersHoldersTokenAddressCollectionIdGET:
         _token2.issuer_address = issuer_address
         _token2.token_address = token_address2
         _token2.abi = {}
+        _token2.version = TokenVersion.V_22_12
         db.add(_token2)
 
         list_id = str(uuid.uuid4())
@@ -340,6 +348,7 @@ class TestAppRoutersHoldersTokenAddressCollectionIdGET:
         _token.issuer_address = issuer_address
         _token.token_address = token_address
         _token.abi = {}
+        _token.version = TokenVersion.V_22_12
         db.add(_token)
 
         list_id = str(uuid.uuid4())

--- a/tests/test_batch_indexer_issue_redeem.py
+++ b/tests/test_batch_indexer_issue_redeem.py
@@ -42,6 +42,7 @@ from app.model.db import (
     IDXIssueRedeemEventType,
     Token,
     TokenType,
+    TokenVersion,
 )
 from app.utils.contract_utils import ContractUtils
 from app.utils.web3_utils import Web3Wrapper
@@ -161,6 +162,7 @@ class TestProcessor:
         token_1.abi = "abi"
         token_1.tx_hash = "tx_hash"
         token_1.token_status = 0
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
         db.commit()
 
@@ -201,6 +203,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         db.commit()
@@ -243,6 +246,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         db.commit()
@@ -308,6 +312,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         db.commit()
@@ -373,6 +378,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         db.commit()
@@ -438,6 +444,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         db.commit()
@@ -502,6 +509,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         db.commit()
@@ -596,6 +604,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         db.commit()
@@ -665,6 +674,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         db.commit()
@@ -689,6 +699,7 @@ class TestProcessor:
         token_2.issuer_address = issuer_address
         token_2.abi = token_contract_2.abi
         token_2.tx_hash = "tx_hash"
+        token_2.version = TokenVersion.V_22_12
         db.add(token_2)
 
         db.commit()
@@ -733,6 +744,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         db.commit()

--- a/tests/test_batch_indexer_personal_info.py
+++ b/tests/test_batch_indexer_personal_info.py
@@ -44,6 +44,7 @@ from app.model.db import (
     IDXPersonalInfoBlockNumber,
     Token,
     TokenType,
+    TokenVersion,
 )
 from app.utils.contract_utils import ContractUtils
 from app.utils.e2ee_utils import E2EEUtils
@@ -184,6 +185,7 @@ class TestProcessor:
         token_1.abi = "abi"
         token_1.tx_hash = "tx_hash"
         token_1.token_status = 0
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         db.commit()
@@ -235,6 +237,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         # Prepare data : Token(processing token)
@@ -245,6 +248,7 @@ class TestProcessor:
         token_2.abi = "abi"
         token_2.tx_hash = "tx_hash"
         token_2.token_status = 0
+        token_2.version = TokenVersion.V_23_12
         db.add(token_2)
 
         # Prepare data : BlockNumber
@@ -306,6 +310,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         # Prepare data : Token(processing token)
@@ -316,6 +321,7 @@ class TestProcessor:
         token_2.abi = "abi"
         token_2.tx_hash = "tx_hash"
         token_2.token_status = 0
+        token_2.version = TokenVersion.V_23_12
         db.add(token_2)
 
         db.commit()
@@ -403,6 +409,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         # Prepare data : Token(processing token)
@@ -413,6 +420,7 @@ class TestProcessor:
         token_2.abi = "abi"
         token_2.tx_hash = "tx_hash"
         token_2.token_status = 0
+        token_2.version = TokenVersion.V_23_12
         db.add(token_2)
 
         db.commit()
@@ -540,6 +548,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         # Prepare data : Token(processing token)
@@ -550,6 +559,7 @@ class TestProcessor:
         token_2.abi = "abi"
         token_2.tx_hash = "tx_hash"
         token_2.token_status = 0
+        token_2.version = TokenVersion.V_23_12
         db.add(token_2)
 
         db.commit()
@@ -753,6 +763,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address_1
         token_1.abi = token_contract1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         # Issuer2 issues bond token.
@@ -769,6 +780,7 @@ class TestProcessor:
         token_2.issuer_address = issuer_address_2
         token_2.abi = token_contract2.abi
         token_2.tx_hash = "tx_hash"
+        token_2.version = TokenVersion.V_23_12
         db.add(token_2)
 
         db.commit()
@@ -927,6 +939,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         # Prepare data : Token(processing token)
@@ -937,6 +950,7 @@ class TestProcessor:
         token_2.abi = "abi"
         token_2.tx_hash = "tx_hash"
         token_2.token_status = 0
+        token_2.version = TokenVersion.V_23_12
         db.add(token_2)
 
         db.commit()
@@ -1043,6 +1057,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         db.commit()

--- a/tests/test_batch_indexer_position_bond.py
+++ b/tests/test_batch_indexer_position_bond.py
@@ -41,6 +41,7 @@ from app.model.db import (
     NotificationType,
     Token,
     TokenType,
+    TokenVersion,
 )
 from app.utils.contract_utils import ContractUtils
 from app.utils.web3_utils import Web3Wrapper
@@ -135,6 +136,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = "abi"
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_22_12
         db.add(token_1)
 
         # Prepare data : Token(processing token)
@@ -145,6 +147,7 @@ class TestProcessor:
         token_2.abi = "abi"
         token_2.tx_hash = "tx_hash"
         token_2.token_status = 0
+        token_2.version = TokenVersion.V_23_12
         db.add(token_2)
 
         db.commit()
@@ -186,6 +189,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         # Prepare data : Token(share token)
@@ -195,6 +199,7 @@ class TestProcessor:
         token_2.issuer_address = issuer_address
         token_2.abi = "abi"
         token_2.tx_hash = "tx_hash"
+        token_2.version = TokenVersion.V_22_12
         db.add(token_2)
 
         # Prepare data : Token(processing token)
@@ -205,6 +210,7 @@ class TestProcessor:
         token_3.abi = "abi"
         token_3.tx_hash = "tx_hash"
         token_3.token_status = 0
+        token_3.version = TokenVersion.V_23_12
         db.add(token_3)
 
         # Prepare data : BlockNumber
@@ -264,6 +270,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         # Prepare data : Token(share token)
@@ -273,6 +280,7 @@ class TestProcessor:
         token_2.issuer_address = issuer_address
         token_2.abi = "abi"
         token_2.tx_hash = "tx_hash"
+        token_2.version = TokenVersion.V_22_12
         db.add(token_2)
 
         # Prepare data : Token(processing token)
@@ -283,6 +291,7 @@ class TestProcessor:
         token_3.abi = "abi"
         token_3.tx_hash = "tx_hash"
         token_3.token_status = 0
+        token_3.version = TokenVersion.V_23_12
         db.add(token_3)
 
         db.commit()
@@ -361,6 +370,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         # Prepare data : Token(share token)
@@ -370,6 +380,7 @@ class TestProcessor:
         token_2.issuer_address = issuer_address
         token_2.abi = "abi"
         token_2.tx_hash = "tx_hash"
+        token_2.version = TokenVersion.V_22_12
         db.add(token_2)
 
         # Prepare data : Token(processing token)
@@ -380,6 +391,7 @@ class TestProcessor:
         token_3.abi = "abi"
         token_3.tx_hash = "tx_hash"
         token_3.token_status = 0
+        token_3.version = TokenVersion.V_23_12
         db.add(token_3)
 
         db.commit()
@@ -463,6 +475,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         # Prepare data : Token(share token)
@@ -472,6 +485,7 @@ class TestProcessor:
         token_2.issuer_address = issuer_address
         token_2.abi = "abi"
         token_2.tx_hash = "tx_hash"
+        token_2.version = TokenVersion.V_22_12
         db.add(token_2)
 
         # Prepare data : Token(processing token)
@@ -482,6 +496,7 @@ class TestProcessor:
         token_3.abi = "abi"
         token_3.tx_hash = "tx_hash"
         token_3.token_status = 0
+        token_3.version = TokenVersion.V_23_12
         db.add(token_3)
 
         db.commit()
@@ -556,6 +571,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         # Prepare data : Token(share token)
@@ -565,6 +581,7 @@ class TestProcessor:
         token_2.issuer_address = issuer_address
         token_2.abi = "abi"
         token_2.tx_hash = "tx_hash"
+        token_2.version = TokenVersion.V_22_12
         db.add(token_2)
 
         # Prepare data : Token(processing token)
@@ -575,6 +592,7 @@ class TestProcessor:
         token_3.abi = "abi"
         token_3.tx_hash = "tx_hash"
         token_3.token_status = 0
+        token_3.version = TokenVersion.V_23_12
         db.add(token_3)
 
         db.commit()
@@ -696,6 +714,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         # Prepare data : Token(share token)
@@ -705,6 +724,7 @@ class TestProcessor:
         token_2.issuer_address = issuer_address
         token_2.abi = "abi"
         token_2.tx_hash = "tx_hash"
+        token_2.version = TokenVersion.V_22_12
         db.add(token_2)
 
         # Prepare data : Token(processing token)
@@ -715,6 +735,7 @@ class TestProcessor:
         token_3.abi = "abi"
         token_3.tx_hash = "tx_hash"
         token_3.token_status = 0
+        token_3.version = TokenVersion.V_22_12
         db.add(token_3)
 
         db.commit()
@@ -828,6 +849,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         # Prepare data : Token(share token)
@@ -837,6 +859,7 @@ class TestProcessor:
         token_2.issuer_address = issuer_address
         token_2.abi = "abi"
         token_2.tx_hash = "tx_hash"
+        token_2.version = TokenVersion.V_22_12
         db.add(token_2)
 
         # Prepare data : Token(processing token)
@@ -847,6 +870,7 @@ class TestProcessor:
         token_3.abi = "abi"
         token_3.tx_hash = "tx_hash"
         token_3.token_status = 0
+        token_3.version = TokenVersion.V_23_12
         db.add(token_3)
 
         db.commit()
@@ -1023,6 +1047,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         # Prepare data : Token(share token)
@@ -1032,6 +1057,7 @@ class TestProcessor:
         token_2.issuer_address = issuer_address
         token_2.abi = "abi"
         token_2.tx_hash = "tx_hash"
+        token_2.version = TokenVersion.V_22_12
         db.add(token_2)
 
         # Prepare data : Token(processing token)
@@ -1042,6 +1068,7 @@ class TestProcessor:
         token_3.abi = "abi"
         token_3.tx_hash = "tx_hash"
         token_3.token_status = 0
+        token_3.version = TokenVersion.V_23_12
         db.add(token_3)
 
         db.commit()
@@ -1115,6 +1142,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         # Prepare data : Token(share token)
@@ -1124,6 +1152,7 @@ class TestProcessor:
         token_2.issuer_address = issuer_address
         token_2.abi = "abi"
         token_2.tx_hash = "tx_hash"
+        token_2.version = TokenVersion.V_22_12
         db.add(token_2)
 
         # Prepare data : Token(processing token)
@@ -1134,6 +1163,7 @@ class TestProcessor:
         token_3.abi = "abi"
         token_3.tx_hash = "tx_hash"
         token_3.token_status = 0
+        token_3.version = TokenVersion.V_23_12
         db.add(token_3)
 
         db.commit()
@@ -1211,6 +1241,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         # Prepare data : Token(share token)
@@ -1220,6 +1251,7 @@ class TestProcessor:
         token_2.issuer_address = issuer_address
         token_2.abi = "abi"
         token_2.tx_hash = "tx_hash"
+        token_2.version = TokenVersion.V_22_12
         db.add(token_2)
 
         # Prepare data : Token(processing token)
@@ -1230,6 +1262,7 @@ class TestProcessor:
         token_3.abi = "abi"
         token_3.tx_hash = "tx_hash"
         token_3.token_status = 0
+        token_3.version = TokenVersion.V_23_12
         db.add(token_3)
 
         db.commit()
@@ -1340,6 +1373,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         # Prepare data : Token(share token)
@@ -1349,6 +1383,7 @@ class TestProcessor:
         token_2.issuer_address = issuer_address
         token_2.abi = "abi"
         token_2.tx_hash = "tx_hash"
+        token_2.version = TokenVersion.V_22_12
         db.add(token_2)
 
         # Prepare data : Token(processing token)
@@ -1359,6 +1394,7 @@ class TestProcessor:
         token_3.abi = "abi"
         token_3.tx_hash = "tx_hash"
         token_3.token_status = 0
+        token_3.version = TokenVersion.V_23_12
         db.add(token_3)
 
         db.commit()
@@ -1479,6 +1515,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         # Prepare data : Token(share token)
@@ -1488,6 +1525,7 @@ class TestProcessor:
         token_2.issuer_address = issuer_address
         token_2.abi = "abi"
         token_2.tx_hash = "tx_hash"
+        token_2.version = TokenVersion.V_22_12
         db.add(token_2)
 
         # Prepare data : Token(processing token)
@@ -1498,6 +1536,7 @@ class TestProcessor:
         token_3.abi = "abi"
         token_3.tx_hash = "tx_hash"
         token_3.token_status = 0
+        token_3.version = TokenVersion.V_23_12
         db.add(token_3)
 
         db.commit()
@@ -1615,6 +1654,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         db.commit()
@@ -1763,6 +1803,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         db.commit()
@@ -1914,6 +1955,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         db.commit()
@@ -2065,6 +2107,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         db.commit()
@@ -2225,6 +2268,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         db.commit()
@@ -2375,6 +2419,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         # Prepare data : Token(share token)
@@ -2384,6 +2429,7 @@ class TestProcessor:
         token_2.issuer_address = issuer_address
         token_2.abi = "abi"
         token_2.tx_hash = "tx_hash"
+        token_2.version = TokenVersion.V_22_12
         db.add(token_2)
 
         # Prepare data : Token(processing token)
@@ -2394,6 +2440,7 @@ class TestProcessor:
         token_3.abi = "abi"
         token_3.tx_hash = "tx_hash"
         token_3.token_status = 0
+        token_3.version = TokenVersion.V_23_12
         db.add(token_3)
 
         db.commit()
@@ -2511,6 +2558,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         db.commit()
@@ -2660,6 +2708,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         db.commit()
@@ -2802,6 +2851,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         # Prepare data : Token(share token)
@@ -2811,6 +2861,7 @@ class TestProcessor:
         token_2.issuer_address = issuer_address
         token_2.abi = "abi"
         token_2.tx_hash = "tx_hash"
+        token_2.version = TokenVersion.V_22_12
         db.add(token_2)
 
         # Prepare data : Token(processing token)
@@ -2821,6 +2872,7 @@ class TestProcessor:
         token_3.abi = "abi"
         token_3.tx_hash = "tx_hash"
         token_3.token_status = 0
+        token_3.version = TokenVersion.V_23_12
         db.add(token_3)
 
         db.commit()
@@ -2954,6 +3006,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         # Prepare data : Token(share token)
@@ -2963,6 +3016,7 @@ class TestProcessor:
         token_2.issuer_address = issuer_address
         token_2.abi = "abi"
         token_2.tx_hash = "tx_hash"
+        token_2.version = TokenVersion.V_22_12
         db.add(token_2)
 
         db.commit()
@@ -3148,6 +3202,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         db.commit()
@@ -3311,6 +3366,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         db.commit()
@@ -3458,6 +3514,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         # Issuer issues bond token.
@@ -3475,6 +3532,7 @@ class TestProcessor:
         token_2.issuer_address = issuer_address
         token_2.abi = token_contract2.abi
         token_2.tx_hash = "tx_hash"
+        token_2.version = TokenVersion.V_23_12
         db.add(token_2)
 
         db.commit()
@@ -3685,6 +3743,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         db.commit()
@@ -3711,6 +3770,7 @@ class TestProcessor:
         token_2.issuer_address = issuer_address
         token_2.abi = token_contract2.abi
         token_2.tx_hash = "tx_hash"
+        token_2.version = TokenVersion.V_23_12
         db.add(token_2)
 
         db.commit()
@@ -3753,6 +3813,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         db.commit()

--- a/tests/test_batch_indexer_position_share.py
+++ b/tests/test_batch_indexer_position_share.py
@@ -41,6 +41,7 @@ from app.model.db import (
     NotificationType,
     Token,
     TokenType,
+    TokenVersion,
 )
 from app.utils.contract_utils import ContractUtils
 from app.utils.web3_utils import Web3Wrapper
@@ -135,6 +136,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = "abi"
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         # Prepare data : Token(processing token)
@@ -145,6 +147,7 @@ class TestProcessor:
         token_2.abi = "abi"
         token_2.tx_hash = "tx_hash"
         token_2.token_status = 0
+        token_2.version = TokenVersion.V_22_12
         db.add(token_2)
 
         db.commit()
@@ -186,6 +189,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_22_12
         db.add(token_1)
 
         # Prepare data : Token(bond token)
@@ -195,6 +199,7 @@ class TestProcessor:
         token_2.issuer_address = issuer_address
         token_2.abi = "abi"
         token_2.tx_hash = "tx_hash"
+        token_2.version = TokenVersion.V_23_12
         db.add(token_2)
 
         # Prepare data : Token(processing token)
@@ -205,6 +210,7 @@ class TestProcessor:
         token_3.abi = "abi"
         token_3.tx_hash = "tx_hash"
         token_3.token_status = 0
+        token_3.version = TokenVersion.V_22_12
         db.add(token_3)
 
         # Prepare data : BlockNumber
@@ -264,6 +270,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_22_12
         db.add(token_1)
 
         # Prepare data : Token(bond token)
@@ -273,6 +280,7 @@ class TestProcessor:
         token_2.issuer_address = issuer_address
         token_2.abi = "abi"
         token_2.tx_hash = "tx_hash"
+        token_2.version = TokenVersion.V_23_12
         db.add(token_2)
 
         # Prepare data : Token(processing token)
@@ -283,6 +291,7 @@ class TestProcessor:
         token_3.abi = "abi"
         token_3.tx_hash = "tx_hash"
         token_3.token_status = 0
+        token_3.version = TokenVersion.V_22_12
         db.add(token_3)
 
         db.commit()
@@ -361,6 +370,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_22_12
         db.add(token_1)
 
         # Prepare data : Token(bond token)
@@ -370,6 +380,7 @@ class TestProcessor:
         token_2.issuer_address = issuer_address
         token_2.abi = "abi"
         token_2.tx_hash = "tx_hash"
+        token_2.version = TokenVersion.V_23_12
         db.add(token_2)
 
         # Prepare data : Token(processing token)
@@ -380,6 +391,7 @@ class TestProcessor:
         token_3.abi = "abi"
         token_3.tx_hash = "tx_hash"
         token_3.token_status = 0
+        token_3.version = TokenVersion.V_22_12
         db.add(token_3)
 
         db.commit()
@@ -463,6 +475,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_22_12
         db.add(token_1)
 
         # Prepare data : Token(bond token)
@@ -472,6 +485,7 @@ class TestProcessor:
         token_2.issuer_address = issuer_address
         token_2.abi = "abi"
         token_2.tx_hash = "tx_hash"
+        token_2.version = TokenVersion.V_23_12
         db.add(token_2)
 
         # Prepare data : Token(processing token)
@@ -482,6 +496,7 @@ class TestProcessor:
         token_3.abi = "abi"
         token_3.tx_hash = "tx_hash"
         token_3.token_status = 0
+        token_3.version = TokenVersion.V_22_12
         db.add(token_3)
 
         db.commit()
@@ -556,6 +571,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_22_12
         db.add(token_1)
 
         # Prepare data : Token(bond token)
@@ -565,6 +581,7 @@ class TestProcessor:
         token_2.issuer_address = issuer_address
         token_2.abi = "abi"
         token_2.tx_hash = "tx_hash"
+        token_2.version = TokenVersion.V_23_12
         db.add(token_2)
 
         # Prepare data : Token(processing token)
@@ -575,6 +592,7 @@ class TestProcessor:
         token_3.abi = "abi"
         token_3.tx_hash = "tx_hash"
         token_3.token_status = 0
+        token_3.version = TokenVersion.V_22_12
         db.add(token_3)
 
         db.commit()
@@ -696,6 +714,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_22_12
         db.add(token_1)
 
         # Prepare data : Token(bond token)
@@ -705,6 +724,7 @@ class TestProcessor:
         token_2.issuer_address = issuer_address
         token_2.abi = "abi"
         token_2.tx_hash = "tx_hash"
+        token_2.version = TokenVersion.V_23_12
         db.add(token_2)
 
         # Prepare data : Token(processing token)
@@ -715,6 +735,7 @@ class TestProcessor:
         token_3.abi = "abi"
         token_3.tx_hash = "tx_hash"
         token_3.token_status = 0
+        token_3.version = TokenVersion.V_22_12
         db.add(token_3)
 
         db.commit()
@@ -828,6 +849,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_22_12
         db.add(token_1)
 
         # Prepare data : Token(bond token)
@@ -837,6 +859,7 @@ class TestProcessor:
         token_2.issuer_address = issuer_address
         token_2.abi = "abi"
         token_2.tx_hash = "tx_hash"
+        token_2.version = TokenVersion.V_23_12
         db.add(token_2)
 
         # Prepare data : Token(processing token)
@@ -847,6 +870,7 @@ class TestProcessor:
         token_3.abi = "abi"
         token_3.tx_hash = "tx_hash"
         token_3.token_status = 0
+        token_3.version = TokenVersion.V_22_12
         db.add(token_3)
 
         db.commit()
@@ -1023,6 +1047,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_22_12
         db.add(token_1)
 
         # Prepare data : Token(bond token)
@@ -1032,6 +1057,7 @@ class TestProcessor:
         token_2.issuer_address = issuer_address
         token_2.abi = "abi"
         token_2.tx_hash = "tx_hash"
+        token_2.version = TokenVersion.V_23_12
         db.add(token_2)
 
         # Prepare data : Token(processing token)
@@ -1042,6 +1068,7 @@ class TestProcessor:
         token_3.abi = "abi"
         token_3.tx_hash = "tx_hash"
         token_3.token_status = 0
+        token_3.version = TokenVersion.V_22_12
         db.add(token_3)
 
         db.commit()
@@ -1115,6 +1142,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_22_12
         db.add(token_1)
 
         # Prepare data : Token(bond token)
@@ -1124,6 +1152,7 @@ class TestProcessor:
         token_2.issuer_address = issuer_address
         token_2.abi = "abi"
         token_2.tx_hash = "tx_hash"
+        token_2.version = TokenVersion.V_23_12
         db.add(token_2)
 
         # Prepare data : Token(processing token)
@@ -1134,6 +1163,7 @@ class TestProcessor:
         token_3.abi = "abi"
         token_3.tx_hash = "tx_hash"
         token_3.token_status = 0
+        token_3.version = TokenVersion.V_22_12
         db.add(token_3)
 
         db.commit()
@@ -1213,6 +1243,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_22_12
         db.add(token_1)
 
         # Prepare data : Token(bond token)
@@ -1222,6 +1253,7 @@ class TestProcessor:
         token_2.issuer_address = issuer_address
         token_2.abi = "abi"
         token_2.tx_hash = "tx_hash"
+        token_2.version = TokenVersion.V_23_12
         db.add(token_2)
 
         # Prepare data : Token(processing token)
@@ -1232,6 +1264,7 @@ class TestProcessor:
         token_3.abi = "abi"
         token_3.tx_hash = "tx_hash"
         token_3.token_status = 0
+        token_3.version = TokenVersion.V_22_12
         db.add(token_3)
 
         db.commit()
@@ -1342,6 +1375,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_22_12
         db.add(token_1)
 
         # Prepare data : Token(bond token)
@@ -1351,6 +1385,7 @@ class TestProcessor:
         token_2.issuer_address = issuer_address
         token_2.abi = "abi"
         token_2.tx_hash = "tx_hash"
+        token_2.version = TokenVersion.V_23_12
         db.add(token_2)
 
         # Prepare data : Token(processing token)
@@ -1361,6 +1396,7 @@ class TestProcessor:
         token_3.abi = "abi"
         token_3.tx_hash = "tx_hash"
         token_3.token_status = 0
+        token_3.version = TokenVersion.V_22_12
         db.add(token_3)
 
         db.commit()
@@ -1481,6 +1517,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_22_12
         db.add(token_1)
 
         # Prepare data : Token(bond token)
@@ -1490,6 +1527,7 @@ class TestProcessor:
         token_2.issuer_address = issuer_address
         token_2.abi = "abi"
         token_2.tx_hash = "tx_hash"
+        token_2.version = TokenVersion.V_23_12
         db.add(token_2)
 
         # Prepare data : Token(processing token)
@@ -1500,6 +1538,7 @@ class TestProcessor:
         token_3.abi = "abi"
         token_3.tx_hash = "tx_hash"
         token_3.token_status = 0
+        token_3.version = TokenVersion.V_22_12
         db.add(token_3)
 
         db.commit()
@@ -1617,6 +1656,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_22_12
         db.add(token_1)
 
         db.commit()
@@ -1765,6 +1805,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_22_12
         db.add(token_1)
 
         db.commit()
@@ -1916,6 +1957,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_22_12
         db.add(token_1)
 
         db.commit()
@@ -2067,6 +2109,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_22_12
         db.add(token_1)
 
         db.commit()
@@ -2227,6 +2270,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_22_12
         db.add(token_1)
 
         db.commit()
@@ -2377,6 +2421,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_22_12
         db.add(token_1)
 
         # Prepare data : Token(bond token)
@@ -2386,6 +2431,7 @@ class TestProcessor:
         token_2.issuer_address = issuer_address
         token_2.abi = "abi"
         token_2.tx_hash = "tx_hash"
+        token_2.version = TokenVersion.V_23_12
         db.add(token_2)
 
         # Prepare data : Token(processing token)
@@ -2396,6 +2442,7 @@ class TestProcessor:
         token_3.abi = "abi"
         token_3.tx_hash = "tx_hash"
         token_3.token_status = 0
+        token_3.version = TokenVersion.V_22_12
         db.add(token_3)
 
         db.commit()
@@ -2513,6 +2560,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_22_12
         db.add(token_1)
 
         db.commit()
@@ -2662,6 +2710,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_22_12
         db.add(token_1)
 
         db.commit()
@@ -2804,6 +2853,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_22_12
         db.add(token_1)
 
         # Prepare data : Token(bond token)
@@ -2813,6 +2863,7 @@ class TestProcessor:
         token_2.issuer_address = issuer_address
         token_2.abi = "abi"
         token_2.tx_hash = "tx_hash"
+        token_2.version = TokenVersion.V_23_12
         db.add(token_2)
 
         # Prepare data : Token(processing token)
@@ -2823,6 +2874,7 @@ class TestProcessor:
         token_3.abi = "abi"
         token_3.tx_hash = "tx_hash"
         token_3.token_status = 0
+        token_3.version = TokenVersion.V_22_12
         db.add(token_3)
 
         db.commit()
@@ -2956,6 +3008,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_22_12
         db.add(token_1)
 
         # Prepare data : Token(share token)
@@ -2965,6 +3018,7 @@ class TestProcessor:
         token_2.issuer_address = issuer_address
         token_2.abi = "abi"
         token_2.tx_hash = "tx_hash"
+        token_2.version = TokenVersion.V_23_12
         db.add(token_2)
 
         db.commit()
@@ -3150,6 +3204,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_22_12
         db.add(token_1)
 
         db.commit()
@@ -3313,6 +3368,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_22_12
         db.add(token_1)
 
         db.commit()
@@ -3460,6 +3516,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_22_12
         db.add(token_1)
 
         # Issuer issues share token.
@@ -3477,6 +3534,7 @@ class TestProcessor:
         token_2.issuer_address = issuer_address
         token_2.abi = token_contract2.abi
         token_2.tx_hash = "tx_hash"
+        token_2.version = TokenVersion.V_22_12
         db.add(token_2)
 
         db.commit()
@@ -3687,6 +3745,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_22_12
         db.add(token_1)
 
         db.commit()
@@ -3713,6 +3772,7 @@ class TestProcessor:
         token_2.issuer_address = issuer_address
         token_2.abi = token_contract2.abi
         token_2.tx_hash = "tx_hash"
+        token_2.version = TokenVersion.V_22_12
         db.add(token_2)
 
         db.commit()
@@ -3755,6 +3815,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_22_12
         db.add(token_1)
 
         db.commit()

--- a/tests/test_batch_indexer_token_holders.py
+++ b/tests/test_batch_indexer_token_holders.py
@@ -40,6 +40,7 @@ from app.model.db import (
     TokenHolderBatchStatus,
     TokenHoldersList,
     TokenType,
+    TokenVersion,
 )
 from app.utils.contract_utils import ContractUtils
 from app.utils.web3_utils import Web3Wrapper
@@ -243,6 +244,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         PersonalInfoContractTestUtils.register(
@@ -616,6 +618,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         PersonalInfoContractTestUtils.register(
@@ -836,6 +839,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         PersonalInfoContractTestUtils.register(
@@ -1025,6 +1029,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_22_12
         db.add(token_1)
 
         PersonalInfoContractTestUtils.register(
@@ -1412,6 +1417,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_22_12
         db.add(token_1)
 
         PersonalInfoContractTestUtils.register(
@@ -1632,6 +1638,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_22_12
         db.add(token_1)
 
         PersonalInfoContractTestUtils.register(
@@ -1825,6 +1832,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         PersonalInfoContractTestUtils.register(
@@ -1940,6 +1948,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         PersonalInfoContractTestUtils.register(
@@ -2123,6 +2132,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         PersonalInfoContractTestUtils.register(
@@ -2274,6 +2284,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         # Insert collection record with above token and checkpoint block number
@@ -2447,6 +2458,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         PersonalInfoContractTestUtils.register(
@@ -2545,6 +2557,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_22_12
         db.add(token_1)
 
         PersonalInfoContractTestUtils.register(

--- a/tests/test_batch_indexer_transfer.py
+++ b/tests/test_batch_indexer_transfer.py
@@ -42,6 +42,7 @@ from app.model.db import (
     IDXTransferSourceEventType,
     Token,
     TokenType,
+    TokenVersion,
 )
 from app.utils.contract_utils import ContractUtils
 from app.utils.web3_utils import Web3Wrapper
@@ -164,6 +165,7 @@ class TestProcessor:
         token_1.abi = "abi"
         token_1.tx_hash = "tx_hash"
         token_1.token_status = 0
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         db.commit()
@@ -203,6 +205,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         # Prepare data : Token(processing token)
@@ -213,6 +216,7 @@ class TestProcessor:
         token_2.abi = "abi"
         token_2.tx_hash = "tx_hash"
         token_2.token_status = 0
+        token_2.version = TokenVersion.V_23_12
         db.add(token_2)
 
         # Prepare data : BlockNumber
@@ -267,6 +271,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         # Prepare data : Token(processing token)
@@ -277,6 +282,7 @@ class TestProcessor:
         token_2.abi = "abi"
         token_2.tx_hash = "tx_hash"
         token_2.token_status = 0
+        token_2.version = TokenVersion.V_23_12
         db.add(token_2)
 
         db.commit()
@@ -393,6 +399,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         # Prepare data : Token(processing token)
@@ -403,6 +410,7 @@ class TestProcessor:
         token_2.abi = "abi"
         token_2.tx_hash = "tx_hash"
         token_2.token_status = 0
+        token_2.version = TokenVersion.V_23_12
         db.add(token_2)
 
         db.commit()
@@ -481,6 +489,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         # Prepare data : Token(processing token)
@@ -491,6 +500,7 @@ class TestProcessor:
         token_2.abi = "abi"
         token_2.tx_hash = "tx_hash"
         token_2.token_status = 0
+        token_2.version = TokenVersion.V_23_12
         db.add(token_2)
 
         db.commit()
@@ -689,6 +699,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         db.commit()
@@ -825,6 +836,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         # Prepare data : Token2
@@ -839,6 +851,7 @@ class TestProcessor:
         token_2.issuer_address = issuer_address
         token_2.abi = token_contract_2.abi
         token_2.tx_hash = "tx_hash"
+        token_2.version = TokenVersion.V_23_12
         db.add(token_2)
 
         db.commit()
@@ -1008,6 +1021,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         db.commit()
@@ -1033,6 +1047,7 @@ class TestProcessor:
         token_2.issuer_address = issuer_address
         token_2.abi = token_contract2.abi
         token_2.tx_hash = "tx_hash"
+        token_2.version = TokenVersion.V_22_12
         db.add(token_2)
 
         db.commit()
@@ -1073,6 +1088,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         db.commit()

--- a/tests/test_batch_indexer_transfer_approval.py
+++ b/tests/test_batch_indexer_transfer_approval.py
@@ -44,6 +44,7 @@ from app.model.db import (
     NotificationType,
     Token,
     TokenType,
+    TokenVersion,
 )
 from app.utils.contract_utils import ContractUtils
 from app.utils.web3_utils import Web3Wrapper
@@ -169,6 +170,7 @@ class TestProcessor:
         token_1.abi = "abi"
         token_1.tx_hash = "tx_hash"
         token_1.token_status = 0
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         db.commit()
@@ -214,6 +216,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         # Prepare data : Token(processing token)
@@ -224,6 +227,7 @@ class TestProcessor:
         token_2.abi = "abi"
         token_2.tx_hash = "tx_hash"
         token_2.token_status = 0
+        token_2.version = TokenVersion.V_23_12
         db.add(token_2)
 
         # Prepare data : BlockNumber
@@ -280,6 +284,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         # Prepare data : Token(processing token)
@@ -290,6 +295,7 @@ class TestProcessor:
         token_2.abi = "abi"
         token_2.tx_hash = "tx_hash"
         token_2.token_status = 0
+        token_2.version = TokenVersion.V_23_12
         db.add(token_2)
 
         # Prepare data : BlockNumber
@@ -404,6 +410,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         # Prepare data : BlockNumber
@@ -535,6 +542,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         # Prepare data : BlockNumber
@@ -665,6 +673,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         # Prepare data : BlockNumber
@@ -801,6 +810,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         # Prepare data : BlockNumber
@@ -940,6 +950,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         # Prepare data : Token(processing token)
@@ -950,6 +961,7 @@ class TestProcessor:
         token_2.abi = "abi"
         token_2.tx_hash = "tx_hash"
         token_2.token_status = 0
+        token_2.version = TokenVersion.V_23_12
         db.add(token_2)
 
         # Prepare data : BlockNumber
@@ -1101,6 +1113,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         # Prepare data : BlockNumber
@@ -1247,6 +1260,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         # Prepare data : BlockNumber
@@ -1433,6 +1447,7 @@ class TestProcessor:
         token.issuer_address = issuer_address
         token.abi = token_contract.abi
         token.tx_hash = "tx_hash"
+        token.version = TokenVersion.V_23_12
         db.add(token)
         db.commit()
 
@@ -1587,6 +1602,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address
         token_1.abi = token_contract1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         db.commit()
@@ -1613,6 +1629,7 @@ class TestProcessor:
         token_2.issuer_address = issuer_address
         token_2.abi = token_contract2.abi
         token_2.tx_hash = "tx_hash"
+        token_2.version = TokenVersion.V_22_12
         db.add(token_2)
 
         db.commit()
@@ -1654,6 +1671,7 @@ class TestProcessor:
         token.issuer_address = issuer_address
         token.abi = token_contract.abi
         token.tx_hash = "tx_hash"
+        token.version = TokenVersion.V_23_12
         db.add(token)
 
         db.commit()

--- a/tests/test_batch_processor_create_utxo.py
+++ b/tests/test_batch_processor_create_utxo.py
@@ -43,7 +43,7 @@ from app.model.blockchain.tx_params.ibet_straight_bond import (
     TransferParams as IbetStraightBondTransferParams,
     UpdateParams as IbetStraightBondUpdateParams,
 )
-from app.model.db import UTXO, Token, TokenType, UTXOBlockNumber
+from app.model.db import UTXO, Token, TokenType, TokenVersion, UTXOBlockNumber
 from app.utils.contract_utils import ContractUtils
 from batch.processor_create_utxo import Processor
 from config import CHAIN_ID, TX_GAS_LIMIT, WEB3_HTTP_PROVIDER
@@ -144,6 +144,7 @@ class TestProcessor:
         _token_1.issuer_address = issuer_address
         _token_1.token_address = token_address_1
         _token_1.abi = {}
+        _token_1.version = TokenVersion.V_23_12
         db.add(_token_1)
 
         token_address_2 = deploy_share_token_contract(
@@ -155,6 +156,7 @@ class TestProcessor:
         _token_2.issuer_address = issuer_address
         _token_2.token_address = token_address_2
         _token_2.abi = {}
+        _token_2.version = TokenVersion.V_22_12
         db.add(_token_2)
 
         db.commit()
@@ -280,6 +282,7 @@ class TestProcessor:
         _token_1.issuer_address = issuer_address
         _token_1.token_address = token_address_1
         _token_1.abi = {}
+        _token_1.version = TokenVersion.V_23_12
         db.add(_token_1)
 
         latest_block_number = web3.eth.block_number
@@ -388,6 +391,7 @@ class TestProcessor:
         _token_1.issuer_address = issuer_address
         _token_1.token_address = token_address_1
         _token_1.abi = {}
+        _token_1.version = TokenVersion.V_23_12
         db.add(_token_1)
 
         db.commit()
@@ -475,6 +479,7 @@ class TestProcessor:
         _token_1.issuer_address = issuer_address
         _token_1.token_address = token_address_1
         _token_1.abi = {}
+        _token_1.version = TokenVersion.V_23_12
         db.add(_token_1)
 
         db.commit()
@@ -558,6 +563,7 @@ class TestProcessor:
         _token_1.issuer_address = issuer_address
         _token_1.token_address = token_address_1
         _token_1.abi = {}
+        _token_1.version = TokenVersion.V_23_12
         db.add(_token_1)
 
         PersonalInfoContractTestUtils.register(
@@ -732,6 +738,7 @@ class TestProcessor:
         _token_1.issuer_address = issuer_address
         _token_1.token_address = token_address_1
         _token_1.abi = {}
+        _token_1.version = TokenVersion.V_23_12
         db.add(_token_1)
 
         token_address_2 = deploy_share_token_contract(
@@ -743,6 +750,7 @@ class TestProcessor:
         _token_2.issuer_address = issuer_address
         _token_2.token_address = token_address_2
         _token_2.abi = {}
+        _token_2.version = TokenVersion.V_22_12
         db.add(_token_2)
 
         db.commit()
@@ -809,6 +817,7 @@ class TestProcessor:
         _token_1.issuer_address = issuer_address
         _token_1.token_address = token_address_1
         _token_1.abi = {}
+        _token_1.version = TokenVersion.V_23_12
         db.add(_token_1)
 
         token_address_2 = deploy_share_token_contract(
@@ -820,6 +829,7 @@ class TestProcessor:
         _token_2.issuer_address = issuer_address
         _token_2.token_address = token_address_2
         _token_2.abi = {}
+        _token_2.version = TokenVersion.V_22_12
         db.add(_token_2)
 
         db.commit()
@@ -957,6 +967,7 @@ class TestProcessor:
         _token_1.issuer_address = issuer_address
         _token_1.token_address = token_address_1
         _token_1.abi = {}
+        _token_1.version = TokenVersion.V_23_12
         db.add(_token_1)
 
         token_address_2 = deploy_share_token_contract(
@@ -968,6 +979,7 @@ class TestProcessor:
         _token_2.issuer_address = issuer_address
         _token_2.token_address = token_address_2
         _token_2.abi = {}
+        _token_2.version = TokenVersion.V_22_12
         db.add(_token_2)
 
         db.commit()
@@ -1137,6 +1149,7 @@ class TestProcessor:
         _token_1.issuer_address = issuer_address
         _token_1.token_address = token_address_1
         _token_1.abi = {}
+        _token_1.version = TokenVersion.V_23_12
         db.add(_token_1)
 
         token_address_2 = deploy_share_token_contract(
@@ -1148,6 +1161,7 @@ class TestProcessor:
         _token_2.issuer_address = issuer_address
         _token_2.token_address = token_address_2
         _token_2.abi = {}
+        _token_2.version = TokenVersion.V_22_12
         db.add(_token_2)
 
         db.commit()
@@ -1300,6 +1314,7 @@ class TestProcessor:
         _token_1.issuer_address = issuer_address
         _token_1.token_address = token_address_1
         _token_1.abi = {}
+        _token_1.version = TokenVersion.V_23_12
         db.add(_token_1)
 
         db.commit()

--- a/tests/test_batch_processor_modify_personal_info.py
+++ b/tests/test_batch_processor_modify_personal_info.py
@@ -40,6 +40,7 @@ from app.model.db import (
     IDXPersonalInfo,
     Token,
     TokenType,
+    TokenVersion,
 )
 from app.utils.contract_utils import ContractUtils
 from app.utils.e2ee_utils import E2EEUtils
@@ -203,6 +204,7 @@ class TestProcessor:
         token_1.issuer_address = issuer_address_1
         token_1.token_address = token_contract_address_1
         token_1.abi = "abi"
+        token_1.version = TokenVersion.V_23_12
         db.add(token_1)
 
         personal_info_contract_address_2 = deploy_personal_info_contract(user_1)
@@ -215,6 +217,7 @@ class TestProcessor:
         token_2.issuer_address = issuer_address_1
         token_2.token_address = token_contract_address_2
         token_2.abi = "abi"
+        token_2.version = TokenVersion.V_22_12
         db.add(token_2)
 
         token_contract_address_3 = deploy_bond_token_contract(user_1, None)
@@ -224,6 +227,7 @@ class TestProcessor:
         token_3.issuer_address = issuer_address_1
         token_3.token_address = token_contract_address_3
         token_3.abi = "abi"
+        token_3.version = TokenVersion.V_23_12
         db.add(token_3)
 
         token_contract_address_4 = deploy_share_token_contract(user_1, None)
@@ -233,6 +237,7 @@ class TestProcessor:
         token_4.issuer_address = issuer_address_1
         token_4.token_address = token_contract_address_4
         token_4.abi = "abi"
+        token_4.version = TokenVersion.V_22_12
         db.add(token_4)
 
         # PersonalInfo

--- a/tests/test_batch_processor_register_personal_info.py
+++ b/tests/test_batch_processor_register_personal_info.py
@@ -39,6 +39,7 @@ from app.model.db import (
     NotificationType,
     Token,
     TokenType,
+    TokenVersion,
 )
 from app.utils.contract_utils import ContractUtils
 from app.utils.e2ee_utils import E2EEUtils
@@ -163,6 +164,7 @@ class TestProcessor:
         token_1.issuer_address = _account["address"]
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_22_12
         db.add(token_1)
 
         db.commit()
@@ -204,6 +206,7 @@ class TestProcessor:
         token_1.issuer_address = _account["address"]
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_22_12
         db.add(token_1)
 
         # Prepare data : BatchRegisterPersonalInfoUpload
@@ -303,6 +306,7 @@ class TestProcessor:
         token_1.issuer_address = _account["address"]
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_22_12
         db.add(token_1)
 
         # Prepare data : BatchRegisterPersonalInfoUpload
@@ -458,6 +462,7 @@ class TestProcessor:
         token_1.issuer_address = _account["address"]
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_22_12
         db.add(token_1)
 
         # Prepare data : BatchRegisterPersonalInfoUpload
@@ -596,6 +601,7 @@ class TestProcessor:
         token_1.issuer_address = _account["address"]
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_22_12
         db.add(token_1)
 
         # Prepare data : BatchRegisterPersonalInfoUpload
@@ -709,6 +715,7 @@ class TestProcessor:
         token_1.issuer_address = _account["address"]
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_22_12
         db.add(token_1)
 
         # Prepare data : BatchRegisterPersonalInfoUpload
@@ -840,6 +847,7 @@ class TestProcessor:
         token_1.issuer_address = _account["address"]
         token_1.abi = token_contract_1.abi
         token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_22_12
         db.add(token_1)
 
         # Prepare data : BatchRegisterPersonalInfoUpload

--- a/tests/test_batch_processor_update_token.py
+++ b/tests/test_batch_processor_update_token.py
@@ -37,6 +37,7 @@ from app.model.db import (
     NotificationType,
     Token,
     TokenType,
+    TokenVersion,
     UpdateToken,
 )
 from app.utils.e2ee_utils import E2EEUtils
@@ -79,6 +80,7 @@ class TestProcessor:
         _token_1.token_address = _token_address_1
         _token_1.abi = ""
         _token_1.token_status = 0
+        _token_1.version = TokenVersion.V_22_12
         db.add(_token_1)
 
         _update_token_1 = UpdateToken()
@@ -116,6 +118,7 @@ class TestProcessor:
         _token_2.token_address = _token_address_2
         _token_2.abi = ""
         _token_2.token_status = 0
+        _token_2.version = TokenVersion.V_23_12
         db.add(_token_2)
 
         _update_token_2 = UpdateToken()
@@ -343,6 +346,7 @@ class TestProcessor:
         _token_1.token_address = _token_address_1
         _token_1.abi = ""
         _token_1.token_status = 0
+        _token_1.version = TokenVersion.V_22_12
         db.add(_token_1)
 
         _update_token_1 = UpdateToken()
@@ -380,6 +384,7 @@ class TestProcessor:
         _token_2.token_address = _token_address_2
         _token_2.abi = ""
         _token_2.token_status = 0
+        _token_2.version = TokenVersion.V_23_12
         db.add(_token_2)
 
         _update_token_2 = UpdateToken()
@@ -557,6 +562,7 @@ class TestProcessor:
         _token_1.token_address = _token_address_1
         _token_1.abi = ""
         _token_1.token_status = 0
+        _token_1.version = TokenVersion.V_22_12
         db.add(_token_1)
 
         _update_token_1 = UpdateToken()
@@ -594,6 +600,7 @@ class TestProcessor:
         _token_2.token_address = _token_address_2
         _token_2.abi = ""
         _token_2.token_status = 0
+        _token_2.version = TokenVersion.V_23_12
         db.add(_token_2)
 
         _update_token_2 = UpdateToken()
@@ -771,6 +778,7 @@ class TestProcessor:
         _token_1.token_address = _token_address_1
         _token_1.abi = ""
         _token_1.token_status = 0
+        _token_1.version = TokenVersion.V_22_12
         db.add(_token_1)
 
         _update_token_1 = UpdateToken()
@@ -808,6 +816,7 @@ class TestProcessor:
         _token_2.token_address = _token_address_2
         _token_2.abi = ""
         _token_2.token_status = 0
+        _token_2.version = TokenVersion.V_23_12
         db.add(_token_2)
 
         _update_token_2 = UpdateToken()
@@ -992,6 +1001,7 @@ class TestProcessor:
         _token_1.token_address = _token_address_1
         _token_1.abi = ""
         _token_1.token_status = 0
+        _token_1.version = TokenVersion.V_22_12
         db.add(_token_1)
 
         _update_token_1 = UpdateToken()
@@ -1029,6 +1039,7 @@ class TestProcessor:
         _token_2.token_address = _token_address_2
         _token_2.abi = ""
         _token_2.token_status = 0
+        _token_2.version = TokenVersion.V_23_12
         db.add(_token_2)
 
         _update_token_2 = UpdateToken()

--- a/tests/test_utils_ledger_utils.py
+++ b/tests/test_utils_ledger_utils.py
@@ -49,6 +49,7 @@ from app.model.db import (
     NotificationType,
     Token,
     TokenType,
+    TokenVersion,
 )
 from app.utils import ledger_utils
 from app.utils.contract_utils import ContractUtils
@@ -203,6 +204,7 @@ class TestCreateLedger:
         _token_1.issuer_address = issuer_address
         _token_1.token_address = token_address_1
         _token_1.abi = {}
+        _token_1.version = TokenVersion.V_22_12
         db.add(_token_1)
 
         # IDXPersonalInfo(only user_1)
@@ -669,6 +671,7 @@ class TestCreateLedger:
         _token_1.issuer_address = issuer_address
         _token_1.token_address = token_address_1
         _token_1.abi = {}
+        _token_1.version = TokenVersion.V_23_12
         db.add(_token_1)
 
         # IDXPersonalInfo(only user_1)
@@ -1089,6 +1092,7 @@ class TestCreateLedger:
         _token_1.issuer_address = issuer_address
         _token_1.token_address = token_address_1
         _token_1.abi = {}
+        _token_1.version = TokenVersion.V_23_12
         db.add(_token_1)
 
         # Execute
@@ -1120,6 +1124,7 @@ class TestCreateLedger:
         _token_1.issuer_address = issuer_address
         _token_1.token_address = token_address_1
         _token_1.abi = {}
+        _token_1.version = TokenVersion.V_22_12
         db.add(_token_1)
 
         # Execute


### PR DESCRIPTION
Related to: #552 

- When issuing a new bond, it is mandatory to enter the face value, but the currency code for the face value was an optional item. This difference is not relevant, so I made both items mandatory.
- Also, for tokens deployed as old contracts, I changed the specification to return the default value of the currency code.

Close: #562 

- Added `version` item as a token attribute.