### PR TITLE
Allow setting empty str for `interest_payment_currency` and `redemption_value_currency` when updating bond token

### DIFF
--- a/app/model/schema/base/__init__.py
+++ b/app/model/schema/base/__init__.py
@@ -17,6 +17,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 from .base import (
+    CURRENCY_str,
     EMPTY_str,
     IbetShareContractVersion,
     IbetStraightBondContractVersion,

--- a/app/model/schema/base/base.py
+++ b/app/model/schema/base/base.py
@@ -44,6 +44,7 @@ YYYYMMDD_constr = Annotated[
         pattern="^(19[0-9]{2}|20[0-9]{2})(0[1-9]|1[0-2])(0[1-9]|[12][0-9]|3[01])$"
     ),
 ]
+CURRENCY_str = Annotated[str, StringConstraints(min_length=3, max_length=3)]
 EMPTY_str = Literal[""]
 
 

--- a/app/model/schema/token.py
+++ b/app/model/schema/token.py
@@ -38,6 +38,7 @@ from app.model.schema.base import (
 )
 
 from . import LockEventCategory
+from .base.base import CURRENCY_str
 from .position import LockEvent
 
 
@@ -134,13 +135,9 @@ class IbetStraightBondUpdate(BaseModel):
     face_value_currency: Optional[str] = Field(default=None, min_length=3, max_length=3)
     interest_rate: Optional[float] = Field(None, ge=0.0000, le=100.0000)
     interest_payment_date: Optional[list[MMDD_constr]] = None
-    interest_payment_currency: Optional[str] = Field(
-        default=None, min_length=3, max_length=3
-    )
+    interest_payment_currency: Optional[CURRENCY_str | EMPTY_str] = Field(default=None)
     redemption_value: Optional[int] = Field(None, ge=0, le=5_000_000_000)
-    redemption_value_currency: Optional[str] = Field(
-        default=None, min_length=3, max_length=3
-    )
+    redemption_value_currency: Optional[CURRENCY_str | EMPTY_str] = Field(default=None)
     base_fx_rate: Optional[float] = Field(default=None, ge=0.000000)
     transferable: Optional[bool] = None
     status: Optional[bool] = None

--- a/app/model/schema/token.py
+++ b/app/model/schema/token.py
@@ -28,6 +28,7 @@ from pydantic.dataclasses import dataclass
 from web3 import Web3
 
 from app.model.schema.base import (
+    CURRENCY_str,
     EMPTY_str,
     IbetShareContractVersion,
     IbetStraightBondContractVersion,
@@ -36,10 +37,7 @@ from app.model.schema.base import (
     SortOrder,
     YYYYMMDD_constr,
 )
-
-from . import LockEventCategory
-from .base.base import CURRENCY_str
-from .position import LockEvent
+from app.model.schema.position import LockEvent, LockEventCategory
 
 
 ############################


### PR DESCRIPTION
Close: #571 