### PR TITLE
Keep `token_cache` data up to date to prevent it from becoming stale

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,6 +90,7 @@ RUN . ~/.bash_profile \
  && poetry install --only main --no-root -E ibet-explorer \
  && rm -f /app/ibet-Prime/pyproject.toml \
  && rm -f /app/ibet-Prime/poetry.lock
+ENV PYTHONPATH /app/ibet-Prime
 
 # command deploy
 USER apl

--- a/app/model/blockchain/freeze_log.py
+++ b/app/model/blockchain/freeze_log.py
@@ -17,14 +17,9 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 import logging
-import os
-import sys
 
 from eth_keyfile import decode_keyfile_json
 from web3.exceptions import TimeExhausted
-
-path = os.path.join(os.path.dirname(__file__), "../")
-sys.path.append(path)
 
 from app.exceptions import ContractRevertError, SendTransactionError
 from app.model.db import FreezeLogAccount

--- a/app/model/blockchain/personal_info.py
+++ b/app/model/blockchain/personal_info.py
@@ -19,8 +19,6 @@ SPDX-License-Identifier: Apache-2.0
 import base64
 import json
 import logging
-import os
-import sys
 
 from Crypto.Cipher import PKCS1_OAEP
 from Crypto.PublicKey import RSA
@@ -28,9 +26,6 @@ from eth_keyfile import decode_keyfile_json
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 from web3.exceptions import TimeExhausted
-
-path = os.path.join(os.path.dirname(__file__), "../")
-sys.path.append(path)
 
 from app.exceptions import ContractRevertError, SendTransactionError
 from app.model.db import Account

--- a/batch/__init__.py
+++ b/batch/__init__.py
@@ -16,24 +16,3 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
-import sys
-
-from sqlalchemy import Table
-
-from app.database import engine, get_db_schema
-from app.model.db import Base
-
-
-def reset():
-    meta = Base.metadata
-    meta.bind = engine
-    table = Table("alembic_version", meta, schema=get_db_schema())
-    if table.exists():
-        table.drop(bind=engine)
-
-
-argv = sys.argv
-
-if len(argv) > 0:
-    if argv[1] == "reset":
-        reset()

--- a/batch/indexer_block_tx_data.py
+++ b/batch/indexer_block_tx_data.py
@@ -16,8 +16,6 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
-import os
-import sys
 import time
 from typing import Sequence
 
@@ -27,14 +25,10 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 from web3.types import BlockData, TxData
 
-path = os.path.join(os.path.dirname(__file__), "../")
-sys.path.append(path)
-
-import batch_log
-
 from app.exceptions import ServiceUnavailableError
 from app.model.db import IDXBlockData, IDXBlockDataBlockNumber, IDXTxData
 from app.utils.web3_utils import Web3Wrapper
+from batch import batch_log
 from config import CHAIN_ID, DATABASE_URL
 
 process_name = "INDEXER-BLOCK_TX_DATA"

--- a/batch/indexer_e2e_messaging.py
+++ b/batch/indexer_e2e_messaging.py
@@ -18,8 +18,6 @@ SPDX-License-Identifier: Apache-2.0
 """
 import base64
 import json
-import os
-import sys
 import time
 from datetime import datetime
 
@@ -29,11 +27,6 @@ from Crypto.Util.Padding import unpad
 from sqlalchemy import and_, create_engine, desc, select
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
-
-path = os.path.join(os.path.dirname(__file__), "../")
-sys.path.append(path)
-
-import batch_log
 
 from app.exceptions import ServiceUnavailableError
 from app.model.db import (
@@ -45,6 +38,7 @@ from app.model.db import (
 from app.utils.contract_utils import ContractUtils
 from app.utils.e2ee_utils import E2EEUtils
 from app.utils.web3_utils import Web3Wrapper
+from batch import batch_log
 from config import (
     DATABASE_URL,
     E2E_MESSAGING_CONTRACT_ADDRESS,

--- a/batch/indexer_issue_redeem.py
+++ b/batch/indexer_issue_redeem.py
@@ -16,7 +16,6 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
-import os
 import sys
 import time
 from datetime import datetime
@@ -28,11 +27,6 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 from web3.eth import Contract
 
-path = os.path.join(os.path.dirname(__file__), "../")
-sys.path.append(path)
-
-import batch_log
-
 from app.exceptions import ServiceUnavailableError
 from app.model.db import (
     IDXIssueRedeem,
@@ -42,6 +36,7 @@ from app.model.db import (
 )
 from app.utils.contract_utils import ContractUtils
 from app.utils.web3_utils import Web3Wrapper
+from batch import batch_log
 from config import DATABASE_URL, INDEXER_BLOCK_LOT_MAX_SIZE, INDEXER_SYNC_INTERVAL
 
 process_name = "INDEXER-Issue-Redeem"

--- a/batch/indexer_personal_info.py
+++ b/batch/indexer_personal_info.py
@@ -17,8 +17,6 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 import json
-import os
-import sys
 import time
 from datetime import datetime
 from typing import Sequence
@@ -28,16 +26,12 @@ from sqlalchemy import and_, create_engine, select
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
-path = os.path.join(os.path.dirname(__file__), "../")
-sys.path.append(path)
-
-import batch_log
-
 from app.exceptions import ServiceUnavailableError
 from app.model.blockchain import PersonalInfoContract
 from app.model.db import IDXPersonalInfo, IDXPersonalInfoBlockNumber, Token
 from app.utils.contract_utils import ContractUtils
 from app.utils.web3_utils import Web3Wrapper
+from batch import batch_log
 from config import (
     DATABASE_URL,
     INDEXER_BLOCK_LOT_MAX_SIZE,

--- a/batch/indexer_position_bond.py
+++ b/batch/indexer_position_bond.py
@@ -17,8 +17,6 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 import json
-import os
-import sys
 import time
 import uuid
 from datetime import datetime, timedelta, timezone
@@ -30,11 +28,6 @@ from sqlalchemy import and_, create_engine, select
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 from web3.eth import Contract
-
-path = os.path.join(os.path.dirname(__file__), "../")
-sys.path.append(path)
-
-import batch_log
 
 from app.exceptions import ServiceUnavailableError
 from app.model.blockchain import IbetExchangeInterface
@@ -51,6 +44,7 @@ from app.model.db import (
 )
 from app.utils.contract_utils import ContractUtils
 from app.utils.web3_utils import Web3Wrapper
+from batch import batch_log
 from config import (
     DATABASE_URL,
     INDEXER_BLOCK_LOT_MAX_SIZE,

--- a/batch/indexer_position_share.py
+++ b/batch/indexer_position_share.py
@@ -17,8 +17,6 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 import json
-import os
-import sys
 import time
 import uuid
 from datetime import datetime, timedelta, timezone
@@ -30,11 +28,6 @@ from sqlalchemy import and_, create_engine, select
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 from web3.eth import Contract
-
-path = os.path.join(os.path.dirname(__file__), "../")
-sys.path.append(path)
-
-import batch_log
 
 from app.exceptions import ServiceUnavailableError
 from app.model.blockchain import IbetExchangeInterface
@@ -51,6 +44,7 @@ from app.model.db import (
 )
 from app.utils.contract_utils import ContractUtils
 from app.utils.web3_utils import Web3Wrapper
+from batch import batch_log
 from config import (
     DATABASE_URL,
     INDEXER_BLOCK_LOT_MAX_SIZE,

--- a/batch/indexer_token_cache.py
+++ b/batch/indexer_token_cache.py
@@ -1,0 +1,93 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+import time
+from datetime import timedelta, timezone
+from typing import Sequence
+
+from sqlalchemy import create_engine, select
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+
+from app.exceptions import ServiceUnavailableError
+from app.model.blockchain import IbetShareContract, IbetStraightBondContract
+from app.model.db import Token, TokenType
+from app.utils.web3_utils import Web3Wrapper
+from batch import batch_log
+from config import DATABASE_URL, INDEXER_SYNC_INTERVAL
+
+process_name = "INDEXER-Token-Cache"
+LOG = batch_log.get_logger(process_name=process_name)
+
+UTC = timezone(timedelta(hours=0), "UTC")
+
+web3 = Web3Wrapper()
+
+db_engine = create_engine(DATABASE_URL, echo=False, pool_pre_ping=True)
+
+
+class Processor:
+    def process(self):
+        db_session = Session(autocommit=False, autoflush=True, bind=db_engine)
+        try:
+            token_list: Sequence[tuple[str, str]] = (
+                db_session.execute(
+                    select(Token.type, Token.token_address)
+                    .filter(Token.token_status == 1)
+                    .order_by(Token.created)
+                )
+                .tuples()
+                .all()
+            )
+            for token_type, token_address in token_list:
+                if token_type == TokenType.IBET_STRAIGHT_BOND:
+                    IbetStraightBondContract(token_address).get()
+                elif token_type == TokenType.IBET_SHARE:
+                    IbetShareContract(token_address).get()
+                db_session.commit()
+                LOG.debug(
+                    f"token refreshed: token_type={token_type}, token_address={token_address}"
+                )
+                time.sleep(60)
+        except Exception as e:
+            db_session.rollback()
+            raise e
+        finally:
+            db_session.close()
+        LOG.info("Sync job has been completed")
+
+
+def main():
+    LOG.info("Service started successfully")
+    processor = Processor()
+
+    while True:
+        try:
+            processor.process()
+        except ServiceUnavailableError:
+            LOG.warning("An external service was unavailable")
+        except SQLAlchemyError as sa_err:
+            LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
+        except Exception:
+            LOG.exception("An exception occurred during event synchronization")
+
+        time.sleep(INDEXER_SYNC_INTERVAL)
+
+
+if __name__ == "__main__":
+    main()

--- a/batch/indexer_token_holders.py
+++ b/batch/indexer_token_holders.py
@@ -16,7 +16,6 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
-import os
 import sys
 import time
 from typing import Dict, Optional, Sequence
@@ -25,11 +24,6 @@ from sqlalchemy import and_, create_engine, delete, select
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 from web3.contract import Contract
-
-path = os.path.join(os.path.dirname(__file__), "../")
-sys.path.append(path)
-
-import batch_log
 
 from app.exceptions import ServiceUnavailableError
 from app.model.db import (
@@ -41,6 +35,7 @@ from app.model.db import (
 )
 from app.utils.contract_utils import ContractUtils
 from app.utils.web3_utils import Web3Wrapper
+from batch import batch_log
 from config import (
     DATABASE_URL,
     INDEXER_BLOCK_LOT_MAX_SIZE,

--- a/batch/indexer_transfer.py
+++ b/batch/indexer_transfer.py
@@ -17,7 +17,6 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 import json
-import os
 import sys
 import time
 from datetime import datetime
@@ -29,11 +28,6 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 from web3.eth import Contract
 
-path = os.path.join(os.path.dirname(__file__), "../")
-sys.path.append(path)
-
-import batch_log
-
 from app.exceptions import ServiceUnavailableError
 from app.model.db import (
     IDXTransfer,
@@ -43,6 +37,7 @@ from app.model.db import (
 )
 from app.utils.contract_utils import ContractUtils
 from app.utils.web3_utils import Web3Wrapper
+from batch import batch_log
 from config import (
     DATABASE_URL,
     INDEXER_BLOCK_LOT_MAX_SIZE,

--- a/batch/indexer_transfer_approval.py
+++ b/batch/indexer_transfer_approval.py
@@ -16,7 +16,6 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
-import os
 import sys
 import time
 import uuid
@@ -28,11 +27,6 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 from web3.eth import Contract
 
-path = os.path.join(os.path.dirname(__file__), "../")
-sys.path.append(path)
-
-import batch_log
-
 from app.exceptions import ServiceUnavailableError
 from app.model.db import (
     IDXTransferApproval,
@@ -43,6 +37,7 @@ from app.model.db import (
 )
 from app.utils.contract_utils import ContractUtils
 from app.utils.web3_utils import Web3Wrapper
+from batch import batch_log
 from config import (
     DATABASE_URL,
     INDEXER_BLOCK_LOT_MAX_SIZE,

--- a/batch/processor_batch_issue_redeem.py
+++ b/batch/processor_batch_issue_redeem.py
@@ -16,8 +16,6 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
-import os
-import sys
 import time
 import uuid
 from typing import Sequence
@@ -26,11 +24,6 @@ from eth_keyfile import decode_keyfile_json
 from sqlalchemy import and_, create_engine, select
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
-
-path = os.path.join(os.path.dirname(__file__), "../")
-sys.path.append(path)
-
-import batch_log
 
 from app.exceptions import ContractRevertError, SendTransactionError
 from app.model.blockchain import IbetShareContract, IbetStraightBondContract
@@ -52,6 +45,7 @@ from app.model.db import (
     TokenType,
 )
 from app.utils.e2ee_utils import E2EEUtils
+from batch import batch_log
 from config import DATABASE_URL
 
 """

--- a/batch/processor_batch_register_personal_info.py
+++ b/batch/processor_batch_register_personal_info.py
@@ -18,8 +18,6 @@ SPDX-License-Identifier: Apache-2.0
 """
 from __future__ import annotations
 
-import os
-import sys
 import threading
 import time
 import uuid
@@ -28,11 +26,6 @@ from typing import Sequence
 from sqlalchemy import and_, create_engine, select, update
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
-
-path = os.path.join(os.path.dirname(__file__), "../")
-sys.path.append(path)
-
-import batch_log
 
 from app.exceptions import (
     ContractRevertError,
@@ -55,6 +48,7 @@ from app.model.db import (
     TokenType,
 )
 from app.utils.web3_utils import Web3Wrapper
+from batch import batch_log
 from config import (
     BATCH_REGISTER_PERSONAL_INFO_INTERVAL,
     BATCH_REGISTER_PERSONAL_INFO_WORKER_COUNT,

--- a/batch/processor_bulk_transfer.py
+++ b/batch/processor_bulk_transfer.py
@@ -16,8 +16,6 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
-import os
-import sys
 import threading
 import time
 import uuid
@@ -27,11 +25,6 @@ from eth_keyfile import decode_keyfile_json
 from sqlalchemy import and_, create_engine, select, update
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
-
-path = os.path.join(os.path.dirname(__file__), "../")
-sys.path.append(path)
-
-import batch_log
 
 from app.exceptions import (
     ContractRevertError,
@@ -57,6 +50,7 @@ from app.model.db import (
 )
 from app.utils.e2ee_utils import E2EEUtils
 from app.utils.web3_utils import Web3Wrapper
+from batch import batch_log
 from config import (
     BULK_TRANSFER_INTERVAL,
     BULK_TRANSFER_WORKER_COUNT,

--- a/batch/processor_create_utxo.py
+++ b/batch/processor_create_utxo.py
@@ -16,7 +16,6 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
-import os
 import sys
 import time
 from datetime import datetime
@@ -27,16 +26,12 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 from web3.eth import Contract
 
-path = os.path.join(os.path.dirname(__file__), "../")
-sys.path.append(path)
-
-import batch_log
-
 from app.exceptions import ServiceUnavailableError
 from app.model.db import UTXO, Token, UTXOBlockNumber
 from app.utils.contract_utils import ContractUtils
 from app.utils.ledger_utils import create_ledger
 from app.utils.web3_utils import Web3Wrapper
+from batch import batch_log
 from config import (
     CREATE_UTXO_BLOCK_LOT_MAX_SIZE,
     CREATE_UTXO_INTERVAL,

--- a/batch/processor_generate_rsa_key.py
+++ b/batch/processor_generate_rsa_key.py
@@ -16,8 +16,6 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
-import os
-import sys
 import time
 from typing import Sequence
 
@@ -27,13 +25,9 @@ from sqlalchemy import create_engine, or_, select
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
-path = os.path.join(os.path.dirname(__file__), "../")
-sys.path.append(path)
-
-import batch_log
-
 from app.model.db import Account, AccountRsaStatus
 from app.utils.e2ee_utils import E2EEUtils
+from batch import batch_log
 from config import DATABASE_URL
 
 """

--- a/batch/processor_modify_personal_info.py
+++ b/batch/processor_modify_personal_info.py
@@ -16,19 +16,12 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
-import os
-import sys
 import time
 from typing import Sequence, Set
 
 from sqlalchemy import and_, create_engine, delete, select, update
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
-
-path = os.path.join(os.path.dirname(__file__), "../")
-sys.path.append(path)
-
-import batch_log
 
 from app.exceptions import ServiceUnavailableError
 from app.model.blockchain import (
@@ -45,6 +38,7 @@ from app.model.db import (
     TokenType,
 )
 from app.utils.contract_utils import ContractUtils
+from batch import batch_log
 from config import DATABASE_URL, ZERO_ADDRESS
 
 """

--- a/batch/processor_monitor_block_sync.py
+++ b/batch/processor_monitor_block_sync.py
@@ -16,8 +16,6 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
-import os
-import sys
 import time
 from typing import Any, Callable
 
@@ -28,13 +26,9 @@ from web3 import Web3
 from web3.middleware import geth_poa_middleware
 from web3.types import RPCEndpoint, RPCResponse
 
-path = os.path.join(os.path.dirname(__file__), "../")
-sys.path.append(path)
-
-import batch_log
-
 from app.exceptions import ServiceUnavailableError
 from app.model.db import Node
+from batch import batch_log
 from config import (
     BLOCK_GENERATION_SPEED_THRESHOLD,
     BLOCK_SYNC_REMAINING_THRESHOLD,

--- a/batch/processor_rotate_e2e_messaging_rsa_key.py
+++ b/batch/processor_rotate_e2e_messaging_rsa_key.py
@@ -16,8 +16,6 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
-import os
-import sys
 import time
 from datetime import datetime
 from typing import Sequence
@@ -29,11 +27,6 @@ from sqlalchemy import create_engine, desc, select
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
-path = os.path.join(os.path.dirname(__file__), "../")
-sys.path.append(path)
-
-import batch_log
-
 from app.exceptions import (
     ContractRevertError,
     SendTransactionError,
@@ -44,6 +37,7 @@ from app.model.db import E2EMessagingAccount, E2EMessagingAccountRsaKey
 from app.utils.contract_utils import ContractUtils
 from app.utils.e2ee_utils import E2EEUtils
 from app.utils.web3_utils import Web3Wrapper
+from batch import batch_log
 from config import (
     DATABASE_URL,
     E2E_MESSAGING_CONTRACT_ADDRESS,

--- a/batch/processor_scheduled_events.py
+++ b/batch/processor_scheduled_events.py
@@ -16,24 +16,16 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
-import os
-import sys
 import threading
 import time
 import uuid
+from datetime import datetime
 from typing import List, Optional, Sequence, Set
 
 from eth_keyfile import decode_keyfile_json
 from sqlalchemy import and_, create_engine, select, update
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
-
-path = os.path.join(os.path.dirname(__file__), "../")
-sys.path.append(path)
-
-from datetime import datetime
-
-import batch_log
 
 from app.exceptions import (
     ContractRevertError,
@@ -59,6 +51,7 @@ from app.model.db import (
 )
 from app.utils.e2ee_utils import E2EEUtils
 from app.utils.web3_utils import Web3Wrapper
+from batch import batch_log
 from config import (
     DATABASE_URL,
     SCHEDULED_EVENTS_INTERVAL,

--- a/batch/processor_update_token.py
+++ b/batch/processor_update_token.py
@@ -16,8 +16,6 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
-import os
-import sys
 import time
 import uuid
 from datetime import datetime
@@ -27,11 +25,6 @@ from eth_keyfile import decode_keyfile_json
 from sqlalchemy import create_engine, select, update
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
-
-path = os.path.join(os.path.dirname(__file__), "../")
-sys.path.append(path)
-
-import batch_log
 
 from app.exceptions import (
     ContractRevertError,
@@ -61,6 +54,7 @@ from app.model.db import (
 )
 from app.utils.contract_utils import ContractUtils
 from app.utils.e2ee_utils import E2EEUtils
+from batch import batch_log
 from config import DATABASE_URL, TOKEN_LIST_CONTRACT_ADDRESS, UPDATE_TOKEN_INTERVAL
 
 """

--- a/bin/healthcheck_indexer.sh
+++ b/bin/healthcheck_indexer.sh
@@ -24,6 +24,7 @@ PROC_LIST="${PROC_LIST} batch/indexer_token_holders.py"
 PROC_LIST="${PROC_LIST} batch/indexer_transfer.py"
 PROC_LIST="${PROC_LIST} batch/indexer_transfer_approval.py"
 PROC_LIST="${PROC_LIST} batch/indexer_issue_redeem.py"
+PROC_LIST="${PROC_LIST} batch/indexer_token_cache.py"
 
 if [ -n "${E2E_MESSAGING_CONTRACT_ADDRESS}" ]; then
   PROC_LIST="${PROC_LIST} batch/indexer_e2e_messaging.py"

--- a/bin/run_indexer.sh
+++ b/bin/run_indexer.sh
@@ -28,6 +28,7 @@ python batch/indexer_token_holders.py &
 python batch/indexer_transfer.py &
 python batch/indexer_transfer_approval.py &
 python batch/indexer_issue_redeem.py &
+python batch/indexer_token_cache.py &
 
 if [ -n "${E2E_MESSAGING_CONTRACT_ADDRESS}" ]; then
   python batch/indexer_e2e_messaging.py &

--- a/cmd/explorer/src/connector/__init__.py
+++ b/cmd/explorer/src/connector/__init__.py
@@ -16,16 +16,10 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
-import os
-import sys
 from dataclasses import asdict
 from typing import Any
 
 from aiohttp import ClientSession
-from cache import AsyncTTL
-
-path = os.path.join(os.path.dirname(__file__), "../../../../")
-sys.path.append(path)
 
 from app.model.schema import (
     BlockDataDetail,
@@ -36,6 +30,7 @@ from app.model.schema import (
     TxDataDetail,
     TxDataListResponse,
 )
+from cache import AsyncTTL
 
 
 class ApiNotEnabledException(Exception):

--- a/config.py
+++ b/config.py
@@ -165,7 +165,11 @@ TOKEN_CACHE_TTL = (
     if os.environ.get("TOKEN_CACHE_TTL")
     else 43200
 )
-
+TOKEN_CACHE_TTL_JITTER = (
+    int(os.environ.get("TOKEN_CACHE_TTL_JITTER"))
+    if os.environ.get("TOKEN_CACHE_TTL_JITTER")
+    else 21600
+)
 
 ####################################################
 # Batch settings

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -96,6 +96,7 @@ USER root
 RUN mkdir -p /app/ibet-Prime/tests/
 COPY --chown=apl:apl tests/ /app/ibet-Prime/tests/
 RUN chmod -R 755 /app/ibet-Prime/tests/
+ENV PYTHONPATH /app/ibet-Prime
 
 USER apl
 RUN mkdir -p /app/ibet-Prime/cov/

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,19 +16,10 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
-import os
-import sys
-
 import pytest
 from eth_keyfile import decode_keyfile_json
 from fastapi.testclient import TestClient
 from sqlalchemy import text
-
-path = os.path.join(os.path.dirname(__file__), "../")
-sys.path.append(path)
-path = os.path.join(os.path.dirname(__file__), "../batch")
-sys.path.append(path)
-
 from web3 import Web3
 from web3.middleware import geth_poa_middleware
 from web3.types import RPCEndpoint

--- a/tests/test_batch_indexer_token_cache.py
+++ b/tests/test_batch_indexer_token_cache.py
@@ -1,0 +1,370 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+import logging
+import time
+from datetime import datetime
+from unittest import mock
+from unittest.mock import MagicMock, patch
+
+import pytest
+from eth_keyfile import decode_keyfile_json
+from sqlalchemy import select
+from sqlalchemy.exc import InvalidRequestError
+from sqlalchemy.orm import Session
+
+from app.exceptions import ServiceUnavailableError
+from app.model.blockchain import IbetShareContract, IbetStraightBondContract
+from app.model.blockchain.tx_params.ibet_share import (
+    UpdateParams as IbetShareUpdateParams,
+)
+from app.model.blockchain.tx_params.ibet_straight_bond import (
+    UpdateParams as IbetStraightBondUpdateParams,
+)
+from app.model.db import Token, TokenCache, TokenType, TokenVersion
+from app.utils.contract_utils import ContractUtils
+from app.utils.web3_utils import Web3Wrapper
+from batch.indexer_token_cache import LOG, Processor, main
+from config import ZERO_ADDRESS
+from tests.account_config import config_eth_account
+
+web3 = Web3Wrapper()
+
+
+@pytest.fixture(scope="function")
+def main_func():
+    LOG = logging.getLogger("background")
+    default_log_level = LOG.level
+    LOG.setLevel(logging.DEBUG)
+    LOG.propagate = True
+    yield main
+    LOG.propagate = False
+    LOG.setLevel(default_log_level)
+
+
+@pytest.fixture(scope="function")
+def processor(db, caplog: pytest.LogCaptureFixture):
+    LOG = logging.getLogger("background")
+    default_log_level = LOG.level
+    LOG.setLevel(logging.DEBUG)
+    LOG.propagate = True
+    yield Processor()
+    LOG.propagate = False
+    LOG.setLevel(default_log_level)
+
+
+def deploy_bond_token_contract(
+    address,
+    private_key,
+    personal_info_contract_address,
+    tradable_exchange_contract_address=None,
+    transfer_approval_required=None,
+):
+    arguments = [
+        "token.name",
+        "token.symbol",
+        100,
+        20,
+        "JPY",
+        "token.redemption_date",
+        30,
+        "JPY",
+        "token.return_date",
+        "token.return_amount",
+        "token.purpose",
+    ]
+    bond_contrat = IbetStraightBondContract()
+    token_address, _, _ = bond_contrat.create(arguments, address, private_key)
+    bond_contrat.update(
+        data=IbetStraightBondUpdateParams(
+            transferable=True,
+            personal_info_contract_address=personal_info_contract_address,
+            tradable_exchange_contract_address=tradable_exchange_contract_address,
+            transfer_approval_required=transfer_approval_required,
+        ),
+        tx_from=address,
+        private_key=private_key,
+    )
+
+    return ContractUtils.get_contract("IbetStraightBond", token_address)
+
+
+def deploy_share_token_contract(
+    address,
+    private_key,
+    personal_info_contract_address,
+    tradable_exchange_contract_address=None,
+    transfer_approval_required=None,
+):
+    arguments = [
+        "token.name",
+        "token.symbol",
+        20,
+        100,
+        3,
+        "token.dividend_record_date",
+        "token.dividend_payment_date",
+        "token.cancellation_date",
+        30,
+    ]
+    share_contract = IbetShareContract()
+    token_address, _, _ = share_contract.create(arguments, address, private_key)
+    share_contract.update(
+        data=IbetShareUpdateParams(
+            transferable=True,
+            personal_info_contract_address=personal_info_contract_address,
+            tradable_exchange_contract_address=tradable_exchange_contract_address,
+            transfer_approval_required=transfer_approval_required,
+        ),
+        tx_from=address,
+        private_key=private_key,
+    )
+
+    return ContractUtils.get_contract("IbetShare", token_address)
+
+
+class TestProcessor:
+    ###########################################################################
+    # Normal Case
+    ###########################################################################
+
+    # <Normal_1_1>
+    # Single Token
+    # not issue token
+    def test_normal_1_1(self, processor, db, personal_info_contract):
+        user_1 = config_eth_account("user1")
+        issuer_address = user_1["address"]
+
+        # Prepare data : Token(processing token)
+        token_1 = Token()
+        token_1.type = TokenType.IBET_STRAIGHT_BOND.value
+        token_1.token_address = "test1"
+        token_1.issuer_address = issuer_address
+        token_1.abi = "abi"
+        token_1.tx_hash = "tx_hash"
+        token_1.token_status = 0
+        token_1.version = TokenVersion.V_23_12
+        db.add(token_1)
+
+        db.commit()
+
+        time_mock = MagicMock(wraps=time)
+        time_mock.sleep.side_effect = [True]
+
+        # Run target process
+        with mock.patch("batch.indexer_token_cache.time", time_mock):
+            processor.process()
+        # Assertion
+        _cache_list = db.scalars(
+            select(TokenCache).order_by(TokenCache.cached_datetime)
+        ).all()
+        assert len(_cache_list) == 0
+
+    # <Normal_1_2>
+    # Multi Token
+    # issued token
+    def test_normal_1_2(self, processor, db, personal_info_contract):
+        user_1 = config_eth_account("user1")
+        issuer_address = user_1["address"]
+        issuer_private_key = decode_keyfile_json(
+            raw_keyfile_json=user_1["keyfile_json"], password="password".encode("utf-8")
+        )
+
+        # Prepare data : Token
+        token_contract_1 = deploy_bond_token_contract(
+            issuer_address, issuer_private_key, personal_info_contract.address
+        )
+        token_address_1 = token_contract_1.address
+        token_1 = Token()
+        token_1.type = TokenType.IBET_STRAIGHT_BOND.value
+        token_1.token_address = token_address_1
+        token_1.issuer_address = issuer_address
+        token_1.abi = token_contract_1.abi
+        token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
+        db.add(token_1)
+
+        # Prepare data : Token
+        token_contract_2 = deploy_share_token_contract(
+            issuer_address, issuer_private_key, personal_info_contract.address
+        )
+        token_address_2 = token_contract_2.address
+        token_2 = Token()
+        token_2.type = TokenType.IBET_SHARE.value
+        token_2.token_address = token_address_2
+        token_2.issuer_address = issuer_address
+        token_2.abi = token_contract_2.abi
+        token_2.tx_hash = "tx_hash"
+        token_2.version = TokenVersion.V_23_12
+        db.add(token_2)
+
+        # Prepare data : Token(processing token)
+        token_3 = Token()
+        token_3.type = TokenType.IBET_SHARE.value
+        token_3.token_address = "test1"
+        token_3.issuer_address = issuer_address
+        token_3.abi = "abi"
+        token_3.tx_hash = "tx_hash"
+        token_3.token_status = 0
+        token_3.version = TokenVersion.V_23_12
+        db.add(token_3)
+
+        db.commit()
+
+        before_cache_time = datetime.utcnow()
+
+        time_mock = MagicMock(wraps=time)
+        time_mock.sleep.side_effect = [True, True]
+
+        # Run target process
+        with mock.patch("batch.indexer_token_cache.time", time_mock):
+            processor.process()
+
+        # Assertion
+        _cache_list = db.scalars(
+            select(TokenCache).order_by(TokenCache.cached_datetime)
+        ).all()
+        assert len(_cache_list) == 2
+
+        assert _cache_list[0].token_address == token_contract_1.address
+        assert _cache_list[0].cached_datetime >= before_cache_time
+        assert _cache_list[0].expiration_datetime >= before_cache_time
+        assert _cache_list[0].attributes == {
+            "contract_name": TokenType.IBET_STRAIGHT_BOND,
+            "token_address": token_address_1,
+            "issuer_address": issuer_address,
+            "name": "token.name",
+            "symbol": "token.symbol",
+            "total_supply": 100,
+            "tradable_exchange_contract_address": ZERO_ADDRESS,
+            "contact_information": "",
+            "privacy_policy": "",
+            "status": True,
+            "personal_info_contract_address": personal_info_contract.address,
+            "transferable": True,
+            "is_offering": False,
+            "transfer_approval_required": False,
+            "face_value": 20,
+            "face_value_currency": "JPY",
+            "interest_rate": 0.0,
+            "interest_payment_currency": "",
+            "redemption_date": "token.redemption_date",
+            "redemption_value": 30,
+            "redemption_value_currency": "JPY",
+            "return_date": "token.return_date",
+            "return_amount": "token.return_amount",
+            "base_fx_rate": 0.0,
+            "purpose": "token.purpose",
+            "memo": "",
+            "is_redeemed": False,
+            "interest_payment_date": ["", "", "", "", "", "", "", "", "", "", "", ""],
+        }
+
+        assert _cache_list[1].token_address == token_contract_2.address
+        assert _cache_list[1].cached_datetime >= before_cache_time
+        assert _cache_list[1].expiration_datetime >= before_cache_time
+        assert _cache_list[1].attributes == {
+            "cancellation_date": "token.cancellation_date",
+            "contact_information": "",
+            "contract_name": "IbetShare",
+            "dividend_payment_date": "token.dividend_payment_date",
+            "dividend_record_date": "token.dividend_record_date",
+            "dividends": 3e-13,
+            "is_canceled": False,
+            "is_offering": False,
+            "issue_price": 20,
+            "issuer_address": issuer_address,
+            "memo": "",
+            "name": "token.name",
+            "personal_info_contract_address": personal_info_contract.address,
+            "principal_value": 30,
+            "privacy_policy": "",
+            "status": True,
+            "symbol": "token.symbol",
+            "token_address": token_address_2,
+            "total_supply": 100,
+            "tradable_exchange_contract_address": ZERO_ADDRESS,
+            "transfer_approval_required": False,
+            "transferable": True,
+        }
+
+    ###########################################################################
+    # Error Case
+    ###########################################################################
+
+    # <Error_1>
+    # If each error occurs, batch will output logs and continue next sync.
+    def test_error_1(
+        self,
+        main_func,
+        db: Session,
+        personal_info_contract,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        user_1 = config_eth_account("user1")
+        issuer_address = user_1["address"]
+        issuer_private_key = decode_keyfile_json(
+            raw_keyfile_json=user_1["keyfile_json"], password="password".encode("utf-8")
+        )
+        # Prepare data : Token
+        token_contract_1 = deploy_bond_token_contract(
+            issuer_address, issuer_private_key, personal_info_contract.address
+        )
+        token_address_1 = token_contract_1.address
+        token_1 = Token()
+        token_1.type = TokenType.IBET_STRAIGHT_BOND.value
+        token_1.token_address = token_address_1
+        token_1.issuer_address = issuer_address
+        token_1.abi = token_contract_1.abi
+        token_1.tx_hash = "tx_hash"
+        token_1.version = TokenVersion.V_23_12
+        db.add(token_1)
+
+        db.commit()
+
+        # Run mainloop once and fail with web3 utils error
+        time_mock = MagicMock(wraps=time)
+        time_mock.sleep.side_effect = [TypeError]
+
+        # Run target process
+        with (
+            patch("batch.indexer_token_cache.INDEXER_SYNC_INTERVAL", None),
+            patch("batch.indexer_token_cache.time", time_mock),
+            patch(
+                target="app.utils.contract_utils.ContractUtils.call_function",
+                side_effect=ServiceUnavailableError(),
+            ),
+            pytest.raises(TypeError),
+        ):
+            main_func()
+        assert 1 == caplog.record_tuples.count(
+            (LOG.name, logging.WARNING, "An external service was unavailable")
+        )
+        caplog.clear()
+
+        # Run mainloop once and fail with sqlalchemy InvalidRequestError
+        with patch("batch.indexer_token_cache.INDEXER_SYNC_INTERVAL", None), patch(
+            "batch.indexer_token_cache.INDEXER_SYNC_INTERVAL", None
+        ), patch.object(
+            Session, "scalars", side_effect=InvalidRequestError()
+        ), pytest.raises(
+            TypeError
+        ):
+            main_func()
+        assert 1 == caplog.text.count("A database error has occurred")
+        caplog.clear()


### PR DESCRIPTION
Close: #576 

- Added a batch to `token_cache` data up to date.
- Changed the logic for calculating the expiration of `token_cache` to ensure that not all records expire at the same time.
- Removed `sys.path.append` lines.