### PR TITLE
Added filter and sort query of personal_info, balance or locked amount to token holders API

### DIFF
--- a/app/model/schema/__init__.py
+++ b/app/model/schema/__init__.py
@@ -129,6 +129,7 @@ from .token import (
     ListAdditionalIssuanceHistoryQuery,
     ListAllAdditionalIssueUploadQuery,
     ListAllHoldersQuery,
+    ListAllHoldersSortItem,
     ListAllRedeemUploadQuery,
     ListAllTokenLockEventsQuery,
     ListAllTokenLockEventsResponse,

--- a/app/model/schema/base/__init__.py
+++ b/app/model/schema/base/__init__.py
@@ -26,5 +26,6 @@ from .base import (
     ResultSet,
     SortOrder,
     TokenType,
+    ValueOperator,
     YYYYMMDD_constr,
 )

--- a/app/model/schema/base/base.py
+++ b/app/model/schema/base/base.py
@@ -54,6 +54,12 @@ class TokenType(str, Enum):
     IBET_SHARE = "IbetShare"
 
 
+class ValueOperator(IntEnum):
+    EQUAL = 0
+    GTE = 1
+    LTE = 2
+
+
 ############################
 # REQUEST
 ############################

--- a/app/model/schema/token.py
+++ b/app/model/schema/token.py
@@ -37,6 +37,7 @@ from .base import (
     MMDD_constr,
     ResultSet,
     SortOrder,
+    ValueOperator,
     YYYYMMDD_constr,
 )
 from .position import LockEvent, LockEventCategory
@@ -352,9 +353,49 @@ class ListAllRedeemUploadQuery:
     limit: Annotated[Optional[int], Query(description="Number of set", ge=0)] = None
 
 
+class ListAllHoldersSortItem(StrEnum):
+    CREATED = "created"
+    ACCOUNT_ADDRESS = "account_address"
+    BALANCE = "balance"
+    PENDING_TRANSFER = "pending_transfer"
+    LOCKED = "locked"
+    HOLDER_NAME = "holder_name"
+
+
 @dataclass
 class ListAllHoldersQuery:
     include_former_holder: Annotated[bool, Query()] = False
+    balance: Annotated[Optional[int], Query(description="number of balance")] = None
+    balance_operator: Annotated[
+        Optional[ValueOperator],
+        Query(
+            description="search condition of balance(0:equal, 1:greater than or equal, 2:less than or equal）",
+        ),
+    ] = ValueOperator.EQUAL
+    pending_transfer: Annotated[
+        Optional[int], Query(description="number of pending transfer amount")
+    ] = None
+    pending_transfer_operator: Annotated[
+        Optional[ValueOperator],
+        Query(
+            description="search condition of pending transfer(0:equal, 1:greater than or equal, 2:less than or equal）",
+        ),
+    ] = ValueOperator.EQUAL
+    locked: Annotated[Optional[int], Query(description="number of locked amount")] = (
+        None
+    )
+    locked_operator: Annotated[
+        Optional[ValueOperator],
+        Query(
+            description="search condition of locked amount(0:equal, 1:greater than or equal, 2:less than or equal）",
+        ),
+    ] = ValueOperator.EQUAL
+    holder_name: Annotated[
+        Optional[str], Query(description="holder_name(partial match)")
+    ] = None
+    sort_item: Annotated[ListAllHoldersSortItem, Query(description="Sort Item")] = (
+        ListAllHoldersSortItem.CREATED
+    )
     sort_order: Annotated[SortOrder, Query(description="0:asc, 1:desc")] = SortOrder.ASC
     offset: Annotated[Optional[int], Query(description="Start position", ge=0)] = None
     limit: Annotated[Optional[int], Query(description="Number of set", ge=0)] = None

--- a/app/model/schema/token.py
+++ b/app/model/schema/token.py
@@ -354,12 +354,13 @@ class ListAllRedeemUploadQuery:
 
 
 class ListAllHoldersSortItem(StrEnum):
-    CREATED = "created"
-    ACCOUNT_ADDRESS = "account_address"
-    BALANCE = "balance"
-    PENDING_TRANSFER = "pending_transfer"
-    LOCKED = "locked"
-    HOLDER_NAME = "holder_name"
+    created = "created"
+    account_address = "account_address"
+    balance = "balance"
+    pending_transfer = "pending_transfer"
+    locked = "locked"
+    key_manager = "key_manager"
+    holder_name = "holder_name"
 
 
 @dataclass
@@ -390,11 +391,17 @@ class ListAllHoldersQuery:
             description="search condition of locked amount(0:equal, 1:greater than or equal, 2:less than or equal）",
         ),
     ] = ValueOperator.EQUAL
+    account_address: Annotated[
+        Optional[str], Query(description="account address(partial match)")
+    ] = None
     holder_name: Annotated[
-        Optional[str], Query(description="holder_name(partial match)")
+        Optional[str], Query(description="holder name(partial match)")
+    ] = None
+    key_manager: Annotated[
+        Optional[str], Query(description="key manager(partial match)")
     ] = None
     sort_item: Annotated[ListAllHoldersSortItem, Query(description="Sort Item")] = (
-        ListAllHoldersSortItem.CREATED
+        ListAllHoldersSortItem.created
     )
     sort_order: Annotated[SortOrder, Query(description="0:asc, 1:desc")] = SortOrder.ASC
     offset: Annotated[Optional[int], Query(description="Start position", ge=0)] = None

--- a/app/routers/bond.py
+++ b/app/routers/bond.py
@@ -28,6 +28,7 @@ from pytz import timezone
 from sqlalchemy import (
     String,
     and_,
+    asc,
     cast,
     column,
     desc,
@@ -123,6 +124,7 @@ from app.model.schema import (
     ListAdditionalIssuanceHistoryQuery,
     ListAllAdditionalIssueUploadQuery,
     ListAllHoldersQuery,
+    ListAllHoldersSortItem,
     ListAllPersonalInfoBatchRegistrationUploadQuery,
     ListAllRedeemUploadQuery,
     ListAllTokenLockEventsQuery,
@@ -149,6 +151,7 @@ from app.model.schema import (
     UpdateTransferApprovalOperationType,
     UpdateTransferApprovalRequest,
 )
+from app.model.schema.base import ValueOperator
 from app.utils.check_utils import (
     address_is_valid_address,
     check_auth,
@@ -1724,6 +1727,14 @@ async def list_all_holders(
 ):
     """List all bond token holders"""
     include_former_holder = get_query.include_former_holder
+    balance = get_query.balance
+    balance_operator = get_query.balance_operator
+    pending_transfer = get_query.pending_transfer
+    pending_transfer_operator = get_query.pending_transfer_operator
+    locked = get_query.locked
+    locked_operator = get_query.locked_operator
+    holder_name = get_query.holder_name
+    sort_item = get_query.sort_item
     sort_order = get_query.sort_order
     offset = get_query.offset
     limit = get_query.limit
@@ -1761,10 +1772,12 @@ async def list_all_holders(
         raise InvalidParameterError("this token is temporarily unavailable")
 
     # Get Holders
+    locked_value = func.sum(IDXLockedPosition.value)
     stmt = (
         select(
             IDXPosition,
-            func.sum(IDXLockedPosition.value),
+            locked_value,
+            IDXPersonalInfo,
             func.max(IDXLockedPosition.modified),
         )
         .outerjoin(
@@ -1774,9 +1787,17 @@ async def list_all_holders(
                 IDXLockedPosition.account_address == IDXPosition.account_address,
             ),
         )
+        .outerjoin(
+            IDXPersonalInfo,
+            and_(
+                IDXPersonalInfo.issuer_address == issuer_address,
+                IDXPersonalInfo.account_address == IDXPosition.account_address,
+            ),
+        )
         .where(IDXPosition.token_address == token_address)
         .group_by(
             IDXPosition.id,
+            IDXPersonalInfo.id,
             IDXLockedPosition.token_address,
             IDXLockedPosition.account_address,
         )
@@ -1795,13 +1816,54 @@ async def list_all_holders(
             )
         )
 
+    if balance is not None and balance_operator is not None:
+        match balance_operator:
+            case ValueOperator.EQUAL:
+                stmt = stmt.where(IDXPosition.balance == balance)
+            case ValueOperator.GTE:
+                stmt = stmt.where(IDXPosition.balance >= balance)
+            case ValueOperator.LTE:
+                stmt = stmt.where(IDXPosition.balance <= balance)
+
+    if pending_transfer is not None and pending_transfer_operator is not None:
+        match pending_transfer_operator:
+            case ValueOperator.EQUAL:
+                stmt = stmt.where(IDXPosition.pending_transfer == pending_transfer)
+            case ValueOperator.GTE:
+                stmt = stmt.where(IDXPosition.pending_transfer >= pending_transfer)
+            case ValueOperator.LTE:
+                stmt = stmt.where(IDXPosition.pending_transfer <= pending_transfer)
+
+    if locked is not None and locked_operator is not None:
+        match locked_operator:
+            case ValueOperator.EQUAL:
+                stmt = stmt.having(locked_value == locked)
+            case ValueOperator.GTE:
+                stmt = stmt.having(locked_value >= locked)
+            case ValueOperator.LTE:
+                stmt = stmt.having(locked_value <= locked)
+
+    if holder_name is not None:
+        stmt = stmt.where(
+            IDXPersonalInfo._personal_info["name"]
+            .as_string()
+            .like("%" + holder_name + "%")
+        )
+
     count = await db.scalar(select(func.count()).select_from(stmt.subquery()))
 
     # Sort
+    if sort_item == ListAllHoldersSortItem.HOLDER_NAME:
+        sort_attr = IDXPersonalInfo._personal_info["name"].as_string()
+    elif sort_item == ListAllHoldersSortItem.LOCKED:
+        sort_attr = locked_value
+    else:
+        sort_attr = getattr(IDXPosition, sort_item)
+
     if sort_order == 0:  # ASC
-        stmt = stmt.order_by(IDXPosition.id)
+        stmt = stmt.order_by(asc(sort_attr))
     else:  # DESC
-        stmt = stmt.order_by(desc(IDXPosition.id))
+        stmt = stmt.order_by(desc(sort_attr))
 
     # Pagination
     if limit is not None:
@@ -1809,21 +1871,9 @@ async def list_all_holders(
     if offset is not None:
         stmt = stmt.offset(offset)
 
-    _holders: Sequence[tuple[IDXPosition, int, datetime | None]] = (
-        (await db.execute(stmt)).tuples().all()
-    )
-
-    # Get personal information
-    _personal_info_list: Sequence[IDXPersonalInfo] = (
-        await db.scalars(
-            select(IDXPersonalInfo)
-            .where(IDXPersonalInfo.issuer_address == issuer_address)
-            .order_by(IDXPersonalInfo.id)
-        )
-    ).all()
-    _personal_info_dict = {}
-    for item in _personal_info_list:
-        _personal_info_dict[item.account_address] = item.personal_info
+    _holders: Sequence[
+        tuple[IDXPosition, int, IDXPersonalInfo | None, datetime | None]
+    ] = ((await db.execute(stmt)).tuples().all())
 
     personal_info_default = {
         "key_manager": None,
@@ -1837,9 +1887,11 @@ async def list_all_holders(
     }
 
     holders = []
-    for _position, _locked, _lock_event_latest_created in _holders:
-        _personal_info = _personal_info_dict.get(
-            _position.account_address, personal_info_default
+    for _position, _locked, _personal_info, _lock_event_latest_created in _holders:
+        personal_info = (
+            _personal_info.personal_info
+            if _personal_info is not None
+            else personal_info_default
         )
         if _position is None and _lock_event_latest_created is not None:
             modified: datetime = _lock_event_latest_created
@@ -1855,7 +1907,7 @@ async def list_all_holders(
         holders.append(
             {
                 "account_address": _position.account_address,
-                "personal_information": _personal_info,
+                "personal_information": personal_info,
                 "balance": _position.balance,
                 "exchange_balance": _position.exchange_balance,
                 "exchange_commitment": _position.exchange_commitment,

--- a/app/routers/bond.py
+++ b/app/routers/bond.py
@@ -1864,6 +1864,9 @@ async def list_all_holders(
         stmt = stmt.order_by(asc(sort_attr))
     else:  # DESC
         stmt = stmt.order_by(desc(sort_attr))
+    if sort_item != ListAllHoldersSortItem.CREATED:
+        # NOTE: Set secondary sort for consistent results
+        stmt = stmt.order_by(asc(IDXPosition.created))
 
     # Pagination
     if limit is not None:

--- a/app/routers/share.py
+++ b/app/routers/share.py
@@ -30,6 +30,7 @@ from sqlalchemy import (
     String,
     and_,
     case,
+    asc,
     cast,
     column,
     desc,
@@ -124,6 +125,7 @@ from app.model.schema import (
     ListAdditionalIssuanceHistoryQuery,
     ListAllAdditionalIssueUploadQuery,
     ListAllHoldersQuery,
+    ListAllHoldersSortItem,
     ListAllPersonalInfoBatchRegistrationUploadQuery,
     ListAllRedeemUploadQuery,
     ListAllTokenLockEventsQuery,
@@ -150,6 +152,7 @@ from app.model.schema import (
     UpdateTransferApprovalOperationType,
     UpdateTransferApprovalRequest,
 )
+from app.model.schema.base import ValueOperator
 from app.utils.check_utils import (
     address_is_valid_address,
     check_auth,
@@ -1708,6 +1711,14 @@ async def list_all_holders(
 ):
     """List all share token holders"""
     include_former_holder = get_query.include_former_holder
+    balance = get_query.balance
+    balance_operator = get_query.balance_operator
+    pending_transfer = get_query.pending_transfer
+    pending_transfer_operator = get_query.pending_transfer_operator
+    locked = get_query.locked
+    locked_operator = get_query.locked_operator
+    holder_name = get_query.holder_name
+    sort_item = get_query.sort_item
     sort_order = get_query.sort_order
     offset = get_query.offset
     limit = get_query.limit
@@ -1745,10 +1756,12 @@ async def list_all_holders(
         raise InvalidParameterError("this token is temporarily unavailable")
 
     # Get Holders
+    locked_value = func.sum(IDXLockedPosition.value)
     stmt = (
         select(
             IDXPosition,
-            func.sum(IDXLockedPosition.value),
+            locked_value,
+            IDXPersonalInfo,
             func.max(IDXLockedPosition.modified),
         )
         .outerjoin(
@@ -1758,9 +1771,17 @@ async def list_all_holders(
                 IDXLockedPosition.account_address == IDXPosition.account_address,
             ),
         )
+        .outerjoin(
+            IDXPersonalInfo,
+            and_(
+                IDXPersonalInfo.issuer_address == issuer_address,
+                IDXPersonalInfo.account_address == IDXPosition.account_address,
+            ),
+        )
         .where(IDXPosition.token_address == token_address)
         .group_by(
             IDXPosition.id,
+            IDXPersonalInfo.id,
             IDXLockedPosition.token_address,
             IDXLockedPosition.account_address,
         )
@@ -1779,13 +1800,57 @@ async def list_all_holders(
             )
         )
 
+    if balance is not None and balance_operator is not None:
+        match balance_operator:
+            case ValueOperator.EQUAL:
+                stmt = stmt.where(IDXPosition.balance == balance)
+            case ValueOperator.GTE:
+                stmt = stmt.where(IDXPosition.balance >= balance)
+            case ValueOperator.LTE:
+                stmt = stmt.where(IDXPosition.balance <= balance)
+
+    if pending_transfer is not None and pending_transfer_operator is not None:
+        match pending_transfer_operator:
+            case ValueOperator.EQUAL:
+                stmt = stmt.where(IDXPosition.pending_transfer == pending_transfer)
+            case ValueOperator.GTE:
+                stmt = stmt.where(IDXPosition.pending_transfer >= pending_transfer)
+            case ValueOperator.LTE:
+                stmt = stmt.where(IDXPosition.pending_transfer <= pending_transfer)
+
+    if locked is not None and locked_operator is not None:
+        match locked_operator:
+            case ValueOperator.EQUAL:
+                stmt = stmt.having(locked_value == locked)
+            case ValueOperator.GTE:
+                stmt = stmt.having(locked_value >= locked)
+            case ValueOperator.LTE:
+                stmt = stmt.having(locked_value <= locked)
+
+    if holder_name is not None:
+        stmt = stmt.where(
+            IDXPersonalInfo._personal_info["name"]
+            .as_string()
+            .like("%" + holder_name + "%")
+        )
+
     count = await db.scalar(select(func.count()).select_from(stmt.subquery()))
 
     # Sort
+    if sort_item == ListAllHoldersSortItem.HOLDER_NAME:
+        sort_attr = IDXPersonalInfo._personal_info["name"].as_string()
+    elif sort_item == ListAllHoldersSortItem.LOCKED:
+        sort_attr = locked_value
+    else:
+        sort_attr = getattr(IDXPosition, sort_item)
+
     if sort_order == 0:  # ASC
-        stmt = stmt.order_by(IDXPosition.id)
+        stmt = stmt.order_by(asc(sort_attr))
     else:  # DESC
-        stmt = stmt.order_by(desc(IDXPosition.id))
+        stmt = stmt.order_by(desc(sort_attr))
+    if sort_item != ListAllHoldersSortItem.CREATED:
+        # NOTE: Set secondary sort for consistent results
+        stmt = stmt.order_by(asc(IDXPosition.created))
 
     # Pagination
     if limit is not None:
@@ -1793,21 +1858,9 @@ async def list_all_holders(
     if offset is not None:
         stmt = stmt.offset(offset)
 
-    _holders: Sequence[tuple[IDXPosition, int, datetime | None]] = (
-        (await db.execute(stmt)).tuples().all()
-    )
-
-    # Get personal information
-    _personal_info_list: Sequence[IDXPersonalInfo] = (
-        await db.scalars(
-            select(IDXPersonalInfo)
-            .where(IDXPersonalInfo.issuer_address == issuer_address)
-            .order_by(IDXPersonalInfo.id)
-        )
-    ).all()
-    _personal_info_dict = {}
-    for item in _personal_info_list:
-        _personal_info_dict[item.account_address] = item.personal_info
+    _holders: Sequence[
+        tuple[IDXPosition, int, IDXPersonalInfo | None, datetime | None]
+    ] = ((await db.execute(stmt)).tuples().all())
 
     personal_info_default = {
         "key_manager": None,
@@ -1821,9 +1874,11 @@ async def list_all_holders(
     }
 
     holders = []
-    for _position, _locked, _lock_event_latest_created in _holders:
-        _personal_info = _personal_info_dict.get(
-            _position.account_address, personal_info_default
+    for _position, _locked, _personal_info, _lock_event_latest_created in _holders:
+        personal_info = (
+            _personal_info.personal_info
+            if _personal_info is not None
+            else personal_info_default
         )
         if _position is None and _lock_event_latest_created is not None:
             modified: datetime = _lock_event_latest_created
@@ -1839,7 +1894,7 @@ async def list_all_holders(
         holders.append(
             {
                 "account_address": _position.account_address,
-                "personal_information": _personal_info,
+                "personal_information": personal_info,
                 "balance": _position.balance,
                 "exchange_balance": _position.exchange_balance,
                 "exchange_commitment": _position.exchange_commitment,

--- a/app/routers/share.py
+++ b/app/routers/share.py
@@ -29,8 +29,8 @@ from pytz import timezone
 from sqlalchemy import (
     String,
     and_,
-    case,
     asc,
+    case,
     cast,
     column,
     desc,
@@ -1717,7 +1717,9 @@ async def list_all_holders(
     pending_transfer_operator = get_query.pending_transfer_operator
     locked = get_query.locked
     locked_operator = get_query.locked_operator
+    account_address = get_query.account_address
     holder_name = get_query.holder_name
+    key_manager = get_query.key_manager
     sort_item = get_query.sort_item
     sort_order = get_query.sort_order
     offset = get_query.offset
@@ -1827,6 +1829,9 @@ async def list_all_holders(
             case ValueOperator.LTE:
                 stmt = stmt.having(locked_value <= locked)
 
+    if account_address is not None:
+        stmt = stmt.where(IDXPosition.account_address.like("%" + account_address + "%"))
+
     if holder_name is not None:
         stmt = stmt.where(
             IDXPersonalInfo._personal_info["name"]
@@ -1834,12 +1839,21 @@ async def list_all_holders(
             .like("%" + holder_name + "%")
         )
 
+    if key_manager is not None:
+        stmt = stmt.where(
+            IDXPersonalInfo._personal_info["key_manager"]
+            .as_string()
+            .like("%" + key_manager + "%")
+        )
+
     count = await db.scalar(select(func.count()).select_from(stmt.subquery()))
 
     # Sort
-    if sort_item == ListAllHoldersSortItem.HOLDER_NAME:
+    if sort_item == ListAllHoldersSortItem.holder_name:
         sort_attr = IDXPersonalInfo._personal_info["name"].as_string()
-    elif sort_item == ListAllHoldersSortItem.LOCKED:
+    elif sort_item == ListAllHoldersSortItem.key_manager:
+        sort_attr = IDXPersonalInfo._personal_info["key_manager"].as_string()
+    elif sort_item == ListAllHoldersSortItem.locked:
         sort_attr = locked_value
     else:
         sort_attr = getattr(IDXPosition, sort_item)
@@ -1848,7 +1862,7 @@ async def list_all_holders(
         stmt = stmt.order_by(asc(sort_attr))
     else:  # DESC
         stmt = stmt.order_by(desc(sort_attr))
-    if sort_item != ListAllHoldersSortItem.CREATED:
+    if sort_item != ListAllHoldersSortItem.created:
         # NOTE: Set secondary sort for consistent results
         stmt = stmt.order_by(asc(IDXPosition.created))
 

--- a/cmd/explorer/src/connector/__init__.py
+++ b/cmd/explorer/src/connector/__init__.py
@@ -21,7 +21,6 @@ from dataclasses import asdict
 from typing import Any
 
 from aiohttp import ClientSession
-from cache import AsyncTTL
 
 from app.model.schema import (
     BlockDataDetail,
@@ -32,6 +31,7 @@ from app.model.schema import (
     TxDataDetail,
     TxDataListResponse,
 )
+from cache import AsyncTTL
 
 
 class ApiNotEnabledException(Exception):

--- a/tests/test_app_routers_bond_tokens_{token_address}_holders_GET.py
+++ b/tests/test_app_routers_bond_tokens_{token_address}_holders_GET.py
@@ -2747,6 +2747,409 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             ],
         }
 
+    # <Normal_4_6>
+    # Search filter: key_manager
+    def test_normal_4_6(self, client, db):
+        user = config_eth_account("user1")
+        _issuer_address = user["address"]
+        _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
+        _account_address_1 = "0xb75c7545b9230FEe99b7af370D38eBd3DAD929f7"
+        _account_address_2 = "0x3F198534Bbe3B2a197d3B317d41392F348EAC707"
+        _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
+
+        account = Account()
+        account.issuer_address = _issuer_address
+        db.add(account)
+
+        token = Token()
+        token.type = TokenType.IBET_STRAIGHT_BOND.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        token.version = TokenVersion.V_23_12
+        db.add(token)
+
+        # prepare data: account_address_1
+        idx_position_1 = IDXPosition()
+        idx_position_1.token_address = _token_address
+        idx_position_1.account_address = _account_address_1
+        idx_position_1.balance = 10
+        idx_position_1.exchange_balance = 11
+        idx_position_1.exchange_commitment = 12
+        idx_position_1.pending_transfer = 5
+        idx_position_1.modified = datetime(2023, 10, 24, 0, 0, 0)
+        db.add(idx_position_1)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = _account_address_1
+        idx_personal_info_1.issuer_address = _issuer_address
+        idx_personal_info_1.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(idx_personal_info_1)
+
+        # prepare data: account_address_2
+        idx_position_2 = IDXPosition()
+        idx_position_2.token_address = _token_address
+        idx_position_2.account_address = _account_address_2
+        idx_position_2.balance = 20
+        idx_position_2.exchange_balance = 21
+        idx_position_2.exchange_commitment = 22
+        idx_position_2.pending_transfer = 10
+        idx_position_2.modified = datetime(2023, 10, 24, 2, 0, 0)
+        db.add(idx_position_2)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 20, 0)
+        db.add(idx_locked_position)
+
+        # prepare data: account_address_3
+        idx_position_3 = IDXPosition()
+        idx_position_3.token_address = _token_address
+        idx_position_3.account_address = _account_address_3
+        idx_position_3.balance = 99
+        idx_position_3.exchange_balance = 99
+        idx_position_3.exchange_commitment = 99
+        idx_position_3.pending_transfer = 99
+        idx_position_3.modified = datetime(2023, 10, 24, 3, 0, 0)
+        db.add(idx_position_3)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 4, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 5, 0, 0)
+        db.add(idx_locked_position)
+
+        # Other locked position
+        _locked_position = IDXLockedPosition()
+        _locked_position.token_address = "other_token_address"
+        _locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        _locked_position.account_address = _account_address_1
+        _locked_position.value = 5
+        _locked_position.modified = datetime(2023, 10, 25, 0, 2, 0)
+        db.add(_locked_position)
+
+        idx_personal_info_3 = IDXPersonalInfo()
+        idx_personal_info_3.account_address = _account_address_3
+        idx_personal_info_3.issuer_address = _issuer_address
+        idx_personal_info_3.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test3",
+            "postal_code": "postal_code_test3",
+            "address": "address_test3",
+            "email": "email_test3",
+            "birth": "birth_test3",
+            # PersonalInfo is partially registered.
+        }
+        db.add(idx_personal_info_3)
+
+        db.commit()
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address),
+            headers={"issuer-address": _issuer_address},
+            params={"key_manager": "_test1"},
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "result_set": {"count": 2, "total": 3, "offset": None, "limit": None},
+            "holders": [
+                {
+                    "account_address": _account_address_1,
+                    "personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test1",
+                        "postal_code": "postal_code_test1",
+                        "address": "address_test1",
+                        "email": "email_test1",
+                        "birth": "birth_test1",
+                        "is_corporate": False,
+                        "tax_category": 10,
+                    },
+                    "balance": 10,
+                    "exchange_balance": 11,
+                    "exchange_commitment": 12,
+                    "pending_transfer": 5,
+                    "locked": 10,
+                    "modified": "2023-10-24T01:10:00",
+                },
+                {
+                    "account_address": _account_address_3,
+                    "personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test3",
+                        "postal_code": "postal_code_test3",
+                        "address": "address_test3",
+                        "email": "email_test3",
+                        "birth": "birth_test3",
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 99,
+                    "exchange_balance": 99,
+                    "exchange_commitment": 99,
+                    "pending_transfer": 99,
+                    "locked": 30,
+                    "modified": "2023-10-24T05:00:00",
+                },
+            ],
+        }
+
+    # <Normal_4_7>
+    # Search filter: account_address
+    def test_normal_4_7(self, client, db):
+        user = config_eth_account("user1")
+        _issuer_address = user["address"]
+        _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
+        _account_address_1 = "0xb75c7545b9230FEe99b7af370D38eBd3DAD929f7"
+        _account_address_2 = "0x3F198534Bbe3B2a197d3B317d41392F348EAC707"
+        _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
+
+        account = Account()
+        account.issuer_address = _issuer_address
+        db.add(account)
+
+        token = Token()
+        token.type = TokenType.IBET_STRAIGHT_BOND.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        token.version = TokenVersion.V_23_12
+        db.add(token)
+
+        # prepare data: account_address_1
+        idx_position_1 = IDXPosition()
+        idx_position_1.token_address = _token_address
+        idx_position_1.account_address = _account_address_1
+        idx_position_1.balance = 10
+        idx_position_1.exchange_balance = 11
+        idx_position_1.exchange_commitment = 12
+        idx_position_1.pending_transfer = 5
+        idx_position_1.modified = datetime(2023, 10, 24, 0, 0, 0)
+        db.add(idx_position_1)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = _account_address_1
+        idx_personal_info_1.issuer_address = _issuer_address
+        idx_personal_info_1.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(idx_personal_info_1)
+
+        # prepare data: account_address_2
+        idx_position_2 = IDXPosition()
+        idx_position_2.token_address = _token_address
+        idx_position_2.account_address = _account_address_2
+        idx_position_2.balance = 20
+        idx_position_2.exchange_balance = 21
+        idx_position_2.exchange_commitment = 22
+        idx_position_2.pending_transfer = 10
+        idx_position_2.modified = datetime(2023, 10, 24, 2, 0, 0)
+        db.add(idx_position_2)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 20, 0)
+        db.add(idx_locked_position)
+
+        # prepare data: account_address_3
+        idx_position_3 = IDXPosition()
+        idx_position_3.token_address = _token_address
+        idx_position_3.account_address = _account_address_3
+        idx_position_3.balance = 99
+        idx_position_3.exchange_balance = 99
+        idx_position_3.exchange_commitment = 99
+        idx_position_3.pending_transfer = 99
+        idx_position_3.modified = datetime(2023, 10, 24, 3, 0, 0)
+        db.add(idx_position_3)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 4, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 5, 0, 0)
+        db.add(idx_locked_position)
+
+        # Other locked position
+        _locked_position = IDXLockedPosition()
+        _locked_position.token_address = "other_token_address"
+        _locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        _locked_position.account_address = _account_address_1
+        _locked_position.value = 5
+        _locked_position.modified = datetime(2023, 10, 25, 0, 2, 0)
+        db.add(_locked_position)
+
+        idx_personal_info_3 = IDXPersonalInfo()
+        idx_personal_info_3.account_address = _account_address_3
+        idx_personal_info_3.issuer_address = _issuer_address
+        idx_personal_info_3.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test3",
+            "postal_code": "postal_code_test3",
+            "address": "address_test3",
+            "email": "email_test3",
+            "birth": "birth_test3",
+            # PersonalInfo is partially registered.
+        }
+        db.add(idx_personal_info_3)
+
+        db.commit()
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address),
+            headers={"issuer-address": _issuer_address},
+            params={"account_address": _account_address_1[10:20]},
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "result_set": {"count": 1, "total": 3, "offset": None, "limit": None},
+            "holders": [
+                {
+                    "account_address": _account_address_1,
+                    "personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test1",
+                        "postal_code": "postal_code_test1",
+                        "address": "address_test1",
+                        "email": "email_test1",
+                        "birth": "birth_test1",
+                        "is_corporate": False,
+                        "tax_category": 10,
+                    },
+                    "balance": 10,
+                    "exchange_balance": 11,
+                    "exchange_commitment": 12,
+                    "pending_transfer": 5,
+                    "locked": 10,
+                    "modified": "2023-10-24T01:10:00",
+                },
+            ],
+        }
+
     # <Normal_5_1>
     # Sort Item: created
     def test_normal_5_1(self, client, db):
@@ -4140,6 +4543,271 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
                     "account_address": _account_address_3,
                     "personal_information": {
                         "key_manager": "key_manager_test1",
+                        "name": "name_test3",
+                        "postal_code": "postal_code_test3",
+                        "address": "address_test3",
+                        "email": "email_test3",
+                        "birth": "birth_test3",
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 99,
+                    "exchange_balance": 99,
+                    "exchange_commitment": 99,
+                    "pending_transfer": 99,
+                    "locked": 30,
+                    "modified": "2023-10-24T05:00:00",
+                },
+                {
+                    "account_address": _account_address_1,
+                    "personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test1",
+                        "postal_code": "postal_code_test1",
+                        "address": "address_test1",
+                        "email": "email_test1",
+                        "birth": "birth_test1",
+                        "is_corporate": False,
+                        "tax_category": 10,
+                    },
+                    "balance": 10,
+                    "exchange_balance": 11,
+                    "exchange_commitment": 12,
+                    "pending_transfer": 5,
+                    "locked": 10,
+                    "modified": "2023-10-24T01:10:00",
+                },
+            ],
+        }
+
+    # <Normal_5_7>
+    # Sort Item: key_manager
+    def test_normal_5_7(self, client, db):
+        user = config_eth_account("user1")
+        _issuer_address = user["address"]
+        _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
+        _account_address_1 = "0xb75c7545b9230FEe99b7af370D38eBd3DAD929f7"
+        _account_address_2 = "0x3F198534Bbe3B2a197d3B317d41392F348EAC707"
+        _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
+        _account_address_4 = "0x917eFFaC072dcda308e2337636f562D0A96F42eA"
+
+        account = Account()
+        account.issuer_address = _issuer_address
+        db.add(account)
+
+        token = Token()
+        token.type = TokenType.IBET_STRAIGHT_BOND.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        token.version = TokenVersion.V_23_12
+        db.add(token)
+
+        # prepare data: account_address_1
+        idx_position_1 = IDXPosition()
+        idx_position_1.token_address = _token_address
+        idx_position_1.account_address = _account_address_1
+        idx_position_1.balance = 10
+        idx_position_1.exchange_balance = 11
+        idx_position_1.exchange_commitment = 12
+        idx_position_1.pending_transfer = 5
+        idx_position_1.created = datetime(2023, 10, 24, 0, 0, 0)
+        idx_position_1.modified = datetime(2023, 10, 24, 0, 0, 0)
+        db.add(idx_position_1)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = _account_address_1
+        idx_personal_info_1.issuer_address = _issuer_address
+        idx_personal_info_1.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(idx_personal_info_1)
+
+        # prepare data: account_address_2
+        idx_position_2 = IDXPosition()
+        idx_position_2.token_address = _token_address
+        idx_position_2.account_address = _account_address_2
+        idx_position_2.balance = 20
+        idx_position_2.exchange_balance = 21
+        idx_position_2.exchange_commitment = 22
+        idx_position_2.pending_transfer = 10
+        idx_position_2.created = datetime(2023, 10, 24, 2, 0, 0)
+        idx_position_2.modified = datetime(2023, 10, 24, 2, 0, 0)
+        db.add(idx_position_2)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 20, 0)
+        db.add(idx_locked_position)
+
+        # prepare data: account_address_3
+        idx_position_3 = IDXPosition()
+        idx_position_3.token_address = _token_address
+        idx_position_3.account_address = _account_address_3
+        idx_position_3.balance = 99
+        idx_position_3.exchange_balance = 99
+        idx_position_3.exchange_commitment = 99
+        idx_position_3.pending_transfer = 99
+        idx_position_3.created = datetime(2023, 10, 24, 3, 0, 0)
+        idx_position_3.modified = datetime(2023, 10, 24, 3, 0, 0)
+        db.add(idx_position_3)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 4, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 5, 0, 0)
+        db.add(idx_locked_position)
+
+        # Other locked position
+        _locked_position = IDXLockedPosition()
+        _locked_position.token_address = "other_token_address"
+        _locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        _locked_position.account_address = _account_address_1
+        _locked_position.value = 5
+        _locked_position.modified = datetime(2023, 10, 25, 0, 2, 0)
+        db.add(_locked_position)
+
+        idx_personal_info_3 = IDXPersonalInfo()
+        idx_personal_info_3.account_address = _account_address_3
+        idx_personal_info_3.issuer_address = _issuer_address
+        idx_personal_info_3.personal_info = {
+            "key_manager": "key_manager_test2",
+            "name": "name_test3",
+            "postal_code": "postal_code_test3",
+            "address": "address_test3",
+            "email": "email_test3",
+            "birth": "birth_test3",
+            # PersonalInfo is partially registered.
+        }
+        db.add(idx_personal_info_3)
+
+        # prepare data: account_address_4
+        idx_position_4 = IDXPosition()
+        idx_position_4.token_address = _token_address
+        idx_position_4.account_address = _account_address_4
+        idx_position_4.balance = 100
+        idx_position_4.exchange_balance = 100
+        idx_position_4.exchange_commitment = 100
+        idx_position_4.pending_transfer = 100
+        idx_position_4.created = datetime(2023, 10, 24, 6, 0, 0)
+        idx_position_4.modified = datetime(2023, 10, 24, 6, 0, 0)
+        db.add(idx_position_4)
+
+        db.commit()
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address),
+            headers={"issuer-address": _issuer_address},
+            params={"sort_order": 1, "sort_item": "key_manager"},
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "result_set": {"count": 4, "total": 4, "offset": None, "limit": None},
+            "holders": [
+                {
+                    "account_address": _account_address_2,
+                    "personal_information": {
+                        "key_manager": None,
+                        "name": None,
+                        "postal_code": None,
+                        "address": None,
+                        "email": None,
+                        "birth": None,
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 20,
+                    "exchange_balance": 21,
+                    "exchange_commitment": 22,
+                    "pending_transfer": 10,
+                    "locked": 20,
+                    "modified": "2023-10-24T02:20:00",
+                },
+                {
+                    "account_address": _account_address_4,
+                    "personal_information": {
+                        "key_manager": None,
+                        "name": None,
+                        "postal_code": None,
+                        "address": None,
+                        "email": None,
+                        "birth": None,
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 100,
+                    "exchange_balance": 100,
+                    "exchange_commitment": 100,
+                    "pending_transfer": 100,
+                    "locked": 0,
+                    "modified": "2023-10-24T06:00:00",
+                },
+                {
+                    "account_address": _account_address_3,
+                    "personal_information": {
+                        "key_manager": "key_manager_test2",
                         "name": "name_test3",
                         "postal_code": "postal_code_test3",
                         "address": "address_test3",

--- a/tests/test_app_routers_bond_tokens_{token_address}_holders_GET.py
+++ b/tests/test_app_routers_bond_tokens_{token_address}_holders_GET.py
@@ -192,9 +192,9 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             ],
         }
 
-    # <Normal_3_1>
+    # <Normal_3>
     # Multi record
-    def test_normal_3_1(self, client, db):
+    def test_normal_3(self, client, db):
         user = config_eth_account("user1")
         _issuer_address = user["address"]
         _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
@@ -421,10 +421,9 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             ],
         }
 
-    # <Normal_3_2>
-    # Multi record (Including former holder)
-    # Query param: including_former_holder=None
-    def test_normal_3_2(self, client, db):
+    # <Normal_4_1_1>
+    # Search filter: including_former_holder=None
+    def test_normal_4_1_1(self, client, db):
         user = config_eth_account("user1")
         _issuer_address = user["address"]
         _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
@@ -556,10 +555,9 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             ],
         }
 
-    # <Normal_3_3>
-    # Multi record (Including former holder)
-    # Query param: including_former_holder=True
-    def test_normal_3_3(self, client, db):
+    # <Normal_4_1_2>
+    # Search filter: including_former_holder=True
+    def test_normal_4_1_2(self, client, db):
         user = config_eth_account("user1")
         _issuer_address = user["address"]
         _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
@@ -715,9 +713,9 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             ],
         }
 
-    # <Normal_4>
-    # Sort Order
-    def test_normal_4(self, client, db):
+    # <Normal_4_2_1>
+    # Search filter: balance & "="
+    def test_normal_4_2_1(self, client, db):
         user = config_eth_account("user1")
         _issuer_address = user["address"]
         _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
@@ -877,7 +875,2044 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
         resp = client.get(
             self.base_url.format(_token_address),
             headers={"issuer-address": _issuer_address},
-            params={"sort_order": 1},
+            params={"balance": 20, "balance_operator": 0},
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "result_set": {"count": 1, "total": 3, "offset": None, "limit": None},
+            "holders": [
+                {
+                    "account_address": _account_address_2,
+                    "personal_information": {
+                        "key_manager": None,
+                        "name": None,
+                        "postal_code": None,
+                        "address": None,
+                        "email": None,
+                        "birth": None,
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 20,
+                    "exchange_balance": 21,
+                    "exchange_commitment": 22,
+                    "pending_transfer": 10,
+                    "locked": 20,
+                    "modified": "2023-10-24T02:20:00",
+                },
+            ],
+        }
+
+    # <Normal_4_2_2>
+    # Search filter: balance & ">="
+    def test_normal_4_2_2(self, client, db):
+        user = config_eth_account("user1")
+        _issuer_address = user["address"]
+        _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
+        _account_address_1 = "0xb75c7545b9230FEe99b7af370D38eBd3DAD929f7"
+        _account_address_2 = "0x3F198534Bbe3B2a197d3B317d41392F348EAC707"
+        _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
+
+        account = Account()
+        account.issuer_address = _issuer_address
+        db.add(account)
+
+        token = Token()
+        token.type = TokenType.IBET_STRAIGHT_BOND.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        token.version = TokenVersion.V_23_12
+        db.add(token)
+
+        # prepare data: account_address_1
+        idx_position_1 = IDXPosition()
+        idx_position_1.token_address = _token_address
+        idx_position_1.account_address = _account_address_1
+        idx_position_1.balance = 10
+        idx_position_1.exchange_balance = 11
+        idx_position_1.exchange_commitment = 12
+        idx_position_1.pending_transfer = 5
+        idx_position_1.modified = datetime(2023, 10, 24, 0, 0, 0)
+        db.add(idx_position_1)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = _account_address_1
+        idx_personal_info_1.issuer_address = _issuer_address
+        idx_personal_info_1.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(idx_personal_info_1)
+
+        # prepare data: account_address_2
+        idx_position_2 = IDXPosition()
+        idx_position_2.token_address = _token_address
+        idx_position_2.account_address = _account_address_2
+        idx_position_2.balance = 20
+        idx_position_2.exchange_balance = 21
+        idx_position_2.exchange_commitment = 22
+        idx_position_2.pending_transfer = 10
+        idx_position_2.modified = datetime(2023, 10, 24, 2, 0, 0)
+        db.add(idx_position_2)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 20, 0)
+        db.add(idx_locked_position)
+
+        # prepare data: account_address_3
+        idx_position_3 = IDXPosition()
+        idx_position_3.token_address = _token_address
+        idx_position_3.account_address = _account_address_3
+        idx_position_3.balance = 99
+        idx_position_3.exchange_balance = 99
+        idx_position_3.exchange_commitment = 99
+        idx_position_3.pending_transfer = 99
+        idx_position_3.modified = datetime(2023, 10, 24, 3, 0, 0)
+        db.add(idx_position_3)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 4, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 5, 0, 0)
+        db.add(idx_locked_position)
+
+        # Other locked position
+        _locked_position = IDXLockedPosition()
+        _locked_position.token_address = "other_token_address"
+        _locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        _locked_position.account_address = _account_address_1
+        _locked_position.value = 5
+        _locked_position.modified = datetime(2023, 10, 25, 0, 2, 0)
+        db.add(_locked_position)
+
+        idx_personal_info_3 = IDXPersonalInfo()
+        idx_personal_info_3.account_address = _account_address_3
+        idx_personal_info_3.issuer_address = _issuer_address
+        idx_personal_info_3.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test3",
+            "postal_code": "postal_code_test3",
+            "address": "address_test3",
+            "email": "email_test3",
+            "birth": "birth_test3",
+            # PersonalInfo is partially registered.
+        }
+        db.add(idx_personal_info_3)
+
+        db.commit()
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address),
+            headers={"issuer-address": _issuer_address},
+            params={"balance": 20, "balance_operator": 1},
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "result_set": {"count": 2, "total": 3, "offset": None, "limit": None},
+            "holders": [
+                {
+                    "account_address": _account_address_2,
+                    "personal_information": {
+                        "key_manager": None,
+                        "name": None,
+                        "postal_code": None,
+                        "address": None,
+                        "email": None,
+                        "birth": None,
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 20,
+                    "exchange_balance": 21,
+                    "exchange_commitment": 22,
+                    "pending_transfer": 10,
+                    "locked": 20,
+                    "modified": "2023-10-24T02:20:00",
+                },
+                {
+                    "account_address": _account_address_3,
+                    "personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test3",
+                        "postal_code": "postal_code_test3",
+                        "address": "address_test3",
+                        "email": "email_test3",
+                        "birth": "birth_test3",
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 99,
+                    "exchange_balance": 99,
+                    "exchange_commitment": 99,
+                    "pending_transfer": 99,
+                    "locked": 30,
+                    "modified": "2023-10-24T05:00:00",
+                },
+            ],
+        }
+
+    # <Normal_4_2_3>
+    # Search filter: balance & "<="
+    def test_normal_4_2_3(self, client, db):
+        user = config_eth_account("user1")
+        _issuer_address = user["address"]
+        _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
+        _account_address_1 = "0xb75c7545b9230FEe99b7af370D38eBd3DAD929f7"
+        _account_address_2 = "0x3F198534Bbe3B2a197d3B317d41392F348EAC707"
+        _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
+
+        account = Account()
+        account.issuer_address = _issuer_address
+        db.add(account)
+
+        token = Token()
+        token.type = TokenType.IBET_STRAIGHT_BOND.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        token.version = TokenVersion.V_23_12
+        db.add(token)
+
+        # prepare data: account_address_1
+        idx_position_1 = IDXPosition()
+        idx_position_1.token_address = _token_address
+        idx_position_1.account_address = _account_address_1
+        idx_position_1.balance = 10
+        idx_position_1.exchange_balance = 11
+        idx_position_1.exchange_commitment = 12
+        idx_position_1.pending_transfer = 5
+        idx_position_1.modified = datetime(2023, 10, 24, 0, 0, 0)
+        db.add(idx_position_1)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = _account_address_1
+        idx_personal_info_1.issuer_address = _issuer_address
+        idx_personal_info_1.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(idx_personal_info_1)
+
+        # prepare data: account_address_2
+        idx_position_2 = IDXPosition()
+        idx_position_2.token_address = _token_address
+        idx_position_2.account_address = _account_address_2
+        idx_position_2.balance = 20
+        idx_position_2.exchange_balance = 21
+        idx_position_2.exchange_commitment = 22
+        idx_position_2.pending_transfer = 10
+        idx_position_2.modified = datetime(2023, 10, 24, 2, 0, 0)
+        db.add(idx_position_2)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 20, 0)
+        db.add(idx_locked_position)
+
+        # prepare data: account_address_3
+        idx_position_3 = IDXPosition()
+        idx_position_3.token_address = _token_address
+        idx_position_3.account_address = _account_address_3
+        idx_position_3.balance = 99
+        idx_position_3.exchange_balance = 99
+        idx_position_3.exchange_commitment = 99
+        idx_position_3.pending_transfer = 99
+        idx_position_3.modified = datetime(2023, 10, 24, 3, 0, 0)
+        db.add(idx_position_3)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 4, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 5, 0, 0)
+        db.add(idx_locked_position)
+
+        # Other locked position
+        _locked_position = IDXLockedPosition()
+        _locked_position.token_address = "other_token_address"
+        _locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        _locked_position.account_address = _account_address_1
+        _locked_position.value = 5
+        _locked_position.modified = datetime(2023, 10, 25, 0, 2, 0)
+        db.add(_locked_position)
+
+        idx_personal_info_3 = IDXPersonalInfo()
+        idx_personal_info_3.account_address = _account_address_3
+        idx_personal_info_3.issuer_address = _issuer_address
+        idx_personal_info_3.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test3",
+            "postal_code": "postal_code_test3",
+            "address": "address_test3",
+            "email": "email_test3",
+            "birth": "birth_test3",
+            # PersonalInfo is partially registered.
+        }
+        db.add(idx_personal_info_3)
+
+        db.commit()
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address),
+            headers={"issuer-address": _issuer_address},
+            params={"balance": 20, "balance_operator": 2},
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "result_set": {"count": 2, "total": 3, "offset": None, "limit": None},
+            "holders": [
+                {
+                    "account_address": _account_address_1,
+                    "personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test1",
+                        "postal_code": "postal_code_test1",
+                        "address": "address_test1",
+                        "email": "email_test1",
+                        "birth": "birth_test1",
+                        "is_corporate": False,
+                        "tax_category": 10,
+                    },
+                    "balance": 10,
+                    "exchange_balance": 11,
+                    "exchange_commitment": 12,
+                    "pending_transfer": 5,
+                    "locked": 10,
+                    "modified": "2023-10-24T01:10:00",
+                },
+                {
+                    "account_address": _account_address_2,
+                    "personal_information": {
+                        "key_manager": None,
+                        "name": None,
+                        "postal_code": None,
+                        "address": None,
+                        "email": None,
+                        "birth": None,
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 20,
+                    "exchange_balance": 21,
+                    "exchange_commitment": 22,
+                    "pending_transfer": 10,
+                    "locked": 20,
+                    "modified": "2023-10-24T02:20:00",
+                },
+            ],
+        }
+
+    # <Normal_4_3_1>
+    # Search filter: pending_transfer & "="
+    def test_normal_4_3_1(self, client, db):
+        user = config_eth_account("user1")
+        _issuer_address = user["address"]
+        _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
+        _account_address_1 = "0xb75c7545b9230FEe99b7af370D38eBd3DAD929f7"
+        _account_address_2 = "0x3F198534Bbe3B2a197d3B317d41392F348EAC707"
+        _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
+
+        account = Account()
+        account.issuer_address = _issuer_address
+        db.add(account)
+
+        token = Token()
+        token.type = TokenType.IBET_STRAIGHT_BOND.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        token.version = TokenVersion.V_23_12
+        db.add(token)
+
+        # prepare data: account_address_1
+        idx_position_1 = IDXPosition()
+        idx_position_1.token_address = _token_address
+        idx_position_1.account_address = _account_address_1
+        idx_position_1.balance = 10
+        idx_position_1.exchange_balance = 11
+        idx_position_1.exchange_commitment = 12
+        idx_position_1.pending_transfer = 5
+        idx_position_1.modified = datetime(2023, 10, 24, 0, 0, 0)
+        db.add(idx_position_1)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = _account_address_1
+        idx_personal_info_1.issuer_address = _issuer_address
+        idx_personal_info_1.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(idx_personal_info_1)
+
+        # prepare data: account_address_2
+        idx_position_2 = IDXPosition()
+        idx_position_2.token_address = _token_address
+        idx_position_2.account_address = _account_address_2
+        idx_position_2.balance = 20
+        idx_position_2.exchange_balance = 21
+        idx_position_2.exchange_commitment = 22
+        idx_position_2.pending_transfer = 10
+        idx_position_2.modified = datetime(2023, 10, 24, 2, 0, 0)
+        db.add(idx_position_2)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 20, 0)
+        db.add(idx_locked_position)
+
+        # prepare data: account_address_3
+        idx_position_3 = IDXPosition()
+        idx_position_3.token_address = _token_address
+        idx_position_3.account_address = _account_address_3
+        idx_position_3.balance = 99
+        idx_position_3.exchange_balance = 99
+        idx_position_3.exchange_commitment = 99
+        idx_position_3.pending_transfer = 99
+        idx_position_3.modified = datetime(2023, 10, 24, 3, 0, 0)
+        db.add(idx_position_3)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 4, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 5, 0, 0)
+        db.add(idx_locked_position)
+
+        # Other locked position
+        _locked_position = IDXLockedPosition()
+        _locked_position.token_address = "other_token_address"
+        _locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        _locked_position.account_address = _account_address_1
+        _locked_position.value = 5
+        _locked_position.modified = datetime(2023, 10, 25, 0, 2, 0)
+        db.add(_locked_position)
+
+        idx_personal_info_3 = IDXPersonalInfo()
+        idx_personal_info_3.account_address = _account_address_3
+        idx_personal_info_3.issuer_address = _issuer_address
+        idx_personal_info_3.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test3",
+            "postal_code": "postal_code_test3",
+            "address": "address_test3",
+            "email": "email_test3",
+            "birth": "birth_test3",
+            # PersonalInfo is partially registered.
+        }
+        db.add(idx_personal_info_3)
+
+        db.commit()
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address),
+            headers={"issuer-address": _issuer_address},
+            params={"pending_transfer": 10, "pending_transfer_operator": 0},
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "result_set": {"count": 1, "total": 3, "offset": None, "limit": None},
+            "holders": [
+                {
+                    "account_address": _account_address_2,
+                    "personal_information": {
+                        "key_manager": None,
+                        "name": None,
+                        "postal_code": None,
+                        "address": None,
+                        "email": None,
+                        "birth": None,
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 20,
+                    "exchange_balance": 21,
+                    "exchange_commitment": 22,
+                    "pending_transfer": 10,
+                    "locked": 20,
+                    "modified": "2023-10-24T02:20:00",
+                },
+            ],
+        }
+
+    # <Normal_4_3_2>
+    # Search filter: pending_transfer & ">="
+    def test_normal_4_3_2(self, client, db):
+        user = config_eth_account("user1")
+        _issuer_address = user["address"]
+        _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
+        _account_address_1 = "0xb75c7545b9230FEe99b7af370D38eBd3DAD929f7"
+        _account_address_2 = "0x3F198534Bbe3B2a197d3B317d41392F348EAC707"
+        _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
+
+        account = Account()
+        account.issuer_address = _issuer_address
+        db.add(account)
+
+        token = Token()
+        token.type = TokenType.IBET_STRAIGHT_BOND.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        token.version = TokenVersion.V_23_12
+        db.add(token)
+
+        # prepare data: account_address_1
+        idx_position_1 = IDXPosition()
+        idx_position_1.token_address = _token_address
+        idx_position_1.account_address = _account_address_1
+        idx_position_1.balance = 10
+        idx_position_1.exchange_balance = 11
+        idx_position_1.exchange_commitment = 12
+        idx_position_1.pending_transfer = 5
+        idx_position_1.modified = datetime(2023, 10, 24, 0, 0, 0)
+        db.add(idx_position_1)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = _account_address_1
+        idx_personal_info_1.issuer_address = _issuer_address
+        idx_personal_info_1.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(idx_personal_info_1)
+
+        # prepare data: account_address_2
+        idx_position_2 = IDXPosition()
+        idx_position_2.token_address = _token_address
+        idx_position_2.account_address = _account_address_2
+        idx_position_2.balance = 20
+        idx_position_2.exchange_balance = 21
+        idx_position_2.exchange_commitment = 22
+        idx_position_2.pending_transfer = 10
+        idx_position_2.modified = datetime(2023, 10, 24, 2, 0, 0)
+        db.add(idx_position_2)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 20, 0)
+        db.add(idx_locked_position)
+
+        # prepare data: account_address_3
+        idx_position_3 = IDXPosition()
+        idx_position_3.token_address = _token_address
+        idx_position_3.account_address = _account_address_3
+        idx_position_3.balance = 99
+        idx_position_3.exchange_balance = 99
+        idx_position_3.exchange_commitment = 99
+        idx_position_3.pending_transfer = 99
+        idx_position_3.modified = datetime(2023, 10, 24, 3, 0, 0)
+        db.add(idx_position_3)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 4, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 5, 0, 0)
+        db.add(idx_locked_position)
+
+        # Other locked position
+        _locked_position = IDXLockedPosition()
+        _locked_position.token_address = "other_token_address"
+        _locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        _locked_position.account_address = _account_address_1
+        _locked_position.value = 5
+        _locked_position.modified = datetime(2023, 10, 25, 0, 2, 0)
+        db.add(_locked_position)
+
+        idx_personal_info_3 = IDXPersonalInfo()
+        idx_personal_info_3.account_address = _account_address_3
+        idx_personal_info_3.issuer_address = _issuer_address
+        idx_personal_info_3.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test3",
+            "postal_code": "postal_code_test3",
+            "address": "address_test3",
+            "email": "email_test3",
+            "birth": "birth_test3",
+            # PersonalInfo is partially registered.
+        }
+        db.add(idx_personal_info_3)
+
+        db.commit()
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address),
+            headers={"issuer-address": _issuer_address},
+            params={"pending_transfer": 10, "pending_transfer_operator": 1},
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "result_set": {"count": 2, "total": 3, "offset": None, "limit": None},
+            "holders": [
+                {
+                    "account_address": _account_address_2,
+                    "personal_information": {
+                        "key_manager": None,
+                        "name": None,
+                        "postal_code": None,
+                        "address": None,
+                        "email": None,
+                        "birth": None,
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 20,
+                    "exchange_balance": 21,
+                    "exchange_commitment": 22,
+                    "pending_transfer": 10,
+                    "locked": 20,
+                    "modified": "2023-10-24T02:20:00",
+                },
+                {
+                    "account_address": _account_address_3,
+                    "personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test3",
+                        "postal_code": "postal_code_test3",
+                        "address": "address_test3",
+                        "email": "email_test3",
+                        "birth": "birth_test3",
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 99,
+                    "exchange_balance": 99,
+                    "exchange_commitment": 99,
+                    "pending_transfer": 99,
+                    "locked": 30,
+                    "modified": "2023-10-24T05:00:00",
+                },
+            ],
+        }
+
+    # <Normal_4_3_3>
+    # Search filter: pending_transfer & "<="
+    def test_normal_4_3_3(self, client, db):
+        user = config_eth_account("user1")
+        _issuer_address = user["address"]
+        _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
+        _account_address_1 = "0xb75c7545b9230FEe99b7af370D38eBd3DAD929f7"
+        _account_address_2 = "0x3F198534Bbe3B2a197d3B317d41392F348EAC707"
+        _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
+
+        account = Account()
+        account.issuer_address = _issuer_address
+        db.add(account)
+
+        token = Token()
+        token.type = TokenType.IBET_STRAIGHT_BOND.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        token.version = TokenVersion.V_23_12
+        db.add(token)
+
+        # prepare data: account_address_1
+        idx_position_1 = IDXPosition()
+        idx_position_1.token_address = _token_address
+        idx_position_1.account_address = _account_address_1
+        idx_position_1.balance = 10
+        idx_position_1.exchange_balance = 11
+        idx_position_1.exchange_commitment = 12
+        idx_position_1.pending_transfer = 5
+        idx_position_1.modified = datetime(2023, 10, 24, 0, 0, 0)
+        db.add(idx_position_1)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = _account_address_1
+        idx_personal_info_1.issuer_address = _issuer_address
+        idx_personal_info_1.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(idx_personal_info_1)
+
+        # prepare data: account_address_2
+        idx_position_2 = IDXPosition()
+        idx_position_2.token_address = _token_address
+        idx_position_2.account_address = _account_address_2
+        idx_position_2.balance = 20
+        idx_position_2.exchange_balance = 21
+        idx_position_2.exchange_commitment = 22
+        idx_position_2.pending_transfer = 10
+        idx_position_2.modified = datetime(2023, 10, 24, 2, 0, 0)
+        db.add(idx_position_2)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 20, 0)
+        db.add(idx_locked_position)
+
+        # prepare data: account_address_3
+        idx_position_3 = IDXPosition()
+        idx_position_3.token_address = _token_address
+        idx_position_3.account_address = _account_address_3
+        idx_position_3.balance = 99
+        idx_position_3.exchange_balance = 99
+        idx_position_3.exchange_commitment = 99
+        idx_position_3.pending_transfer = 99
+        idx_position_3.modified = datetime(2023, 10, 24, 3, 0, 0)
+        db.add(idx_position_3)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 4, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 5, 0, 0)
+        db.add(idx_locked_position)
+
+        # Other locked position
+        _locked_position = IDXLockedPosition()
+        _locked_position.token_address = "other_token_address"
+        _locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        _locked_position.account_address = _account_address_1
+        _locked_position.value = 5
+        _locked_position.modified = datetime(2023, 10, 25, 0, 2, 0)
+        db.add(_locked_position)
+
+        idx_personal_info_3 = IDXPersonalInfo()
+        idx_personal_info_3.account_address = _account_address_3
+        idx_personal_info_3.issuer_address = _issuer_address
+        idx_personal_info_3.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test3",
+            "postal_code": "postal_code_test3",
+            "address": "address_test3",
+            "email": "email_test3",
+            "birth": "birth_test3",
+            # PersonalInfo is partially registered.
+        }
+        db.add(idx_personal_info_3)
+
+        db.commit()
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address),
+            headers={"issuer-address": _issuer_address},
+            params={"pending_transfer": 10, "pending_transfer_operator": 2},
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "result_set": {"count": 2, "total": 3, "offset": None, "limit": None},
+            "holders": [
+                {
+                    "account_address": _account_address_1,
+                    "personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test1",
+                        "postal_code": "postal_code_test1",
+                        "address": "address_test1",
+                        "email": "email_test1",
+                        "birth": "birth_test1",
+                        "is_corporate": False,
+                        "tax_category": 10,
+                    },
+                    "balance": 10,
+                    "exchange_balance": 11,
+                    "exchange_commitment": 12,
+                    "pending_transfer": 5,
+                    "locked": 10,
+                    "modified": "2023-10-24T01:10:00",
+                },
+                {
+                    "account_address": _account_address_2,
+                    "personal_information": {
+                        "key_manager": None,
+                        "name": None,
+                        "postal_code": None,
+                        "address": None,
+                        "email": None,
+                        "birth": None,
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 20,
+                    "exchange_balance": 21,
+                    "exchange_commitment": 22,
+                    "pending_transfer": 10,
+                    "locked": 20,
+                    "modified": "2023-10-24T02:20:00",
+                },
+            ],
+        }
+
+    # <Normal_4_4_1>
+    # Search filter: locked & "="
+    def test_normal_4_4_1(self, client, db):
+        user = config_eth_account("user1")
+        _issuer_address = user["address"]
+        _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
+        _account_address_1 = "0xb75c7545b9230FEe99b7af370D38eBd3DAD929f7"
+        _account_address_2 = "0x3F198534Bbe3B2a197d3B317d41392F348EAC707"
+        _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
+
+        account = Account()
+        account.issuer_address = _issuer_address
+        db.add(account)
+
+        token = Token()
+        token.type = TokenType.IBET_STRAIGHT_BOND.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        token.version = TokenVersion.V_23_12
+        db.add(token)
+
+        # prepare data: account_address_1
+        idx_position_1 = IDXPosition()
+        idx_position_1.token_address = _token_address
+        idx_position_1.account_address = _account_address_1
+        idx_position_1.balance = 10
+        idx_position_1.exchange_balance = 11
+        idx_position_1.exchange_commitment = 12
+        idx_position_1.pending_transfer = 5
+        idx_position_1.modified = datetime(2023, 10, 24, 0, 0, 0)
+        db.add(idx_position_1)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = _account_address_1
+        idx_personal_info_1.issuer_address = _issuer_address
+        idx_personal_info_1.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(idx_personal_info_1)
+
+        # prepare data: account_address_2
+        idx_position_2 = IDXPosition()
+        idx_position_2.token_address = _token_address
+        idx_position_2.account_address = _account_address_2
+        idx_position_2.balance = 20
+        idx_position_2.exchange_balance = 21
+        idx_position_2.exchange_commitment = 22
+        idx_position_2.pending_transfer = 10
+        idx_position_2.modified = datetime(2023, 10, 24, 2, 0, 0)
+        db.add(idx_position_2)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 20, 0)
+        db.add(idx_locked_position)
+
+        # prepare data: account_address_3
+        idx_position_3 = IDXPosition()
+        idx_position_3.token_address = _token_address
+        idx_position_3.account_address = _account_address_3
+        idx_position_3.balance = 99
+        idx_position_3.exchange_balance = 99
+        idx_position_3.exchange_commitment = 99
+        idx_position_3.pending_transfer = 99
+        idx_position_3.modified = datetime(2023, 10, 24, 3, 0, 0)
+        db.add(idx_position_3)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 4, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 5, 0, 0)
+        db.add(idx_locked_position)
+
+        # Other locked position
+        _locked_position = IDXLockedPosition()
+        _locked_position.token_address = "other_token_address"
+        _locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        _locked_position.account_address = _account_address_1
+        _locked_position.value = 5
+        _locked_position.modified = datetime(2023, 10, 25, 0, 2, 0)
+        db.add(_locked_position)
+
+        idx_personal_info_3 = IDXPersonalInfo()
+        idx_personal_info_3.account_address = _account_address_3
+        idx_personal_info_3.issuer_address = _issuer_address
+        idx_personal_info_3.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test3",
+            "postal_code": "postal_code_test3",
+            "address": "address_test3",
+            "email": "email_test3",
+            "birth": "birth_test3",
+            # PersonalInfo is partially registered.
+        }
+        db.add(idx_personal_info_3)
+
+        db.commit()
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address),
+            headers={"issuer-address": _issuer_address},
+            params={"locked": 20, "locked_operator": 0},
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "result_set": {"count": 1, "total": 3, "offset": None, "limit": None},
+            "holders": [
+                {
+                    "account_address": _account_address_2,
+                    "personal_information": {
+                        "key_manager": None,
+                        "name": None,
+                        "postal_code": None,
+                        "address": None,
+                        "email": None,
+                        "birth": None,
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 20,
+                    "exchange_balance": 21,
+                    "exchange_commitment": 22,
+                    "pending_transfer": 10,
+                    "locked": 20,
+                    "modified": "2023-10-24T02:20:00",
+                },
+            ],
+        }
+
+    # <Normal_4_4_2>
+    # Search filter: locked & ">="
+    def test_normal_4_4_2(self, client, db):
+        user = config_eth_account("user1")
+        _issuer_address = user["address"]
+        _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
+        _account_address_1 = "0xb75c7545b9230FEe99b7af370D38eBd3DAD929f7"
+        _account_address_2 = "0x3F198534Bbe3B2a197d3B317d41392F348EAC707"
+        _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
+
+        account = Account()
+        account.issuer_address = _issuer_address
+        db.add(account)
+
+        token = Token()
+        token.type = TokenType.IBET_STRAIGHT_BOND.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        token.version = TokenVersion.V_23_12
+        db.add(token)
+
+        # prepare data: account_address_1
+        idx_position_1 = IDXPosition()
+        idx_position_1.token_address = _token_address
+        idx_position_1.account_address = _account_address_1
+        idx_position_1.balance = 10
+        idx_position_1.exchange_balance = 11
+        idx_position_1.exchange_commitment = 12
+        idx_position_1.pending_transfer = 5
+        idx_position_1.modified = datetime(2023, 10, 24, 0, 0, 0)
+        db.add(idx_position_1)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = _account_address_1
+        idx_personal_info_1.issuer_address = _issuer_address
+        idx_personal_info_1.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(idx_personal_info_1)
+
+        # prepare data: account_address_2
+        idx_position_2 = IDXPosition()
+        idx_position_2.token_address = _token_address
+        idx_position_2.account_address = _account_address_2
+        idx_position_2.balance = 20
+        idx_position_2.exchange_balance = 21
+        idx_position_2.exchange_commitment = 22
+        idx_position_2.pending_transfer = 10
+        idx_position_2.modified = datetime(2023, 10, 24, 2, 0, 0)
+        db.add(idx_position_2)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 20, 0)
+        db.add(idx_locked_position)
+
+        # prepare data: account_address_3
+        idx_position_3 = IDXPosition()
+        idx_position_3.token_address = _token_address
+        idx_position_3.account_address = _account_address_3
+        idx_position_3.balance = 99
+        idx_position_3.exchange_balance = 99
+        idx_position_3.exchange_commitment = 99
+        idx_position_3.pending_transfer = 99
+        idx_position_3.modified = datetime(2023, 10, 24, 3, 0, 0)
+        db.add(idx_position_3)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 4, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 5, 0, 0)
+        db.add(idx_locked_position)
+
+        # Other locked position
+        _locked_position = IDXLockedPosition()
+        _locked_position.token_address = "other_token_address"
+        _locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        _locked_position.account_address = _account_address_1
+        _locked_position.value = 5
+        _locked_position.modified = datetime(2023, 10, 25, 0, 2, 0)
+        db.add(_locked_position)
+
+        idx_personal_info_3 = IDXPersonalInfo()
+        idx_personal_info_3.account_address = _account_address_3
+        idx_personal_info_3.issuer_address = _issuer_address
+        idx_personal_info_3.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test3",
+            "postal_code": "postal_code_test3",
+            "address": "address_test3",
+            "email": "email_test3",
+            "birth": "birth_test3",
+            # PersonalInfo is partially registered.
+        }
+        db.add(idx_personal_info_3)
+
+        db.commit()
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address),
+            headers={"issuer-address": _issuer_address},
+            params={"locked": 20, "locked_operator": 1},
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "result_set": {"count": 2, "total": 3, "offset": None, "limit": None},
+            "holders": [
+                {
+                    "account_address": _account_address_2,
+                    "personal_information": {
+                        "key_manager": None,
+                        "name": None,
+                        "postal_code": None,
+                        "address": None,
+                        "email": None,
+                        "birth": None,
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 20,
+                    "exchange_balance": 21,
+                    "exchange_commitment": 22,
+                    "pending_transfer": 10,
+                    "locked": 20,
+                    "modified": "2023-10-24T02:20:00",
+                },
+                {
+                    "account_address": _account_address_3,
+                    "personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test3",
+                        "postal_code": "postal_code_test3",
+                        "address": "address_test3",
+                        "email": "email_test3",
+                        "birth": "birth_test3",
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 99,
+                    "exchange_balance": 99,
+                    "exchange_commitment": 99,
+                    "pending_transfer": 99,
+                    "locked": 30,
+                    "modified": "2023-10-24T05:00:00",
+                },
+            ],
+        }
+
+    # <Normal_4_4_3>
+    # Search filter: locked & "<="
+    def test_normal_4_4_3(self, client, db):
+        user = config_eth_account("user1")
+        _issuer_address = user["address"]
+        _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
+        _account_address_1 = "0xb75c7545b9230FEe99b7af370D38eBd3DAD929f7"
+        _account_address_2 = "0x3F198534Bbe3B2a197d3B317d41392F348EAC707"
+        _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
+
+        account = Account()
+        account.issuer_address = _issuer_address
+        db.add(account)
+
+        token = Token()
+        token.type = TokenType.IBET_STRAIGHT_BOND.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        token.version = TokenVersion.V_23_12
+        db.add(token)
+
+        # prepare data: account_address_1
+        idx_position_1 = IDXPosition()
+        idx_position_1.token_address = _token_address
+        idx_position_1.account_address = _account_address_1
+        idx_position_1.balance = 10
+        idx_position_1.exchange_balance = 11
+        idx_position_1.exchange_commitment = 12
+        idx_position_1.pending_transfer = 5
+        idx_position_1.modified = datetime(2023, 10, 24, 0, 0, 0)
+        db.add(idx_position_1)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = _account_address_1
+        idx_personal_info_1.issuer_address = _issuer_address
+        idx_personal_info_1.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(idx_personal_info_1)
+
+        # prepare data: account_address_2
+        idx_position_2 = IDXPosition()
+        idx_position_2.token_address = _token_address
+        idx_position_2.account_address = _account_address_2
+        idx_position_2.balance = 20
+        idx_position_2.exchange_balance = 21
+        idx_position_2.exchange_commitment = 22
+        idx_position_2.pending_transfer = 10
+        idx_position_2.modified = datetime(2023, 10, 24, 2, 0, 0)
+        db.add(idx_position_2)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 20, 0)
+        db.add(idx_locked_position)
+
+        # prepare data: account_address_3
+        idx_position_3 = IDXPosition()
+        idx_position_3.token_address = _token_address
+        idx_position_3.account_address = _account_address_3
+        idx_position_3.balance = 99
+        idx_position_3.exchange_balance = 99
+        idx_position_3.exchange_commitment = 99
+        idx_position_3.pending_transfer = 99
+        idx_position_3.modified = datetime(2023, 10, 24, 3, 0, 0)
+        db.add(idx_position_3)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 4, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 5, 0, 0)
+        db.add(idx_locked_position)
+
+        # Other locked position
+        _locked_position = IDXLockedPosition()
+        _locked_position.token_address = "other_token_address"
+        _locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        _locked_position.account_address = _account_address_1
+        _locked_position.value = 5
+        _locked_position.modified = datetime(2023, 10, 25, 0, 2, 0)
+        db.add(_locked_position)
+
+        idx_personal_info_3 = IDXPersonalInfo()
+        idx_personal_info_3.account_address = _account_address_3
+        idx_personal_info_3.issuer_address = _issuer_address
+        idx_personal_info_3.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test3",
+            "postal_code": "postal_code_test3",
+            "address": "address_test3",
+            "email": "email_test3",
+            "birth": "birth_test3",
+            # PersonalInfo is partially registered.
+        }
+        db.add(idx_personal_info_3)
+
+        db.commit()
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address),
+            headers={"issuer-address": _issuer_address},
+            params={"locked": 20, "locked_operator": 2},
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "result_set": {"count": 2, "total": 3, "offset": None, "limit": None},
+            "holders": [
+                {
+                    "account_address": _account_address_1,
+                    "personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test1",
+                        "postal_code": "postal_code_test1",
+                        "address": "address_test1",
+                        "email": "email_test1",
+                        "birth": "birth_test1",
+                        "is_corporate": False,
+                        "tax_category": 10,
+                    },
+                    "balance": 10,
+                    "exchange_balance": 11,
+                    "exchange_commitment": 12,
+                    "pending_transfer": 5,
+                    "locked": 10,
+                    "modified": "2023-10-24T01:10:00",
+                },
+                {
+                    "account_address": _account_address_2,
+                    "personal_information": {
+                        "key_manager": None,
+                        "name": None,
+                        "postal_code": None,
+                        "address": None,
+                        "email": None,
+                        "birth": None,
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 20,
+                    "exchange_balance": 21,
+                    "exchange_commitment": 22,
+                    "pending_transfer": 10,
+                    "locked": 20,
+                    "modified": "2023-10-24T02:20:00",
+                },
+            ],
+        }
+
+    # <Normal_4_5>
+    # Search filter: holder_name
+    def test_normal_4_5(self, client, db):
+        user = config_eth_account("user1")
+        _issuer_address = user["address"]
+        _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
+        _account_address_1 = "0xb75c7545b9230FEe99b7af370D38eBd3DAD929f7"
+        _account_address_2 = "0x3F198534Bbe3B2a197d3B317d41392F348EAC707"
+        _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
+
+        account = Account()
+        account.issuer_address = _issuer_address
+        db.add(account)
+
+        token = Token()
+        token.type = TokenType.IBET_STRAIGHT_BOND.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        token.version = TokenVersion.V_23_12
+        db.add(token)
+
+        # prepare data: account_address_1
+        idx_position_1 = IDXPosition()
+        idx_position_1.token_address = _token_address
+        idx_position_1.account_address = _account_address_1
+        idx_position_1.balance = 10
+        idx_position_1.exchange_balance = 11
+        idx_position_1.exchange_commitment = 12
+        idx_position_1.pending_transfer = 5
+        idx_position_1.modified = datetime(2023, 10, 24, 0, 0, 0)
+        db.add(idx_position_1)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = _account_address_1
+        idx_personal_info_1.issuer_address = _issuer_address
+        idx_personal_info_1.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(idx_personal_info_1)
+
+        # prepare data: account_address_2
+        idx_position_2 = IDXPosition()
+        idx_position_2.token_address = _token_address
+        idx_position_2.account_address = _account_address_2
+        idx_position_2.balance = 20
+        idx_position_2.exchange_balance = 21
+        idx_position_2.exchange_commitment = 22
+        idx_position_2.pending_transfer = 10
+        idx_position_2.modified = datetime(2023, 10, 24, 2, 0, 0)
+        db.add(idx_position_2)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 20, 0)
+        db.add(idx_locked_position)
+
+        # prepare data: account_address_3
+        idx_position_3 = IDXPosition()
+        idx_position_3.token_address = _token_address
+        idx_position_3.account_address = _account_address_3
+        idx_position_3.balance = 99
+        idx_position_3.exchange_balance = 99
+        idx_position_3.exchange_commitment = 99
+        idx_position_3.pending_transfer = 99
+        idx_position_3.modified = datetime(2023, 10, 24, 3, 0, 0)
+        db.add(idx_position_3)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 4, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 5, 0, 0)
+        db.add(idx_locked_position)
+
+        # Other locked position
+        _locked_position = IDXLockedPosition()
+        _locked_position.token_address = "other_token_address"
+        _locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        _locked_position.account_address = _account_address_1
+        _locked_position.value = 5
+        _locked_position.modified = datetime(2023, 10, 25, 0, 2, 0)
+        db.add(_locked_position)
+
+        idx_personal_info_3 = IDXPersonalInfo()
+        idx_personal_info_3.account_address = _account_address_3
+        idx_personal_info_3.issuer_address = _issuer_address
+        idx_personal_info_3.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test3",
+            "postal_code": "postal_code_test3",
+            "address": "address_test3",
+            "email": "email_test3",
+            "birth": "birth_test3",
+            # PersonalInfo is partially registered.
+        }
+        db.add(idx_personal_info_3)
+
+        db.commit()
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address),
+            headers={"issuer-address": _issuer_address},
+            params={"holder_name": "test3"},
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "result_set": {"count": 1, "total": 3, "offset": None, "limit": None},
+            "holders": [
+                {
+                    "account_address": _account_address_3,
+                    "personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test3",
+                        "postal_code": "postal_code_test3",
+                        "address": "address_test3",
+                        "email": "email_test3",
+                        "birth": "birth_test3",
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 99,
+                    "exchange_balance": 99,
+                    "exchange_commitment": 99,
+                    "pending_transfer": 99,
+                    "locked": 30,
+                    "modified": "2023-10-24T05:00:00",
+                },
+            ],
+        }
+
+    # <Normal_5_1>
+    # Sort Item: created
+    def test_normal_5_1(self, client, db):
+        user = config_eth_account("user1")
+        _issuer_address = user["address"]
+        _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
+        _account_address_1 = "0xb75c7545b9230FEe99b7af370D38eBd3DAD929f7"
+        _account_address_2 = "0x3F198534Bbe3B2a197d3B317d41392F348EAC707"
+        _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
+
+        account = Account()
+        account.issuer_address = _issuer_address
+        db.add(account)
+
+        token = Token()
+        token.type = TokenType.IBET_STRAIGHT_BOND.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        token.version = TokenVersion.V_23_12
+        db.add(token)
+
+        # prepare data: account_address_1
+        idx_position_1 = IDXPosition()
+        idx_position_1.token_address = _token_address
+        idx_position_1.account_address = _account_address_1
+        idx_position_1.balance = 10
+        idx_position_1.exchange_balance = 11
+        idx_position_1.exchange_commitment = 12
+        idx_position_1.pending_transfer = 5
+        idx_position_1.created = datetime(2023, 10, 24, 0, 0, 0)
+        idx_position_1.modified = datetime(2023, 10, 24, 0, 0, 0)
+        db.add(idx_position_1)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = _account_address_1
+        idx_personal_info_1.issuer_address = _issuer_address
+        idx_personal_info_1.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(idx_personal_info_1)
+
+        # prepare data: account_address_2
+        idx_position_2 = IDXPosition()
+        idx_position_2.token_address = _token_address
+        idx_position_2.account_address = _account_address_2
+        idx_position_2.balance = 20
+        idx_position_2.exchange_balance = 21
+        idx_position_2.exchange_commitment = 22
+        idx_position_2.pending_transfer = 10
+        idx_position_2.created = datetime(2023, 10, 24, 2, 0, 0)
+        idx_position_2.modified = datetime(2023, 10, 24, 2, 0, 0)
+        db.add(idx_position_2)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 20, 0)
+        db.add(idx_locked_position)
+
+        # prepare data: account_address_3
+        idx_position_3 = IDXPosition()
+        idx_position_3.token_address = _token_address
+        idx_position_3.account_address = _account_address_3
+        idx_position_3.balance = 99
+        idx_position_3.exchange_balance = 99
+        idx_position_3.exchange_commitment = 99
+        idx_position_3.pending_transfer = 99
+        idx_position_3.created = datetime(2023, 10, 24, 3, 0, 0)
+        idx_position_3.modified = datetime(2023, 10, 24, 3, 0, 0)
+        db.add(idx_position_3)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 4, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 5, 0, 0)
+        db.add(idx_locked_position)
+
+        # Other locked position
+        _locked_position = IDXLockedPosition()
+        _locked_position.token_address = "other_token_address"
+        _locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        _locked_position.account_address = _account_address_1
+        _locked_position.value = 5
+        _locked_position.modified = datetime(2023, 10, 25, 0, 2, 0)
+        db.add(_locked_position)
+
+        idx_personal_info_3 = IDXPersonalInfo()
+        idx_personal_info_3.account_address = _account_address_3
+        idx_personal_info_3.issuer_address = _issuer_address
+        idx_personal_info_3.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test3",
+            "postal_code": "postal_code_test3",
+            "address": "address_test3",
+            "email": "email_test3",
+            "birth": "birth_test3",
+            # PersonalInfo is partially registered.
+        }
+        db.add(idx_personal_info_3)
+
+        db.commit()
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address),
+            headers={"issuer-address": _issuer_address},
+            params={"sort_order": 1, "sort_item": "created"},
         )
 
         # assertion
@@ -945,9 +2980,1174 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             ],
         }
 
-    # <Normal_5_1>
+    # <Normal_5_2>
+    # Sort Item: account_address
+    def test_normal_5_2(self, client, db):
+        user = config_eth_account("user1")
+        _issuer_address = user["address"]
+        _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
+        _account_address_1 = "0xb75c7545b9230FEe99b7af370D38eBd3DAD929f7"
+        _account_address_2 = "0x3F198534Bbe3B2a197d3B317d41392F348EAC707"
+        _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
+
+        account = Account()
+        account.issuer_address = _issuer_address
+        db.add(account)
+
+        token = Token()
+        token.type = TokenType.IBET_STRAIGHT_BOND.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        token.version = TokenVersion.V_23_12
+        db.add(token)
+
+        # prepare data: account_address_1
+        idx_position_1 = IDXPosition()
+        idx_position_1.token_address = _token_address
+        idx_position_1.account_address = _account_address_1
+        idx_position_1.balance = 10
+        idx_position_1.exchange_balance = 11
+        idx_position_1.exchange_commitment = 12
+        idx_position_1.pending_transfer = 5
+        idx_position_1.created = datetime(2023, 10, 24, 0, 0, 0)
+        idx_position_1.modified = datetime(2023, 10, 24, 0, 0, 0)
+        db.add(idx_position_1)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = _account_address_1
+        idx_personal_info_1.issuer_address = _issuer_address
+        idx_personal_info_1.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(idx_personal_info_1)
+
+        # prepare data: account_address_2
+        idx_position_2 = IDXPosition()
+        idx_position_2.token_address = _token_address
+        idx_position_2.account_address = _account_address_2
+        idx_position_2.balance = 20
+        idx_position_2.exchange_balance = 21
+        idx_position_2.exchange_commitment = 22
+        idx_position_2.pending_transfer = 10
+        idx_position_2.created = datetime(2023, 10, 24, 2, 0, 0)
+        idx_position_2.modified = datetime(2023, 10, 24, 2, 0, 0)
+        db.add(idx_position_2)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 20, 0)
+        db.add(idx_locked_position)
+
+        # prepare data: account_address_3
+        idx_position_3 = IDXPosition()
+        idx_position_3.token_address = _token_address
+        idx_position_3.account_address = _account_address_3
+        idx_position_3.balance = 99
+        idx_position_3.exchange_balance = 99
+        idx_position_3.exchange_commitment = 99
+        idx_position_3.pending_transfer = 99
+        idx_position_3.created = datetime(2023, 10, 24, 3, 0, 0)
+        idx_position_3.modified = datetime(2023, 10, 24, 3, 0, 0)
+        db.add(idx_position_3)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 4, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 5, 0, 0)
+        db.add(idx_locked_position)
+
+        # Other locked position
+        _locked_position = IDXLockedPosition()
+        _locked_position.token_address = "other_token_address"
+        _locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        _locked_position.account_address = _account_address_1
+        _locked_position.value = 5
+        _locked_position.modified = datetime(2023, 10, 25, 0, 2, 0)
+        db.add(_locked_position)
+
+        idx_personal_info_3 = IDXPersonalInfo()
+        idx_personal_info_3.account_address = _account_address_3
+        idx_personal_info_3.issuer_address = _issuer_address
+        idx_personal_info_3.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test3",
+            "postal_code": "postal_code_test3",
+            "address": "address_test3",
+            "email": "email_test3",
+            "birth": "birth_test3",
+            # PersonalInfo is partially registered.
+        }
+        db.add(idx_personal_info_3)
+
+        db.commit()
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address),
+            headers={"issuer-address": _issuer_address},
+            params={"sort_order": 0, "sort_item": "account_address"},
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "result_set": {"count": 3, "total": 3, "offset": None, "limit": None},
+            "holders": [
+                {
+                    "account_address": _account_address_2,
+                    "personal_information": {
+                        "key_manager": None,
+                        "name": None,
+                        "postal_code": None,
+                        "address": None,
+                        "email": None,
+                        "birth": None,
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 20,
+                    "exchange_balance": 21,
+                    "exchange_commitment": 22,
+                    "pending_transfer": 10,
+                    "locked": 20,
+                    "modified": "2023-10-24T02:20:00",
+                },
+                {
+                    "account_address": _account_address_3,
+                    "personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test3",
+                        "postal_code": "postal_code_test3",
+                        "address": "address_test3",
+                        "email": "email_test3",
+                        "birth": "birth_test3",
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 99,
+                    "exchange_balance": 99,
+                    "exchange_commitment": 99,
+                    "pending_transfer": 99,
+                    "locked": 30,
+                    "modified": "2023-10-24T05:00:00",
+                },
+                {
+                    "account_address": _account_address_1,
+                    "personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test1",
+                        "postal_code": "postal_code_test1",
+                        "address": "address_test1",
+                        "email": "email_test1",
+                        "birth": "birth_test1",
+                        "is_corporate": False,
+                        "tax_category": 10,
+                    },
+                    "balance": 10,
+                    "exchange_balance": 11,
+                    "exchange_commitment": 12,
+                    "pending_transfer": 5,
+                    "locked": 10,
+                    "modified": "2023-10-24T01:10:00",
+                },
+            ],
+        }
+
+    # <Normal_5_3>
+    # Sort Item: balance
+    def test_normal_5_3(self, client, db):
+        user = config_eth_account("user1")
+        _issuer_address = user["address"]
+        _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
+        _account_address_1 = "0xb75c7545b9230FEe99b7af370D38eBd3DAD929f7"
+        _account_address_2 = "0x3F198534Bbe3B2a197d3B317d41392F348EAC707"
+        _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
+
+        account = Account()
+        account.issuer_address = _issuer_address
+        db.add(account)
+
+        token = Token()
+        token.type = TokenType.IBET_STRAIGHT_BOND.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        token.version = TokenVersion.V_23_12
+        db.add(token)
+
+        # prepare data: account_address_1
+        idx_position_1 = IDXPosition()
+        idx_position_1.token_address = _token_address
+        idx_position_1.account_address = _account_address_1
+        idx_position_1.balance = 10
+        idx_position_1.exchange_balance = 11
+        idx_position_1.exchange_commitment = 12
+        idx_position_1.pending_transfer = 5
+        idx_position_1.created = datetime(2023, 10, 24, 0, 0, 0)
+        idx_position_1.modified = datetime(2023, 10, 24, 0, 0, 0)
+        db.add(idx_position_1)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = _account_address_1
+        idx_personal_info_1.issuer_address = _issuer_address
+        idx_personal_info_1.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(idx_personal_info_1)
+
+        # prepare data: account_address_2
+        idx_position_2 = IDXPosition()
+        idx_position_2.token_address = _token_address
+        idx_position_2.account_address = _account_address_2
+        idx_position_2.balance = 20
+        idx_position_2.exchange_balance = 21
+        idx_position_2.exchange_commitment = 22
+        idx_position_2.pending_transfer = 10
+        idx_position_2.created = datetime(2023, 10, 24, 2, 0, 0)
+        idx_position_2.modified = datetime(2023, 10, 24, 2, 0, 0)
+        db.add(idx_position_2)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 20, 0)
+        db.add(idx_locked_position)
+
+        # prepare data: account_address_3
+        idx_position_3 = IDXPosition()
+        idx_position_3.token_address = _token_address
+        idx_position_3.account_address = _account_address_3
+        idx_position_3.balance = 99
+        idx_position_3.exchange_balance = 99
+        idx_position_3.exchange_commitment = 99
+        idx_position_3.pending_transfer = 99
+        idx_position_3.created = datetime(2023, 10, 24, 3, 0, 0)
+        idx_position_3.modified = datetime(2023, 10, 24, 3, 0, 0)
+        db.add(idx_position_3)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 4, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 5, 0, 0)
+        db.add(idx_locked_position)
+
+        # Other locked position
+        _locked_position = IDXLockedPosition()
+        _locked_position.token_address = "other_token_address"
+        _locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        _locked_position.account_address = _account_address_1
+        _locked_position.value = 5
+        _locked_position.modified = datetime(2023, 10, 25, 0, 2, 0)
+        db.add(_locked_position)
+
+        idx_personal_info_3 = IDXPersonalInfo()
+        idx_personal_info_3.account_address = _account_address_3
+        idx_personal_info_3.issuer_address = _issuer_address
+        idx_personal_info_3.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test3",
+            "postal_code": "postal_code_test3",
+            "address": "address_test3",
+            "email": "email_test3",
+            "birth": "birth_test3",
+            # PersonalInfo is partially registered.
+        }
+        db.add(idx_personal_info_3)
+
+        db.commit()
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address),
+            headers={"issuer-address": _issuer_address},
+            params={"sort_order": 1, "sort_item": "balance"},
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "result_set": {"count": 3, "total": 3, "offset": None, "limit": None},
+            "holders": [
+                {
+                    "account_address": _account_address_3,
+                    "personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test3",
+                        "postal_code": "postal_code_test3",
+                        "address": "address_test3",
+                        "email": "email_test3",
+                        "birth": "birth_test3",
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 99,
+                    "exchange_balance": 99,
+                    "exchange_commitment": 99,
+                    "pending_transfer": 99,
+                    "locked": 30,
+                    "modified": "2023-10-24T05:00:00",
+                },
+                {
+                    "account_address": _account_address_2,
+                    "personal_information": {
+                        "key_manager": None,
+                        "name": None,
+                        "postal_code": None,
+                        "address": None,
+                        "email": None,
+                        "birth": None,
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 20,
+                    "exchange_balance": 21,
+                    "exchange_commitment": 22,
+                    "pending_transfer": 10,
+                    "locked": 20,
+                    "modified": "2023-10-24T02:20:00",
+                },
+                {
+                    "account_address": _account_address_1,
+                    "personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test1",
+                        "postal_code": "postal_code_test1",
+                        "address": "address_test1",
+                        "email": "email_test1",
+                        "birth": "birth_test1",
+                        "is_corporate": False,
+                        "tax_category": 10,
+                    },
+                    "balance": 10,
+                    "exchange_balance": 11,
+                    "exchange_commitment": 12,
+                    "pending_transfer": 5,
+                    "locked": 10,
+                    "modified": "2023-10-24T01:10:00",
+                },
+            ],
+        }
+
+    # <Normal_5_4>
+    # Sort Item: pending_transfer
+    def test_normal_5_4(self, client, db):
+        user = config_eth_account("user1")
+        _issuer_address = user["address"]
+        _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
+        _account_address_1 = "0xb75c7545b9230FEe99b7af370D38eBd3DAD929f7"
+        _account_address_2 = "0x3F198534Bbe3B2a197d3B317d41392F348EAC707"
+        _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
+
+        account = Account()
+        account.issuer_address = _issuer_address
+        db.add(account)
+
+        token = Token()
+        token.type = TokenType.IBET_STRAIGHT_BOND.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        token.version = TokenVersion.V_23_12
+        db.add(token)
+
+        # prepare data: account_address_1
+        idx_position_1 = IDXPosition()
+        idx_position_1.token_address = _token_address
+        idx_position_1.account_address = _account_address_1
+        idx_position_1.balance = 10
+        idx_position_1.exchange_balance = 11
+        idx_position_1.exchange_commitment = 12
+        idx_position_1.pending_transfer = 5
+        idx_position_1.created = datetime(2023, 10, 24, 0, 0, 0)
+        idx_position_1.modified = datetime(2023, 10, 24, 0, 0, 0)
+        db.add(idx_position_1)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = _account_address_1
+        idx_personal_info_1.issuer_address = _issuer_address
+        idx_personal_info_1.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(idx_personal_info_1)
+
+        # prepare data: account_address_2
+        idx_position_2 = IDXPosition()
+        idx_position_2.token_address = _token_address
+        idx_position_2.account_address = _account_address_2
+        idx_position_2.balance = 20
+        idx_position_2.exchange_balance = 21
+        idx_position_2.exchange_commitment = 22
+        idx_position_2.pending_transfer = 10
+        idx_position_2.created = datetime(2023, 10, 24, 2, 0, 0)
+        idx_position_2.modified = datetime(2023, 10, 24, 2, 0, 0)
+        db.add(idx_position_2)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 20, 0)
+        db.add(idx_locked_position)
+
+        # prepare data: account_address_3
+        idx_position_3 = IDXPosition()
+        idx_position_3.token_address = _token_address
+        idx_position_3.account_address = _account_address_3
+        idx_position_3.balance = 99
+        idx_position_3.exchange_balance = 99
+        idx_position_3.exchange_commitment = 99
+        idx_position_3.pending_transfer = 99
+        idx_position_3.created = datetime(2023, 10, 24, 3, 0, 0)
+        idx_position_3.modified = datetime(2023, 10, 24, 3, 0, 0)
+        db.add(idx_position_3)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 4, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 5, 0, 0)
+        db.add(idx_locked_position)
+
+        # Other locked position
+        _locked_position = IDXLockedPosition()
+        _locked_position.token_address = "other_token_address"
+        _locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        _locked_position.account_address = _account_address_1
+        _locked_position.value = 5
+        _locked_position.modified = datetime(2023, 10, 25, 0, 2, 0)
+        db.add(_locked_position)
+
+        idx_personal_info_3 = IDXPersonalInfo()
+        idx_personal_info_3.account_address = _account_address_3
+        idx_personal_info_3.issuer_address = _issuer_address
+        idx_personal_info_3.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test3",
+            "postal_code": "postal_code_test3",
+            "address": "address_test3",
+            "email": "email_test3",
+            "birth": "birth_test3",
+            # PersonalInfo is partially registered.
+        }
+        db.add(idx_personal_info_3)
+
+        db.commit()
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address),
+            headers={"issuer-address": _issuer_address},
+            params={"sort_order": 1, "sort_item": "pending_transfer"},
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "result_set": {"count": 3, "total": 3, "offset": None, "limit": None},
+            "holders": [
+                {
+                    "account_address": _account_address_3,
+                    "personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test3",
+                        "postal_code": "postal_code_test3",
+                        "address": "address_test3",
+                        "email": "email_test3",
+                        "birth": "birth_test3",
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 99,
+                    "exchange_balance": 99,
+                    "exchange_commitment": 99,
+                    "pending_transfer": 99,
+                    "locked": 30,
+                    "modified": "2023-10-24T05:00:00",
+                },
+                {
+                    "account_address": _account_address_2,
+                    "personal_information": {
+                        "key_manager": None,
+                        "name": None,
+                        "postal_code": None,
+                        "address": None,
+                        "email": None,
+                        "birth": None,
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 20,
+                    "exchange_balance": 21,
+                    "exchange_commitment": 22,
+                    "pending_transfer": 10,
+                    "locked": 20,
+                    "modified": "2023-10-24T02:20:00",
+                },
+                {
+                    "account_address": _account_address_1,
+                    "personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test1",
+                        "postal_code": "postal_code_test1",
+                        "address": "address_test1",
+                        "email": "email_test1",
+                        "birth": "birth_test1",
+                        "is_corporate": False,
+                        "tax_category": 10,
+                    },
+                    "balance": 10,
+                    "exchange_balance": 11,
+                    "exchange_commitment": 12,
+                    "pending_transfer": 5,
+                    "locked": 10,
+                    "modified": "2023-10-24T01:10:00",
+                },
+            ],
+        }
+
+    # <Normal_5_5>
+    # Sort Item: locked
+    def test_normal_5_5(self, client, db):
+        user = config_eth_account("user1")
+        _issuer_address = user["address"]
+        _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
+        _account_address_1 = "0xb75c7545b9230FEe99b7af370D38eBd3DAD929f7"
+        _account_address_2 = "0x3F198534Bbe3B2a197d3B317d41392F348EAC707"
+        _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
+
+        account = Account()
+        account.issuer_address = _issuer_address
+        db.add(account)
+
+        token = Token()
+        token.type = TokenType.IBET_STRAIGHT_BOND.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        token.version = TokenVersion.V_23_12
+        db.add(token)
+
+        # prepare data: account_address_1
+        idx_position_1 = IDXPosition()
+        idx_position_1.token_address = _token_address
+        idx_position_1.account_address = _account_address_1
+        idx_position_1.balance = 10
+        idx_position_1.exchange_balance = 11
+        idx_position_1.exchange_commitment = 12
+        idx_position_1.pending_transfer = 5
+        idx_position_1.created = datetime(2023, 10, 24, 0, 0, 0)
+        idx_position_1.modified = datetime(2023, 10, 24, 0, 0, 0)
+        db.add(idx_position_1)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = _account_address_1
+        idx_personal_info_1.issuer_address = _issuer_address
+        idx_personal_info_1.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(idx_personal_info_1)
+
+        # prepare data: account_address_2
+        idx_position_2 = IDXPosition()
+        idx_position_2.token_address = _token_address
+        idx_position_2.account_address = _account_address_2
+        idx_position_2.balance = 20
+        idx_position_2.exchange_balance = 21
+        idx_position_2.exchange_commitment = 22
+        idx_position_2.pending_transfer = 10
+        idx_position_2.created = datetime(2023, 10, 24, 2, 0, 0)
+        idx_position_2.modified = datetime(2023, 10, 24, 2, 0, 0)
+        db.add(idx_position_2)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 20, 0)
+        db.add(idx_locked_position)
+
+        # prepare data: account_address_3
+        idx_position_3 = IDXPosition()
+        idx_position_3.token_address = _token_address
+        idx_position_3.account_address = _account_address_3
+        idx_position_3.balance = 99
+        idx_position_3.exchange_balance = 99
+        idx_position_3.exchange_commitment = 99
+        idx_position_3.pending_transfer = 99
+        idx_position_3.created = datetime(2023, 10, 24, 3, 0, 0)
+        idx_position_3.modified = datetime(2023, 10, 24, 3, 0, 0)
+        db.add(idx_position_3)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 4, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 5, 0, 0)
+        db.add(idx_locked_position)
+
+        # Other locked position
+        _locked_position = IDXLockedPosition()
+        _locked_position.token_address = "other_token_address"
+        _locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        _locked_position.account_address = _account_address_1
+        _locked_position.value = 5
+        _locked_position.modified = datetime(2023, 10, 25, 0, 2, 0)
+        db.add(_locked_position)
+
+        idx_personal_info_3 = IDXPersonalInfo()
+        idx_personal_info_3.account_address = _account_address_3
+        idx_personal_info_3.issuer_address = _issuer_address
+        idx_personal_info_3.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test3",
+            "postal_code": "postal_code_test3",
+            "address": "address_test3",
+            "email": "email_test3",
+            "birth": "birth_test3",
+            # PersonalInfo is partially registered.
+        }
+        db.add(idx_personal_info_3)
+
+        db.commit()
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address),
+            headers={"issuer-address": _issuer_address},
+            params={"sort_order": 1, "sort_item": "locked"},
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "result_set": {"count": 3, "total": 3, "offset": None, "limit": None},
+            "holders": [
+                {
+                    "account_address": _account_address_3,
+                    "personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test3",
+                        "postal_code": "postal_code_test3",
+                        "address": "address_test3",
+                        "email": "email_test3",
+                        "birth": "birth_test3",
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 99,
+                    "exchange_balance": 99,
+                    "exchange_commitment": 99,
+                    "pending_transfer": 99,
+                    "locked": 30,
+                    "modified": "2023-10-24T05:00:00",
+                },
+                {
+                    "account_address": _account_address_2,
+                    "personal_information": {
+                        "key_manager": None,
+                        "name": None,
+                        "postal_code": None,
+                        "address": None,
+                        "email": None,
+                        "birth": None,
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 20,
+                    "exchange_balance": 21,
+                    "exchange_commitment": 22,
+                    "pending_transfer": 10,
+                    "locked": 20,
+                    "modified": "2023-10-24T02:20:00",
+                },
+                {
+                    "account_address": _account_address_1,
+                    "personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test1",
+                        "postal_code": "postal_code_test1",
+                        "address": "address_test1",
+                        "email": "email_test1",
+                        "birth": "birth_test1",
+                        "is_corporate": False,
+                        "tax_category": 10,
+                    },
+                    "balance": 10,
+                    "exchange_balance": 11,
+                    "exchange_commitment": 12,
+                    "pending_transfer": 5,
+                    "locked": 10,
+                    "modified": "2023-10-24T01:10:00",
+                },
+            ],
+        }
+
+    # <Normal_5_6>
+    # Sort Item: holder_name
+    def test_normal_5_6(self, client, db):
+        user = config_eth_account("user1")
+        _issuer_address = user["address"]
+        _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
+        _account_address_1 = "0xb75c7545b9230FEe99b7af370D38eBd3DAD929f7"
+        _account_address_2 = "0x3F198534Bbe3B2a197d3B317d41392F348EAC707"
+        _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
+
+        account = Account()
+        account.issuer_address = _issuer_address
+        db.add(account)
+
+        token = Token()
+        token.type = TokenType.IBET_STRAIGHT_BOND.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        token.version = TokenVersion.V_23_12
+        db.add(token)
+
+        # prepare data: account_address_1
+        idx_position_1 = IDXPosition()
+        idx_position_1.token_address = _token_address
+        idx_position_1.account_address = _account_address_1
+        idx_position_1.balance = 10
+        idx_position_1.exchange_balance = 11
+        idx_position_1.exchange_commitment = 12
+        idx_position_1.pending_transfer = 5
+        idx_position_1.created = datetime(2023, 10, 24, 0, 0, 0)
+        idx_position_1.modified = datetime(2023, 10, 24, 0, 0, 0)
+        db.add(idx_position_1)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = _account_address_1
+        idx_personal_info_1.issuer_address = _issuer_address
+        idx_personal_info_1.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(idx_personal_info_1)
+
+        # prepare data: account_address_2
+        idx_position_2 = IDXPosition()
+        idx_position_2.token_address = _token_address
+        idx_position_2.account_address = _account_address_2
+        idx_position_2.balance = 20
+        idx_position_2.exchange_balance = 21
+        idx_position_2.exchange_commitment = 22
+        idx_position_2.pending_transfer = 10
+        idx_position_2.created = datetime(2023, 10, 24, 2, 0, 0)
+        idx_position_2.modified = datetime(2023, 10, 24, 2, 0, 0)
+        db.add(idx_position_2)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 20, 0)
+        db.add(idx_locked_position)
+
+        # prepare data: account_address_3
+        idx_position_3 = IDXPosition()
+        idx_position_3.token_address = _token_address
+        idx_position_3.account_address = _account_address_3
+        idx_position_3.balance = 99
+        idx_position_3.exchange_balance = 99
+        idx_position_3.exchange_commitment = 99
+        idx_position_3.pending_transfer = 99
+        idx_position_3.created = datetime(2023, 10, 24, 3, 0, 0)
+        idx_position_3.modified = datetime(2023, 10, 24, 3, 0, 0)
+        db.add(idx_position_3)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 4, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 5, 0, 0)
+        db.add(idx_locked_position)
+
+        # Other locked position
+        _locked_position = IDXLockedPosition()
+        _locked_position.token_address = "other_token_address"
+        _locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        _locked_position.account_address = _account_address_1
+        _locked_position.value = 5
+        _locked_position.modified = datetime(2023, 10, 25, 0, 2, 0)
+        db.add(_locked_position)
+
+        idx_personal_info_3 = IDXPersonalInfo()
+        idx_personal_info_3.account_address = _account_address_3
+        idx_personal_info_3.issuer_address = _issuer_address
+        idx_personal_info_3.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test3",
+            "postal_code": "postal_code_test3",
+            "address": "address_test3",
+            "email": "email_test3",
+            "birth": "birth_test3",
+            # PersonalInfo is partially registered.
+        }
+        db.add(idx_personal_info_3)
+
+        db.commit()
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address),
+            headers={"issuer-address": _issuer_address},
+            params={"sort_order": 1, "sort_item": "holder_name"},
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "result_set": {"count": 3, "total": 3, "offset": None, "limit": None},
+            "holders": [
+                {
+                    "account_address": _account_address_2,
+                    "personal_information": {
+                        "key_manager": None,
+                        "name": None,
+                        "postal_code": None,
+                        "address": None,
+                        "email": None,
+                        "birth": None,
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 20,
+                    "exchange_balance": 21,
+                    "exchange_commitment": 22,
+                    "pending_transfer": 10,
+                    "locked": 20,
+                    "modified": "2023-10-24T02:20:00",
+                },
+                {
+                    "account_address": _account_address_3,
+                    "personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test3",
+                        "postal_code": "postal_code_test3",
+                        "address": "address_test3",
+                        "email": "email_test3",
+                        "birth": "birth_test3",
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 99,
+                    "exchange_balance": 99,
+                    "exchange_commitment": 99,
+                    "pending_transfer": 99,
+                    "locked": 30,
+                    "modified": "2023-10-24T05:00:00",
+                },
+                {
+                    "account_address": _account_address_1,
+                    "personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test1",
+                        "postal_code": "postal_code_test1",
+                        "address": "address_test1",
+                        "email": "email_test1",
+                        "birth": "birth_test1",
+                        "is_corporate": False,
+                        "tax_category": 10,
+                    },
+                    "balance": 10,
+                    "exchange_balance": 11,
+                    "exchange_commitment": 12,
+                    "pending_transfer": 5,
+                    "locked": 10,
+                    "modified": "2023-10-24T01:10:00",
+                },
+            ],
+        }
+
+    # <Normal_6_1>
     # Pagination
-    def test_normal_5_1(self, client, db):
+    def test_normal_6_1(self, client, db):
         user = config_eth_account("user1")
         _issuer_address = user["address"]
         _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
@@ -1156,9 +4356,9 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             ],
         }
 
-    # <Normal_5_2>
+    # <Normal_6_2>
     # Pagination (over offset)
-    def test_normal_5_2(self, client, db):
+    def test_normal_6_2(self, client, db):
         user = config_eth_account("user1")
         _issuer_address = user["address"]
         _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"

--- a/tests/test_app_routers_bond_tokens_{token_address}_holders_GET.py
+++ b/tests/test_app_routers_bond_tokens_{token_address}_holders_GET.py
@@ -3921,6 +3921,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
         _account_address_1 = "0xb75c7545b9230FEe99b7af370D38eBd3DAD929f7"
         _account_address_2 = "0x3F198534Bbe3B2a197d3B317d41392F348EAC707"
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
+        _account_address_4 = "0x917eFFaC072dcda308e2337636f562D0A96F42eA"
 
         account = Account()
         account.issuer_address = _issuer_address
@@ -4071,6 +4072,18 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
         }
         db.add(idx_personal_info_3)
 
+        # prepare data: account_address_4
+        idx_position_4 = IDXPosition()
+        idx_position_4.token_address = _token_address
+        idx_position_4.account_address = _account_address_4
+        idx_position_4.balance = 100
+        idx_position_4.exchange_balance = 100
+        idx_position_4.exchange_commitment = 100
+        idx_position_4.pending_transfer = 100
+        idx_position_4.created = datetime(2023, 10, 24, 6, 0, 0)
+        idx_position_4.modified = datetime(2023, 10, 24, 6, 0, 0)
+        db.add(idx_position_4)
+
         db.commit()
 
         # request target API
@@ -4083,7 +4096,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
         # assertion
         assert resp.status_code == 200
         assert resp.json() == {
-            "result_set": {"count": 3, "total": 3, "offset": None, "limit": None},
+            "result_set": {"count": 4, "total": 4, "offset": None, "limit": None},
             "holders": [
                 {
                     "account_address": _account_address_2,
@@ -4103,6 +4116,25 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
                     "pending_transfer": 10,
                     "locked": 20,
                     "modified": "2023-10-24T02:20:00",
+                },
+                {
+                    "account_address": _account_address_4,
+                    "personal_information": {
+                        "key_manager": None,
+                        "name": None,
+                        "postal_code": None,
+                        "address": None,
+                        "email": None,
+                        "birth": None,
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 100,
+                    "exchange_balance": 100,
+                    "exchange_commitment": 100,
+                    "pending_transfer": 100,
+                    "locked": 0,
+                    "modified": "2023-10-24T06:00:00",
                 },
                 {
                     "account_address": _account_address_3,

--- a/tests/test_app_routers_share_tokens_{token_address}_holders_GET.py
+++ b/tests/test_app_routers_share_tokens_{token_address}_holders_GET.py
@@ -110,25 +110,36 @@ class TestAppRoutersShareTokensTokenAddressHoldersGET:
         db.add(idx_position_1)
 
         # prepare data: Locked Position
-        idx_locked_position = IDXLockedPosition()
-        idx_locked_position.token_address = _token_address
-        idx_locked_position.lock_address = (
+        _locked_position = IDXLockedPosition()
+        _locked_position.token_address = _token_address
+        _locked_position.lock_address = (
             "0x1234567890123456789012345678900000000001"  # lock address 1
         )
-        idx_locked_position.account_address = _account_address_1
-        idx_locked_position.value = 5
-        idx_locked_position.modified = datetime(2023, 10, 24, 0, 1, 0)
-        db.add(idx_locked_position)
+        _locked_position.account_address = _account_address_1
+        _locked_position.value = 5
+        _locked_position.modified = datetime(2023, 10, 24, 0, 1, 0)
+        db.add(_locked_position)
 
-        idx_locked_position = IDXLockedPosition()
-        idx_locked_position.token_address = _token_address
-        idx_locked_position.lock_address = (
+        _locked_position = IDXLockedPosition()
+        _locked_position.token_address = _token_address
+        _locked_position.lock_address = (
             "0x1234567890123456789012345678900000000002"  # lock address 2
         )
-        idx_locked_position.account_address = _account_address_1
-        idx_locked_position.value = 5
-        idx_locked_position.modified = datetime(2023, 10, 24, 0, 2, 0)
-        db.add(idx_locked_position)
+        _locked_position.account_address = _account_address_1
+        _locked_position.value = 5
+        _locked_position.modified = datetime(2023, 10, 24, 0, 2, 0)
+        db.add(_locked_position)
+
+        # Other locked position
+        _locked_position = IDXLockedPosition()
+        _locked_position.token_address = "other_token_address"
+        _locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        _locked_position.account_address = _account_address_1
+        _locked_position.value = 5
+        _locked_position.modified = datetime(2023, 10, 25, 0, 2, 0)
+        db.add(_locked_position)
 
         # prepare data: Personal Info
         idx_personal_info_1 = IDXPersonalInfo()
@@ -181,9 +192,9 @@ class TestAppRoutersShareTokensTokenAddressHoldersGET:
             ],
         }
 
-    # <Normal_3_1>
+    # <Normal_3>
     # Multi record
-    def test_normal_3_1(self, client, db):
+    def test_normal_3(self, client, db):
         user = config_eth_account("user1")
         _issuer_address = user["address"]
         _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
@@ -410,10 +421,9 @@ class TestAppRoutersShareTokensTokenAddressHoldersGET:
             ],
         }
 
-    # <Normal_3_2>
-    # Multi record (Including former holder)
-    # Query param: including_former_holder=None
-    def test_normal_3_2(self, client, db):
+    # <Normal_4_1_1>
+    # Search filter: including_former_holder=None
+    def test_normal_4_1_1(self, client, db):
         user = config_eth_account("user1")
         _issuer_address = user["address"]
         _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
@@ -559,10 +569,9 @@ class TestAppRoutersShareTokensTokenAddressHoldersGET:
             ],
         }
 
-    # <Normal_3_3>
-    # Multi record (Including former holder)
-    # Query param: including_former_holder=True
-    def test_normal_3_3(self, client, db):
+    # <Normal_4_1_2>
+    # Search filter: including_former_holder=True
+    def test_normal_4_1_2(self, client, db):
         user = config_eth_account("user1")
         _issuer_address = user["address"]
         _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
@@ -718,9 +727,9 @@ class TestAppRoutersShareTokensTokenAddressHoldersGET:
             ],
         }
 
-    # <Normal_4>
-    # Sort Order
-    def test_normal_4(self, client, db):
+    # <Normal_4_2_1>
+    # Search filter: balance & "="
+    def test_normal_4_2_1(self, client, db):
         user = config_eth_account("user1")
         _issuer_address = user["address"]
         _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
@@ -880,7 +889,2044 @@ class TestAppRoutersShareTokensTokenAddressHoldersGET:
         resp = client.get(
             self.base_url.format(_token_address),
             headers={"issuer-address": _issuer_address},
-            params={"sort_order": 1},
+            params={"balance": 20, "balance_operator": 0},
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "result_set": {"count": 1, "total": 3, "offset": None, "limit": None},
+            "holders": [
+                {
+                    "account_address": _account_address_2,
+                    "personal_information": {
+                        "key_manager": None,
+                        "name": None,
+                        "postal_code": None,
+                        "address": None,
+                        "email": None,
+                        "birth": None,
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 20,
+                    "exchange_balance": 21,
+                    "exchange_commitment": 22,
+                    "pending_transfer": 10,
+                    "locked": 20,
+                    "modified": "2023-10-24T02:20:00",
+                },
+            ],
+        }
+
+    # <Normal_4_2_2>
+    # Search filter: balance & ">="
+    def test_normal_4_2_2(self, client, db):
+        user = config_eth_account("user1")
+        _issuer_address = user["address"]
+        _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
+        _account_address_1 = "0xb75c7545b9230FEe99b7af370D38eBd3DAD929f7"
+        _account_address_2 = "0x3F198534Bbe3B2a197d3B317d41392F348EAC707"
+        _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
+
+        account = Account()
+        account.issuer_address = _issuer_address
+        db.add(account)
+
+        token = Token()
+        token.type = TokenType.IBET_SHARE.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        token.version = TokenVersion.V_22_12
+        db.add(token)
+
+        # prepare data: account_address_1
+        idx_position_1 = IDXPosition()
+        idx_position_1.token_address = _token_address
+        idx_position_1.account_address = _account_address_1
+        idx_position_1.balance = 10
+        idx_position_1.exchange_balance = 11
+        idx_position_1.exchange_commitment = 12
+        idx_position_1.pending_transfer = 5
+        idx_position_1.modified = datetime(2023, 10, 24, 0, 0, 0)
+        db.add(idx_position_1)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = _account_address_1
+        idx_personal_info_1.issuer_address = _issuer_address
+        idx_personal_info_1.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(idx_personal_info_1)
+
+        # prepare data: account_address_2
+        idx_position_2 = IDXPosition()
+        idx_position_2.token_address = _token_address
+        idx_position_2.account_address = _account_address_2
+        idx_position_2.balance = 20
+        idx_position_2.exchange_balance = 21
+        idx_position_2.exchange_commitment = 22
+        idx_position_2.pending_transfer = 10
+        idx_position_2.modified = datetime(2023, 10, 24, 2, 0, 0)
+        db.add(idx_position_2)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 20, 0)
+        db.add(idx_locked_position)
+
+        # prepare data: account_address_3
+        idx_position_3 = IDXPosition()
+        idx_position_3.token_address = _token_address
+        idx_position_3.account_address = _account_address_3
+        idx_position_3.balance = 99
+        idx_position_3.exchange_balance = 99
+        idx_position_3.exchange_commitment = 99
+        idx_position_3.pending_transfer = 99
+        idx_position_3.modified = datetime(2023, 10, 24, 3, 0, 0)
+        db.add(idx_position_3)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 4, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 5, 0, 0)
+        db.add(idx_locked_position)
+
+        # Other locked position
+        _locked_position = IDXLockedPosition()
+        _locked_position.token_address = "other_token_address"
+        _locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        _locked_position.account_address = _account_address_1
+        _locked_position.value = 5
+        _locked_position.modified = datetime(2023, 10, 25, 0, 2, 0)
+        db.add(_locked_position)
+
+        idx_personal_info_3 = IDXPersonalInfo()
+        idx_personal_info_3.account_address = _account_address_3
+        idx_personal_info_3.issuer_address = _issuer_address
+        idx_personal_info_3.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test3",
+            "postal_code": "postal_code_test3",
+            "address": "address_test3",
+            "email": "email_test3",
+            "birth": "birth_test3",
+            # PersonalInfo is partially registered.
+        }
+        db.add(idx_personal_info_3)
+
+        db.commit()
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address),
+            headers={"issuer-address": _issuer_address},
+            params={"balance": 20, "balance_operator": 1},
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "result_set": {"count": 2, "total": 3, "offset": None, "limit": None},
+            "holders": [
+                {
+                    "account_address": _account_address_2,
+                    "personal_information": {
+                        "key_manager": None,
+                        "name": None,
+                        "postal_code": None,
+                        "address": None,
+                        "email": None,
+                        "birth": None,
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 20,
+                    "exchange_balance": 21,
+                    "exchange_commitment": 22,
+                    "pending_transfer": 10,
+                    "locked": 20,
+                    "modified": "2023-10-24T02:20:00",
+                },
+                {
+                    "account_address": _account_address_3,
+                    "personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test3",
+                        "postal_code": "postal_code_test3",
+                        "address": "address_test3",
+                        "email": "email_test3",
+                        "birth": "birth_test3",
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 99,
+                    "exchange_balance": 99,
+                    "exchange_commitment": 99,
+                    "pending_transfer": 99,
+                    "locked": 30,
+                    "modified": "2023-10-24T05:00:00",
+                },
+            ],
+        }
+
+    # <Normal_4_2_3>
+    # Search filter: balance & "<="
+    def test_normal_4_2_3(self, client, db):
+        user = config_eth_account("user1")
+        _issuer_address = user["address"]
+        _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
+        _account_address_1 = "0xb75c7545b9230FEe99b7af370D38eBd3DAD929f7"
+        _account_address_2 = "0x3F198534Bbe3B2a197d3B317d41392F348EAC707"
+        _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
+
+        account = Account()
+        account.issuer_address = _issuer_address
+        db.add(account)
+
+        token = Token()
+        token.type = TokenType.IBET_SHARE.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        token.version = TokenVersion.V_22_12
+        db.add(token)
+
+        # prepare data: account_address_1
+        idx_position_1 = IDXPosition()
+        idx_position_1.token_address = _token_address
+        idx_position_1.account_address = _account_address_1
+        idx_position_1.balance = 10
+        idx_position_1.exchange_balance = 11
+        idx_position_1.exchange_commitment = 12
+        idx_position_1.pending_transfer = 5
+        idx_position_1.modified = datetime(2023, 10, 24, 0, 0, 0)
+        db.add(idx_position_1)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = _account_address_1
+        idx_personal_info_1.issuer_address = _issuer_address
+        idx_personal_info_1.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(idx_personal_info_1)
+
+        # prepare data: account_address_2
+        idx_position_2 = IDXPosition()
+        idx_position_2.token_address = _token_address
+        idx_position_2.account_address = _account_address_2
+        idx_position_2.balance = 20
+        idx_position_2.exchange_balance = 21
+        idx_position_2.exchange_commitment = 22
+        idx_position_2.pending_transfer = 10
+        idx_position_2.modified = datetime(2023, 10, 24, 2, 0, 0)
+        db.add(idx_position_2)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 20, 0)
+        db.add(idx_locked_position)
+
+        # prepare data: account_address_3
+        idx_position_3 = IDXPosition()
+        idx_position_3.token_address = _token_address
+        idx_position_3.account_address = _account_address_3
+        idx_position_3.balance = 99
+        idx_position_3.exchange_balance = 99
+        idx_position_3.exchange_commitment = 99
+        idx_position_3.pending_transfer = 99
+        idx_position_3.modified = datetime(2023, 10, 24, 3, 0, 0)
+        db.add(idx_position_3)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 4, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 5, 0, 0)
+        db.add(idx_locked_position)
+
+        # Other locked position
+        _locked_position = IDXLockedPosition()
+        _locked_position.token_address = "other_token_address"
+        _locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        _locked_position.account_address = _account_address_1
+        _locked_position.value = 5
+        _locked_position.modified = datetime(2023, 10, 25, 0, 2, 0)
+        db.add(_locked_position)
+
+        idx_personal_info_3 = IDXPersonalInfo()
+        idx_personal_info_3.account_address = _account_address_3
+        idx_personal_info_3.issuer_address = _issuer_address
+        idx_personal_info_3.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test3",
+            "postal_code": "postal_code_test3",
+            "address": "address_test3",
+            "email": "email_test3",
+            "birth": "birth_test3",
+            # PersonalInfo is partially registered.
+        }
+        db.add(idx_personal_info_3)
+
+        db.commit()
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address),
+            headers={"issuer-address": _issuer_address},
+            params={"balance": 20, "balance_operator": 2},
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "result_set": {"count": 2, "total": 3, "offset": None, "limit": None},
+            "holders": [
+                {
+                    "account_address": _account_address_1,
+                    "personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test1",
+                        "postal_code": "postal_code_test1",
+                        "address": "address_test1",
+                        "email": "email_test1",
+                        "birth": "birth_test1",
+                        "is_corporate": False,
+                        "tax_category": 10,
+                    },
+                    "balance": 10,
+                    "exchange_balance": 11,
+                    "exchange_commitment": 12,
+                    "pending_transfer": 5,
+                    "locked": 10,
+                    "modified": "2023-10-24T01:10:00",
+                },
+                {
+                    "account_address": _account_address_2,
+                    "personal_information": {
+                        "key_manager": None,
+                        "name": None,
+                        "postal_code": None,
+                        "address": None,
+                        "email": None,
+                        "birth": None,
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 20,
+                    "exchange_balance": 21,
+                    "exchange_commitment": 22,
+                    "pending_transfer": 10,
+                    "locked": 20,
+                    "modified": "2023-10-24T02:20:00",
+                },
+            ],
+        }
+
+    # <Normal_4_3_1>
+    # Search filter: pending_transfer & "="
+    def test_normal_4_3_1(self, client, db):
+        user = config_eth_account("user1")
+        _issuer_address = user["address"]
+        _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
+        _account_address_1 = "0xb75c7545b9230FEe99b7af370D38eBd3DAD929f7"
+        _account_address_2 = "0x3F198534Bbe3B2a197d3B317d41392F348EAC707"
+        _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
+
+        account = Account()
+        account.issuer_address = _issuer_address
+        db.add(account)
+
+        token = Token()
+        token.type = TokenType.IBET_SHARE.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        token.version = TokenVersion.V_22_12
+        db.add(token)
+
+        # prepare data: account_address_1
+        idx_position_1 = IDXPosition()
+        idx_position_1.token_address = _token_address
+        idx_position_1.account_address = _account_address_1
+        idx_position_1.balance = 10
+        idx_position_1.exchange_balance = 11
+        idx_position_1.exchange_commitment = 12
+        idx_position_1.pending_transfer = 5
+        idx_position_1.modified = datetime(2023, 10, 24, 0, 0, 0)
+        db.add(idx_position_1)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = _account_address_1
+        idx_personal_info_1.issuer_address = _issuer_address
+        idx_personal_info_1.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(idx_personal_info_1)
+
+        # prepare data: account_address_2
+        idx_position_2 = IDXPosition()
+        idx_position_2.token_address = _token_address
+        idx_position_2.account_address = _account_address_2
+        idx_position_2.balance = 20
+        idx_position_2.exchange_balance = 21
+        idx_position_2.exchange_commitment = 22
+        idx_position_2.pending_transfer = 10
+        idx_position_2.modified = datetime(2023, 10, 24, 2, 0, 0)
+        db.add(idx_position_2)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 20, 0)
+        db.add(idx_locked_position)
+
+        # prepare data: account_address_3
+        idx_position_3 = IDXPosition()
+        idx_position_3.token_address = _token_address
+        idx_position_3.account_address = _account_address_3
+        idx_position_3.balance = 99
+        idx_position_3.exchange_balance = 99
+        idx_position_3.exchange_commitment = 99
+        idx_position_3.pending_transfer = 99
+        idx_position_3.modified = datetime(2023, 10, 24, 3, 0, 0)
+        db.add(idx_position_3)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 4, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 5, 0, 0)
+        db.add(idx_locked_position)
+
+        # Other locked position
+        _locked_position = IDXLockedPosition()
+        _locked_position.token_address = "other_token_address"
+        _locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        _locked_position.account_address = _account_address_1
+        _locked_position.value = 5
+        _locked_position.modified = datetime(2023, 10, 25, 0, 2, 0)
+        db.add(_locked_position)
+
+        idx_personal_info_3 = IDXPersonalInfo()
+        idx_personal_info_3.account_address = _account_address_3
+        idx_personal_info_3.issuer_address = _issuer_address
+        idx_personal_info_3.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test3",
+            "postal_code": "postal_code_test3",
+            "address": "address_test3",
+            "email": "email_test3",
+            "birth": "birth_test3",
+            # PersonalInfo is partially registered.
+        }
+        db.add(idx_personal_info_3)
+
+        db.commit()
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address),
+            headers={"issuer-address": _issuer_address},
+            params={"pending_transfer": 10, "pending_transfer_operator": 0},
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "result_set": {"count": 1, "total": 3, "offset": None, "limit": None},
+            "holders": [
+                {
+                    "account_address": _account_address_2,
+                    "personal_information": {
+                        "key_manager": None,
+                        "name": None,
+                        "postal_code": None,
+                        "address": None,
+                        "email": None,
+                        "birth": None,
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 20,
+                    "exchange_balance": 21,
+                    "exchange_commitment": 22,
+                    "pending_transfer": 10,
+                    "locked": 20,
+                    "modified": "2023-10-24T02:20:00",
+                },
+            ],
+        }
+
+    # <Normal_4_3_2>
+    # Search filter: pending_transfer & ">="
+    def test_normal_4_3_2(self, client, db):
+        user = config_eth_account("user1")
+        _issuer_address = user["address"]
+        _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
+        _account_address_1 = "0xb75c7545b9230FEe99b7af370D38eBd3DAD929f7"
+        _account_address_2 = "0x3F198534Bbe3B2a197d3B317d41392F348EAC707"
+        _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
+
+        account = Account()
+        account.issuer_address = _issuer_address
+        db.add(account)
+
+        token = Token()
+        token.type = TokenType.IBET_SHARE.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        token.version = TokenVersion.V_22_12
+        db.add(token)
+
+        # prepare data: account_address_1
+        idx_position_1 = IDXPosition()
+        idx_position_1.token_address = _token_address
+        idx_position_1.account_address = _account_address_1
+        idx_position_1.balance = 10
+        idx_position_1.exchange_balance = 11
+        idx_position_1.exchange_commitment = 12
+        idx_position_1.pending_transfer = 5
+        idx_position_1.modified = datetime(2023, 10, 24, 0, 0, 0)
+        db.add(idx_position_1)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = _account_address_1
+        idx_personal_info_1.issuer_address = _issuer_address
+        idx_personal_info_1.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(idx_personal_info_1)
+
+        # prepare data: account_address_2
+        idx_position_2 = IDXPosition()
+        idx_position_2.token_address = _token_address
+        idx_position_2.account_address = _account_address_2
+        idx_position_2.balance = 20
+        idx_position_2.exchange_balance = 21
+        idx_position_2.exchange_commitment = 22
+        idx_position_2.pending_transfer = 10
+        idx_position_2.modified = datetime(2023, 10, 24, 2, 0, 0)
+        db.add(idx_position_2)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 20, 0)
+        db.add(idx_locked_position)
+
+        # prepare data: account_address_3
+        idx_position_3 = IDXPosition()
+        idx_position_3.token_address = _token_address
+        idx_position_3.account_address = _account_address_3
+        idx_position_3.balance = 99
+        idx_position_3.exchange_balance = 99
+        idx_position_3.exchange_commitment = 99
+        idx_position_3.pending_transfer = 99
+        idx_position_3.modified = datetime(2023, 10, 24, 3, 0, 0)
+        db.add(idx_position_3)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 4, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 5, 0, 0)
+        db.add(idx_locked_position)
+
+        # Other locked position
+        _locked_position = IDXLockedPosition()
+        _locked_position.token_address = "other_token_address"
+        _locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        _locked_position.account_address = _account_address_1
+        _locked_position.value = 5
+        _locked_position.modified = datetime(2023, 10, 25, 0, 2, 0)
+        db.add(_locked_position)
+
+        idx_personal_info_3 = IDXPersonalInfo()
+        idx_personal_info_3.account_address = _account_address_3
+        idx_personal_info_3.issuer_address = _issuer_address
+        idx_personal_info_3.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test3",
+            "postal_code": "postal_code_test3",
+            "address": "address_test3",
+            "email": "email_test3",
+            "birth": "birth_test3",
+            # PersonalInfo is partially registered.
+        }
+        db.add(idx_personal_info_3)
+
+        db.commit()
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address),
+            headers={"issuer-address": _issuer_address},
+            params={"pending_transfer": 10, "pending_transfer_operator": 1},
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "result_set": {"count": 2, "total": 3, "offset": None, "limit": None},
+            "holders": [
+                {
+                    "account_address": _account_address_2,
+                    "personal_information": {
+                        "key_manager": None,
+                        "name": None,
+                        "postal_code": None,
+                        "address": None,
+                        "email": None,
+                        "birth": None,
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 20,
+                    "exchange_balance": 21,
+                    "exchange_commitment": 22,
+                    "pending_transfer": 10,
+                    "locked": 20,
+                    "modified": "2023-10-24T02:20:00",
+                },
+                {
+                    "account_address": _account_address_3,
+                    "personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test3",
+                        "postal_code": "postal_code_test3",
+                        "address": "address_test3",
+                        "email": "email_test3",
+                        "birth": "birth_test3",
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 99,
+                    "exchange_balance": 99,
+                    "exchange_commitment": 99,
+                    "pending_transfer": 99,
+                    "locked": 30,
+                    "modified": "2023-10-24T05:00:00",
+                },
+            ],
+        }
+
+    # <Normal_4_3_3>
+    # Search filter: pending_transfer & "<="
+    def test_normal_4_3_3(self, client, db):
+        user = config_eth_account("user1")
+        _issuer_address = user["address"]
+        _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
+        _account_address_1 = "0xb75c7545b9230FEe99b7af370D38eBd3DAD929f7"
+        _account_address_2 = "0x3F198534Bbe3B2a197d3B317d41392F348EAC707"
+        _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
+
+        account = Account()
+        account.issuer_address = _issuer_address
+        db.add(account)
+
+        token = Token()
+        token.type = TokenType.IBET_SHARE.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        token.version = TokenVersion.V_22_12
+        db.add(token)
+
+        # prepare data: account_address_1
+        idx_position_1 = IDXPosition()
+        idx_position_1.token_address = _token_address
+        idx_position_1.account_address = _account_address_1
+        idx_position_1.balance = 10
+        idx_position_1.exchange_balance = 11
+        idx_position_1.exchange_commitment = 12
+        idx_position_1.pending_transfer = 5
+        idx_position_1.modified = datetime(2023, 10, 24, 0, 0, 0)
+        db.add(idx_position_1)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = _account_address_1
+        idx_personal_info_1.issuer_address = _issuer_address
+        idx_personal_info_1.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(idx_personal_info_1)
+
+        # prepare data: account_address_2
+        idx_position_2 = IDXPosition()
+        idx_position_2.token_address = _token_address
+        idx_position_2.account_address = _account_address_2
+        idx_position_2.balance = 20
+        idx_position_2.exchange_balance = 21
+        idx_position_2.exchange_commitment = 22
+        idx_position_2.pending_transfer = 10
+        idx_position_2.modified = datetime(2023, 10, 24, 2, 0, 0)
+        db.add(idx_position_2)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 20, 0)
+        db.add(idx_locked_position)
+
+        # prepare data: account_address_3
+        idx_position_3 = IDXPosition()
+        idx_position_3.token_address = _token_address
+        idx_position_3.account_address = _account_address_3
+        idx_position_3.balance = 99
+        idx_position_3.exchange_balance = 99
+        idx_position_3.exchange_commitment = 99
+        idx_position_3.pending_transfer = 99
+        idx_position_3.modified = datetime(2023, 10, 24, 3, 0, 0)
+        db.add(idx_position_3)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 4, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 5, 0, 0)
+        db.add(idx_locked_position)
+
+        # Other locked position
+        _locked_position = IDXLockedPosition()
+        _locked_position.token_address = "other_token_address"
+        _locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        _locked_position.account_address = _account_address_1
+        _locked_position.value = 5
+        _locked_position.modified = datetime(2023, 10, 25, 0, 2, 0)
+        db.add(_locked_position)
+
+        idx_personal_info_3 = IDXPersonalInfo()
+        idx_personal_info_3.account_address = _account_address_3
+        idx_personal_info_3.issuer_address = _issuer_address
+        idx_personal_info_3.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test3",
+            "postal_code": "postal_code_test3",
+            "address": "address_test3",
+            "email": "email_test3",
+            "birth": "birth_test3",
+            # PersonalInfo is partially registered.
+        }
+        db.add(idx_personal_info_3)
+
+        db.commit()
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address),
+            headers={"issuer-address": _issuer_address},
+            params={"pending_transfer": 10, "pending_transfer_operator": 2},
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "result_set": {"count": 2, "total": 3, "offset": None, "limit": None},
+            "holders": [
+                {
+                    "account_address": _account_address_1,
+                    "personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test1",
+                        "postal_code": "postal_code_test1",
+                        "address": "address_test1",
+                        "email": "email_test1",
+                        "birth": "birth_test1",
+                        "is_corporate": False,
+                        "tax_category": 10,
+                    },
+                    "balance": 10,
+                    "exchange_balance": 11,
+                    "exchange_commitment": 12,
+                    "pending_transfer": 5,
+                    "locked": 10,
+                    "modified": "2023-10-24T01:10:00",
+                },
+                {
+                    "account_address": _account_address_2,
+                    "personal_information": {
+                        "key_manager": None,
+                        "name": None,
+                        "postal_code": None,
+                        "address": None,
+                        "email": None,
+                        "birth": None,
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 20,
+                    "exchange_balance": 21,
+                    "exchange_commitment": 22,
+                    "pending_transfer": 10,
+                    "locked": 20,
+                    "modified": "2023-10-24T02:20:00",
+                },
+            ],
+        }
+
+    # <Normal_4_4_1>
+    # Search filter: locked & "="
+    def test_normal_4_4_1(self, client, db):
+        user = config_eth_account("user1")
+        _issuer_address = user["address"]
+        _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
+        _account_address_1 = "0xb75c7545b9230FEe99b7af370D38eBd3DAD929f7"
+        _account_address_2 = "0x3F198534Bbe3B2a197d3B317d41392F348EAC707"
+        _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
+
+        account = Account()
+        account.issuer_address = _issuer_address
+        db.add(account)
+
+        token = Token()
+        token.type = TokenType.IBET_SHARE.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        token.version = TokenVersion.V_22_12
+        db.add(token)
+
+        # prepare data: account_address_1
+        idx_position_1 = IDXPosition()
+        idx_position_1.token_address = _token_address
+        idx_position_1.account_address = _account_address_1
+        idx_position_1.balance = 10
+        idx_position_1.exchange_balance = 11
+        idx_position_1.exchange_commitment = 12
+        idx_position_1.pending_transfer = 5
+        idx_position_1.modified = datetime(2023, 10, 24, 0, 0, 0)
+        db.add(idx_position_1)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = _account_address_1
+        idx_personal_info_1.issuer_address = _issuer_address
+        idx_personal_info_1.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(idx_personal_info_1)
+
+        # prepare data: account_address_2
+        idx_position_2 = IDXPosition()
+        idx_position_2.token_address = _token_address
+        idx_position_2.account_address = _account_address_2
+        idx_position_2.balance = 20
+        idx_position_2.exchange_balance = 21
+        idx_position_2.exchange_commitment = 22
+        idx_position_2.pending_transfer = 10
+        idx_position_2.modified = datetime(2023, 10, 24, 2, 0, 0)
+        db.add(idx_position_2)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 20, 0)
+        db.add(idx_locked_position)
+
+        # prepare data: account_address_3
+        idx_position_3 = IDXPosition()
+        idx_position_3.token_address = _token_address
+        idx_position_3.account_address = _account_address_3
+        idx_position_3.balance = 99
+        idx_position_3.exchange_balance = 99
+        idx_position_3.exchange_commitment = 99
+        idx_position_3.pending_transfer = 99
+        idx_position_3.modified = datetime(2023, 10, 24, 3, 0, 0)
+        db.add(idx_position_3)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 4, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 5, 0, 0)
+        db.add(idx_locked_position)
+
+        # Other locked position
+        _locked_position = IDXLockedPosition()
+        _locked_position.token_address = "other_token_address"
+        _locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        _locked_position.account_address = _account_address_1
+        _locked_position.value = 5
+        _locked_position.modified = datetime(2023, 10, 25, 0, 2, 0)
+        db.add(_locked_position)
+
+        idx_personal_info_3 = IDXPersonalInfo()
+        idx_personal_info_3.account_address = _account_address_3
+        idx_personal_info_3.issuer_address = _issuer_address
+        idx_personal_info_3.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test3",
+            "postal_code": "postal_code_test3",
+            "address": "address_test3",
+            "email": "email_test3",
+            "birth": "birth_test3",
+            # PersonalInfo is partially registered.
+        }
+        db.add(idx_personal_info_3)
+
+        db.commit()
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address),
+            headers={"issuer-address": _issuer_address},
+            params={"locked": 20, "locked_operator": 0},
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "result_set": {"count": 1, "total": 3, "offset": None, "limit": None},
+            "holders": [
+                {
+                    "account_address": _account_address_2,
+                    "personal_information": {
+                        "key_manager": None,
+                        "name": None,
+                        "postal_code": None,
+                        "address": None,
+                        "email": None,
+                        "birth": None,
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 20,
+                    "exchange_balance": 21,
+                    "exchange_commitment": 22,
+                    "pending_transfer": 10,
+                    "locked": 20,
+                    "modified": "2023-10-24T02:20:00",
+                },
+            ],
+        }
+
+    # <Normal_4_4_2>
+    # Search filter: locked & ">="
+    def test_normal_4_4_2(self, client, db):
+        user = config_eth_account("user1")
+        _issuer_address = user["address"]
+        _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
+        _account_address_1 = "0xb75c7545b9230FEe99b7af370D38eBd3DAD929f7"
+        _account_address_2 = "0x3F198534Bbe3B2a197d3B317d41392F348EAC707"
+        _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
+
+        account = Account()
+        account.issuer_address = _issuer_address
+        db.add(account)
+
+        token = Token()
+        token.type = TokenType.IBET_SHARE.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        token.version = TokenVersion.V_22_12
+        db.add(token)
+
+        # prepare data: account_address_1
+        idx_position_1 = IDXPosition()
+        idx_position_1.token_address = _token_address
+        idx_position_1.account_address = _account_address_1
+        idx_position_1.balance = 10
+        idx_position_1.exchange_balance = 11
+        idx_position_1.exchange_commitment = 12
+        idx_position_1.pending_transfer = 5
+        idx_position_1.modified = datetime(2023, 10, 24, 0, 0, 0)
+        db.add(idx_position_1)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = _account_address_1
+        idx_personal_info_1.issuer_address = _issuer_address
+        idx_personal_info_1.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(idx_personal_info_1)
+
+        # prepare data: account_address_2
+        idx_position_2 = IDXPosition()
+        idx_position_2.token_address = _token_address
+        idx_position_2.account_address = _account_address_2
+        idx_position_2.balance = 20
+        idx_position_2.exchange_balance = 21
+        idx_position_2.exchange_commitment = 22
+        idx_position_2.pending_transfer = 10
+        idx_position_2.modified = datetime(2023, 10, 24, 2, 0, 0)
+        db.add(idx_position_2)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 20, 0)
+        db.add(idx_locked_position)
+
+        # prepare data: account_address_3
+        idx_position_3 = IDXPosition()
+        idx_position_3.token_address = _token_address
+        idx_position_3.account_address = _account_address_3
+        idx_position_3.balance = 99
+        idx_position_3.exchange_balance = 99
+        idx_position_3.exchange_commitment = 99
+        idx_position_3.pending_transfer = 99
+        idx_position_3.modified = datetime(2023, 10, 24, 3, 0, 0)
+        db.add(idx_position_3)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 4, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 5, 0, 0)
+        db.add(idx_locked_position)
+
+        # Other locked position
+        _locked_position = IDXLockedPosition()
+        _locked_position.token_address = "other_token_address"
+        _locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        _locked_position.account_address = _account_address_1
+        _locked_position.value = 5
+        _locked_position.modified = datetime(2023, 10, 25, 0, 2, 0)
+        db.add(_locked_position)
+
+        idx_personal_info_3 = IDXPersonalInfo()
+        idx_personal_info_3.account_address = _account_address_3
+        idx_personal_info_3.issuer_address = _issuer_address
+        idx_personal_info_3.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test3",
+            "postal_code": "postal_code_test3",
+            "address": "address_test3",
+            "email": "email_test3",
+            "birth": "birth_test3",
+            # PersonalInfo is partially registered.
+        }
+        db.add(idx_personal_info_3)
+
+        db.commit()
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address),
+            headers={"issuer-address": _issuer_address},
+            params={"locked": 20, "locked_operator": 1},
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "result_set": {"count": 2, "total": 3, "offset": None, "limit": None},
+            "holders": [
+                {
+                    "account_address": _account_address_2,
+                    "personal_information": {
+                        "key_manager": None,
+                        "name": None,
+                        "postal_code": None,
+                        "address": None,
+                        "email": None,
+                        "birth": None,
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 20,
+                    "exchange_balance": 21,
+                    "exchange_commitment": 22,
+                    "pending_transfer": 10,
+                    "locked": 20,
+                    "modified": "2023-10-24T02:20:00",
+                },
+                {
+                    "account_address": _account_address_3,
+                    "personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test3",
+                        "postal_code": "postal_code_test3",
+                        "address": "address_test3",
+                        "email": "email_test3",
+                        "birth": "birth_test3",
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 99,
+                    "exchange_balance": 99,
+                    "exchange_commitment": 99,
+                    "pending_transfer": 99,
+                    "locked": 30,
+                    "modified": "2023-10-24T05:00:00",
+                },
+            ],
+        }
+
+    # <Normal_4_4_3>
+    # Search filter: locked & "<="
+    def test_normal_4_4_3(self, client, db):
+        user = config_eth_account("user1")
+        _issuer_address = user["address"]
+        _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
+        _account_address_1 = "0xb75c7545b9230FEe99b7af370D38eBd3DAD929f7"
+        _account_address_2 = "0x3F198534Bbe3B2a197d3B317d41392F348EAC707"
+        _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
+
+        account = Account()
+        account.issuer_address = _issuer_address
+        db.add(account)
+
+        token = Token()
+        token.type = TokenType.IBET_SHARE.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        token.version = TokenVersion.V_22_12
+        db.add(token)
+
+        # prepare data: account_address_1
+        idx_position_1 = IDXPosition()
+        idx_position_1.token_address = _token_address
+        idx_position_1.account_address = _account_address_1
+        idx_position_1.balance = 10
+        idx_position_1.exchange_balance = 11
+        idx_position_1.exchange_commitment = 12
+        idx_position_1.pending_transfer = 5
+        idx_position_1.modified = datetime(2023, 10, 24, 0, 0, 0)
+        db.add(idx_position_1)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = _account_address_1
+        idx_personal_info_1.issuer_address = _issuer_address
+        idx_personal_info_1.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(idx_personal_info_1)
+
+        # prepare data: account_address_2
+        idx_position_2 = IDXPosition()
+        idx_position_2.token_address = _token_address
+        idx_position_2.account_address = _account_address_2
+        idx_position_2.balance = 20
+        idx_position_2.exchange_balance = 21
+        idx_position_2.exchange_commitment = 22
+        idx_position_2.pending_transfer = 10
+        idx_position_2.modified = datetime(2023, 10, 24, 2, 0, 0)
+        db.add(idx_position_2)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 20, 0)
+        db.add(idx_locked_position)
+
+        # prepare data: account_address_3
+        idx_position_3 = IDXPosition()
+        idx_position_3.token_address = _token_address
+        idx_position_3.account_address = _account_address_3
+        idx_position_3.balance = 99
+        idx_position_3.exchange_balance = 99
+        idx_position_3.exchange_commitment = 99
+        idx_position_3.pending_transfer = 99
+        idx_position_3.modified = datetime(2023, 10, 24, 3, 0, 0)
+        db.add(idx_position_3)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 4, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 5, 0, 0)
+        db.add(idx_locked_position)
+
+        # Other locked position
+        _locked_position = IDXLockedPosition()
+        _locked_position.token_address = "other_token_address"
+        _locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        _locked_position.account_address = _account_address_1
+        _locked_position.value = 5
+        _locked_position.modified = datetime(2023, 10, 25, 0, 2, 0)
+        db.add(_locked_position)
+
+        idx_personal_info_3 = IDXPersonalInfo()
+        idx_personal_info_3.account_address = _account_address_3
+        idx_personal_info_3.issuer_address = _issuer_address
+        idx_personal_info_3.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test3",
+            "postal_code": "postal_code_test3",
+            "address": "address_test3",
+            "email": "email_test3",
+            "birth": "birth_test3",
+            # PersonalInfo is partially registered.
+        }
+        db.add(idx_personal_info_3)
+
+        db.commit()
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address),
+            headers={"issuer-address": _issuer_address},
+            params={"locked": 20, "locked_operator": 2},
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "result_set": {"count": 2, "total": 3, "offset": None, "limit": None},
+            "holders": [
+                {
+                    "account_address": _account_address_1,
+                    "personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test1",
+                        "postal_code": "postal_code_test1",
+                        "address": "address_test1",
+                        "email": "email_test1",
+                        "birth": "birth_test1",
+                        "is_corporate": False,
+                        "tax_category": 10,
+                    },
+                    "balance": 10,
+                    "exchange_balance": 11,
+                    "exchange_commitment": 12,
+                    "pending_transfer": 5,
+                    "locked": 10,
+                    "modified": "2023-10-24T01:10:00",
+                },
+                {
+                    "account_address": _account_address_2,
+                    "personal_information": {
+                        "key_manager": None,
+                        "name": None,
+                        "postal_code": None,
+                        "address": None,
+                        "email": None,
+                        "birth": None,
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 20,
+                    "exchange_balance": 21,
+                    "exchange_commitment": 22,
+                    "pending_transfer": 10,
+                    "locked": 20,
+                    "modified": "2023-10-24T02:20:00",
+                },
+            ],
+        }
+
+    # <Normal_4_5>
+    # Search filter: holder_name
+    def test_normal_4_5(self, client, db):
+        user = config_eth_account("user1")
+        _issuer_address = user["address"]
+        _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
+        _account_address_1 = "0xb75c7545b9230FEe99b7af370D38eBd3DAD929f7"
+        _account_address_2 = "0x3F198534Bbe3B2a197d3B317d41392F348EAC707"
+        _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
+
+        account = Account()
+        account.issuer_address = _issuer_address
+        db.add(account)
+
+        token = Token()
+        token.type = TokenType.IBET_SHARE.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        token.version = TokenVersion.V_22_12
+        db.add(token)
+
+        # prepare data: account_address_1
+        idx_position_1 = IDXPosition()
+        idx_position_1.token_address = _token_address
+        idx_position_1.account_address = _account_address_1
+        idx_position_1.balance = 10
+        idx_position_1.exchange_balance = 11
+        idx_position_1.exchange_commitment = 12
+        idx_position_1.pending_transfer = 5
+        idx_position_1.modified = datetime(2023, 10, 24, 0, 0, 0)
+        db.add(idx_position_1)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = _account_address_1
+        idx_personal_info_1.issuer_address = _issuer_address
+        idx_personal_info_1.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(idx_personal_info_1)
+
+        # prepare data: account_address_2
+        idx_position_2 = IDXPosition()
+        idx_position_2.token_address = _token_address
+        idx_position_2.account_address = _account_address_2
+        idx_position_2.balance = 20
+        idx_position_2.exchange_balance = 21
+        idx_position_2.exchange_commitment = 22
+        idx_position_2.pending_transfer = 10
+        idx_position_2.modified = datetime(2023, 10, 24, 2, 0, 0)
+        db.add(idx_position_2)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 20, 0)
+        db.add(idx_locked_position)
+
+        # prepare data: account_address_3
+        idx_position_3 = IDXPosition()
+        idx_position_3.token_address = _token_address
+        idx_position_3.account_address = _account_address_3
+        idx_position_3.balance = 99
+        idx_position_3.exchange_balance = 99
+        idx_position_3.exchange_commitment = 99
+        idx_position_3.pending_transfer = 99
+        idx_position_3.modified = datetime(2023, 10, 24, 3, 0, 0)
+        db.add(idx_position_3)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 4, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 5, 0, 0)
+        db.add(idx_locked_position)
+
+        # Other locked position
+        _locked_position = IDXLockedPosition()
+        _locked_position.token_address = "other_token_address"
+        _locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        _locked_position.account_address = _account_address_1
+        _locked_position.value = 5
+        _locked_position.modified = datetime(2023, 10, 25, 0, 2, 0)
+        db.add(_locked_position)
+
+        idx_personal_info_3 = IDXPersonalInfo()
+        idx_personal_info_3.account_address = _account_address_3
+        idx_personal_info_3.issuer_address = _issuer_address
+        idx_personal_info_3.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test3",
+            "postal_code": "postal_code_test3",
+            "address": "address_test3",
+            "email": "email_test3",
+            "birth": "birth_test3",
+            # PersonalInfo is partially registered.
+        }
+        db.add(idx_personal_info_3)
+
+        db.commit()
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address),
+            headers={"issuer-address": _issuer_address},
+            params={"holder_name": "test3"},
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "result_set": {"count": 1, "total": 3, "offset": None, "limit": None},
+            "holders": [
+                {
+                    "account_address": _account_address_3,
+                    "personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test3",
+                        "postal_code": "postal_code_test3",
+                        "address": "address_test3",
+                        "email": "email_test3",
+                        "birth": "birth_test3",
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 99,
+                    "exchange_balance": 99,
+                    "exchange_commitment": 99,
+                    "pending_transfer": 99,
+                    "locked": 30,
+                    "modified": "2023-10-24T05:00:00",
+                },
+            ],
+        }
+
+    # <Normal_5_1>
+    # Sort Item: created
+    def test_normal_5_1(self, client, db):
+        user = config_eth_account("user1")
+        _issuer_address = user["address"]
+        _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
+        _account_address_1 = "0xb75c7545b9230FEe99b7af370D38eBd3DAD929f7"
+        _account_address_2 = "0x3F198534Bbe3B2a197d3B317d41392F348EAC707"
+        _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
+
+        account = Account()
+        account.issuer_address = _issuer_address
+        db.add(account)
+
+        token = Token()
+        token.type = TokenType.IBET_SHARE.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        token.version = TokenVersion.V_22_12
+        db.add(token)
+
+        # prepare data: account_address_1
+        idx_position_1 = IDXPosition()
+        idx_position_1.token_address = _token_address
+        idx_position_1.account_address = _account_address_1
+        idx_position_1.balance = 10
+        idx_position_1.exchange_balance = 11
+        idx_position_1.exchange_commitment = 12
+        idx_position_1.pending_transfer = 5
+        idx_position_1.created = datetime(2023, 10, 24, 0, 0, 0)
+        idx_position_1.modified = datetime(2023, 10, 24, 0, 0, 0)
+        db.add(idx_position_1)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = _account_address_1
+        idx_personal_info_1.issuer_address = _issuer_address
+        idx_personal_info_1.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(idx_personal_info_1)
+
+        # prepare data: account_address_2
+        idx_position_2 = IDXPosition()
+        idx_position_2.token_address = _token_address
+        idx_position_2.account_address = _account_address_2
+        idx_position_2.balance = 20
+        idx_position_2.exchange_balance = 21
+        idx_position_2.exchange_commitment = 22
+        idx_position_2.pending_transfer = 10
+        idx_position_2.created = datetime(2023, 10, 24, 2, 0, 0)
+        idx_position_2.modified = datetime(2023, 10, 24, 2, 0, 0)
+        db.add(idx_position_2)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 20, 0)
+        db.add(idx_locked_position)
+
+        # prepare data: account_address_3
+        idx_position_3 = IDXPosition()
+        idx_position_3.token_address = _token_address
+        idx_position_3.account_address = _account_address_3
+        idx_position_3.balance = 99
+        idx_position_3.exchange_balance = 99
+        idx_position_3.exchange_commitment = 99
+        idx_position_3.pending_transfer = 99
+        idx_position_3.created = datetime(2023, 10, 24, 3, 0, 0)
+        idx_position_3.modified = datetime(2023, 10, 24, 3, 0, 0)
+        db.add(idx_position_3)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 4, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 5, 0, 0)
+        db.add(idx_locked_position)
+
+        # Other locked position
+        _locked_position = IDXLockedPosition()
+        _locked_position.token_address = "other_token_address"
+        _locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        _locked_position.account_address = _account_address_1
+        _locked_position.value = 5
+        _locked_position.modified = datetime(2023, 10, 25, 0, 2, 0)
+        db.add(_locked_position)
+
+        idx_personal_info_3 = IDXPersonalInfo()
+        idx_personal_info_3.account_address = _account_address_3
+        idx_personal_info_3.issuer_address = _issuer_address
+        idx_personal_info_3.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test3",
+            "postal_code": "postal_code_test3",
+            "address": "address_test3",
+            "email": "email_test3",
+            "birth": "birth_test3",
+            # PersonalInfo is partially registered.
+        }
+        db.add(idx_personal_info_3)
+
+        db.commit()
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address),
+            headers={"issuer-address": _issuer_address},
+            params={"sort_order": 1, "sort_item": "created"},
         )
 
         # assertion
@@ -948,9 +2994,1206 @@ class TestAppRoutersShareTokensTokenAddressHoldersGET:
             ],
         }
 
-    # <Normal_5_1>
+    # <Normal_5_2>
+    # Sort Item: account_address
+    def test_normal_5_2(self, client, db):
+        user = config_eth_account("user1")
+        _issuer_address = user["address"]
+        _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
+        _account_address_1 = "0xb75c7545b9230FEe99b7af370D38eBd3DAD929f7"
+        _account_address_2 = "0x3F198534Bbe3B2a197d3B317d41392F348EAC707"
+        _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
+
+        account = Account()
+        account.issuer_address = _issuer_address
+        db.add(account)
+
+        token = Token()
+        token.type = TokenType.IBET_SHARE.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        token.version = TokenVersion.V_22_12
+        db.add(token)
+
+        # prepare data: account_address_1
+        idx_position_1 = IDXPosition()
+        idx_position_1.token_address = _token_address
+        idx_position_1.account_address = _account_address_1
+        idx_position_1.balance = 10
+        idx_position_1.exchange_balance = 11
+        idx_position_1.exchange_commitment = 12
+        idx_position_1.pending_transfer = 5
+        idx_position_1.created = datetime(2023, 10, 24, 0, 0, 0)
+        idx_position_1.modified = datetime(2023, 10, 24, 0, 0, 0)
+        db.add(idx_position_1)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = _account_address_1
+        idx_personal_info_1.issuer_address = _issuer_address
+        idx_personal_info_1.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(idx_personal_info_1)
+
+        # prepare data: account_address_2
+        idx_position_2 = IDXPosition()
+        idx_position_2.token_address = _token_address
+        idx_position_2.account_address = _account_address_2
+        idx_position_2.balance = 20
+        idx_position_2.exchange_balance = 21
+        idx_position_2.exchange_commitment = 22
+        idx_position_2.pending_transfer = 10
+        idx_position_2.created = datetime(2023, 10, 24, 2, 0, 0)
+        idx_position_2.modified = datetime(2023, 10, 24, 2, 0, 0)
+        db.add(idx_position_2)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 20, 0)
+        db.add(idx_locked_position)
+
+        # prepare data: account_address_3
+        idx_position_3 = IDXPosition()
+        idx_position_3.token_address = _token_address
+        idx_position_3.account_address = _account_address_3
+        idx_position_3.balance = 99
+        idx_position_3.exchange_balance = 99
+        idx_position_3.exchange_commitment = 99
+        idx_position_3.pending_transfer = 99
+        idx_position_3.created = datetime(2023, 10, 24, 3, 0, 0)
+        idx_position_3.modified = datetime(2023, 10, 24, 3, 0, 0)
+        db.add(idx_position_3)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 4, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 5, 0, 0)
+        db.add(idx_locked_position)
+
+        # Other locked position
+        _locked_position = IDXLockedPosition()
+        _locked_position.token_address = "other_token_address"
+        _locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        _locked_position.account_address = _account_address_1
+        _locked_position.value = 5
+        _locked_position.modified = datetime(2023, 10, 25, 0, 2, 0)
+        db.add(_locked_position)
+
+        idx_personal_info_3 = IDXPersonalInfo()
+        idx_personal_info_3.account_address = _account_address_3
+        idx_personal_info_3.issuer_address = _issuer_address
+        idx_personal_info_3.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test3",
+            "postal_code": "postal_code_test3",
+            "address": "address_test3",
+            "email": "email_test3",
+            "birth": "birth_test3",
+            # PersonalInfo is partially registered.
+        }
+        db.add(idx_personal_info_3)
+
+        db.commit()
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address),
+            headers={"issuer-address": _issuer_address},
+            params={"sort_order": 0, "sort_item": "account_address"},
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "result_set": {"count": 3, "total": 3, "offset": None, "limit": None},
+            "holders": [
+                {
+                    "account_address": _account_address_2,
+                    "personal_information": {
+                        "key_manager": None,
+                        "name": None,
+                        "postal_code": None,
+                        "address": None,
+                        "email": None,
+                        "birth": None,
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 20,
+                    "exchange_balance": 21,
+                    "exchange_commitment": 22,
+                    "pending_transfer": 10,
+                    "locked": 20,
+                    "modified": "2023-10-24T02:20:00",
+                },
+                {
+                    "account_address": _account_address_3,
+                    "personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test3",
+                        "postal_code": "postal_code_test3",
+                        "address": "address_test3",
+                        "email": "email_test3",
+                        "birth": "birth_test3",
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 99,
+                    "exchange_balance": 99,
+                    "exchange_commitment": 99,
+                    "pending_transfer": 99,
+                    "locked": 30,
+                    "modified": "2023-10-24T05:00:00",
+                },
+                {
+                    "account_address": _account_address_1,
+                    "personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test1",
+                        "postal_code": "postal_code_test1",
+                        "address": "address_test1",
+                        "email": "email_test1",
+                        "birth": "birth_test1",
+                        "is_corporate": False,
+                        "tax_category": 10,
+                    },
+                    "balance": 10,
+                    "exchange_balance": 11,
+                    "exchange_commitment": 12,
+                    "pending_transfer": 5,
+                    "locked": 10,
+                    "modified": "2023-10-24T01:10:00",
+                },
+            ],
+        }
+
+    # <Normal_5_3>
+    # Sort Item: balance
+    def test_normal_5_3(self, client, db):
+        user = config_eth_account("user1")
+        _issuer_address = user["address"]
+        _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
+        _account_address_1 = "0xb75c7545b9230FEe99b7af370D38eBd3DAD929f7"
+        _account_address_2 = "0x3F198534Bbe3B2a197d3B317d41392F348EAC707"
+        _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
+
+        account = Account()
+        account.issuer_address = _issuer_address
+        db.add(account)
+
+        token = Token()
+        token.type = TokenType.IBET_SHARE.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        token.version = TokenVersion.V_22_12
+        db.add(token)
+
+        # prepare data: account_address_1
+        idx_position_1 = IDXPosition()
+        idx_position_1.token_address = _token_address
+        idx_position_1.account_address = _account_address_1
+        idx_position_1.balance = 10
+        idx_position_1.exchange_balance = 11
+        idx_position_1.exchange_commitment = 12
+        idx_position_1.pending_transfer = 5
+        idx_position_1.created = datetime(2023, 10, 24, 0, 0, 0)
+        idx_position_1.modified = datetime(2023, 10, 24, 0, 0, 0)
+        db.add(idx_position_1)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = _account_address_1
+        idx_personal_info_1.issuer_address = _issuer_address
+        idx_personal_info_1.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(idx_personal_info_1)
+
+        # prepare data: account_address_2
+        idx_position_2 = IDXPosition()
+        idx_position_2.token_address = _token_address
+        idx_position_2.account_address = _account_address_2
+        idx_position_2.balance = 20
+        idx_position_2.exchange_balance = 21
+        idx_position_2.exchange_commitment = 22
+        idx_position_2.pending_transfer = 10
+        idx_position_2.created = datetime(2023, 10, 24, 2, 0, 0)
+        idx_position_2.modified = datetime(2023, 10, 24, 2, 0, 0)
+        db.add(idx_position_2)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 20, 0)
+        db.add(idx_locked_position)
+
+        # prepare data: account_address_3
+        idx_position_3 = IDXPosition()
+        idx_position_3.token_address = _token_address
+        idx_position_3.account_address = _account_address_3
+        idx_position_3.balance = 99
+        idx_position_3.exchange_balance = 99
+        idx_position_3.exchange_commitment = 99
+        idx_position_3.pending_transfer = 99
+        idx_position_3.created = datetime(2023, 10, 24, 3, 0, 0)
+        idx_position_3.modified = datetime(2023, 10, 24, 3, 0, 0)
+        db.add(idx_position_3)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 4, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 5, 0, 0)
+        db.add(idx_locked_position)
+
+        # Other locked position
+        _locked_position = IDXLockedPosition()
+        _locked_position.token_address = "other_token_address"
+        _locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        _locked_position.account_address = _account_address_1
+        _locked_position.value = 5
+        _locked_position.modified = datetime(2023, 10, 25, 0, 2, 0)
+        db.add(_locked_position)
+
+        idx_personal_info_3 = IDXPersonalInfo()
+        idx_personal_info_3.account_address = _account_address_3
+        idx_personal_info_3.issuer_address = _issuer_address
+        idx_personal_info_3.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test3",
+            "postal_code": "postal_code_test3",
+            "address": "address_test3",
+            "email": "email_test3",
+            "birth": "birth_test3",
+            # PersonalInfo is partially registered.
+        }
+        db.add(idx_personal_info_3)
+
+        db.commit()
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address),
+            headers={"issuer-address": _issuer_address},
+            params={"sort_order": 1, "sort_item": "balance"},
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "result_set": {"count": 3, "total": 3, "offset": None, "limit": None},
+            "holders": [
+                {
+                    "account_address": _account_address_3,
+                    "personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test3",
+                        "postal_code": "postal_code_test3",
+                        "address": "address_test3",
+                        "email": "email_test3",
+                        "birth": "birth_test3",
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 99,
+                    "exchange_balance": 99,
+                    "exchange_commitment": 99,
+                    "pending_transfer": 99,
+                    "locked": 30,
+                    "modified": "2023-10-24T05:00:00",
+                },
+                {
+                    "account_address": _account_address_2,
+                    "personal_information": {
+                        "key_manager": None,
+                        "name": None,
+                        "postal_code": None,
+                        "address": None,
+                        "email": None,
+                        "birth": None,
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 20,
+                    "exchange_balance": 21,
+                    "exchange_commitment": 22,
+                    "pending_transfer": 10,
+                    "locked": 20,
+                    "modified": "2023-10-24T02:20:00",
+                },
+                {
+                    "account_address": _account_address_1,
+                    "personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test1",
+                        "postal_code": "postal_code_test1",
+                        "address": "address_test1",
+                        "email": "email_test1",
+                        "birth": "birth_test1",
+                        "is_corporate": False,
+                        "tax_category": 10,
+                    },
+                    "balance": 10,
+                    "exchange_balance": 11,
+                    "exchange_commitment": 12,
+                    "pending_transfer": 5,
+                    "locked": 10,
+                    "modified": "2023-10-24T01:10:00",
+                },
+            ],
+        }
+
+    # <Normal_5_4>
+    # Sort Item: pending_transfer
+    def test_normal_5_4(self, client, db):
+        user = config_eth_account("user1")
+        _issuer_address = user["address"]
+        _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
+        _account_address_1 = "0xb75c7545b9230FEe99b7af370D38eBd3DAD929f7"
+        _account_address_2 = "0x3F198534Bbe3B2a197d3B317d41392F348EAC707"
+        _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
+
+        account = Account()
+        account.issuer_address = _issuer_address
+        db.add(account)
+
+        token = Token()
+        token.type = TokenType.IBET_SHARE.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        token.version = TokenVersion.V_22_12
+        db.add(token)
+
+        # prepare data: account_address_1
+        idx_position_1 = IDXPosition()
+        idx_position_1.token_address = _token_address
+        idx_position_1.account_address = _account_address_1
+        idx_position_1.balance = 10
+        idx_position_1.exchange_balance = 11
+        idx_position_1.exchange_commitment = 12
+        idx_position_1.pending_transfer = 5
+        idx_position_1.created = datetime(2023, 10, 24, 0, 0, 0)
+        idx_position_1.modified = datetime(2023, 10, 24, 0, 0, 0)
+        db.add(idx_position_1)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = _account_address_1
+        idx_personal_info_1.issuer_address = _issuer_address
+        idx_personal_info_1.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(idx_personal_info_1)
+
+        # prepare data: account_address_2
+        idx_position_2 = IDXPosition()
+        idx_position_2.token_address = _token_address
+        idx_position_2.account_address = _account_address_2
+        idx_position_2.balance = 20
+        idx_position_2.exchange_balance = 21
+        idx_position_2.exchange_commitment = 22
+        idx_position_2.pending_transfer = 10
+        idx_position_2.created = datetime(2023, 10, 24, 2, 0, 0)
+        idx_position_2.modified = datetime(2023, 10, 24, 2, 0, 0)
+        db.add(idx_position_2)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 20, 0)
+        db.add(idx_locked_position)
+
+        # prepare data: account_address_3
+        idx_position_3 = IDXPosition()
+        idx_position_3.token_address = _token_address
+        idx_position_3.account_address = _account_address_3
+        idx_position_3.balance = 99
+        idx_position_3.exchange_balance = 99
+        idx_position_3.exchange_commitment = 99
+        idx_position_3.pending_transfer = 99
+        idx_position_3.created = datetime(2023, 10, 24, 3, 0, 0)
+        idx_position_3.modified = datetime(2023, 10, 24, 3, 0, 0)
+        db.add(idx_position_3)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 4, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 5, 0, 0)
+        db.add(idx_locked_position)
+
+        # Other locked position
+        _locked_position = IDXLockedPosition()
+        _locked_position.token_address = "other_token_address"
+        _locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        _locked_position.account_address = _account_address_1
+        _locked_position.value = 5
+        _locked_position.modified = datetime(2023, 10, 25, 0, 2, 0)
+        db.add(_locked_position)
+
+        idx_personal_info_3 = IDXPersonalInfo()
+        idx_personal_info_3.account_address = _account_address_3
+        idx_personal_info_3.issuer_address = _issuer_address
+        idx_personal_info_3.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test3",
+            "postal_code": "postal_code_test3",
+            "address": "address_test3",
+            "email": "email_test3",
+            "birth": "birth_test3",
+            # PersonalInfo is partially registered.
+        }
+        db.add(idx_personal_info_3)
+
+        db.commit()
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address),
+            headers={"issuer-address": _issuer_address},
+            params={"sort_order": 1, "sort_item": "pending_transfer"},
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "result_set": {"count": 3, "total": 3, "offset": None, "limit": None},
+            "holders": [
+                {
+                    "account_address": _account_address_3,
+                    "personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test3",
+                        "postal_code": "postal_code_test3",
+                        "address": "address_test3",
+                        "email": "email_test3",
+                        "birth": "birth_test3",
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 99,
+                    "exchange_balance": 99,
+                    "exchange_commitment": 99,
+                    "pending_transfer": 99,
+                    "locked": 30,
+                    "modified": "2023-10-24T05:00:00",
+                },
+                {
+                    "account_address": _account_address_2,
+                    "personal_information": {
+                        "key_manager": None,
+                        "name": None,
+                        "postal_code": None,
+                        "address": None,
+                        "email": None,
+                        "birth": None,
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 20,
+                    "exchange_balance": 21,
+                    "exchange_commitment": 22,
+                    "pending_transfer": 10,
+                    "locked": 20,
+                    "modified": "2023-10-24T02:20:00",
+                },
+                {
+                    "account_address": _account_address_1,
+                    "personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test1",
+                        "postal_code": "postal_code_test1",
+                        "address": "address_test1",
+                        "email": "email_test1",
+                        "birth": "birth_test1",
+                        "is_corporate": False,
+                        "tax_category": 10,
+                    },
+                    "balance": 10,
+                    "exchange_balance": 11,
+                    "exchange_commitment": 12,
+                    "pending_transfer": 5,
+                    "locked": 10,
+                    "modified": "2023-10-24T01:10:00",
+                },
+            ],
+        }
+
+    # <Normal_5_5>
+    # Sort Item: locked
+    def test_normal_5_5(self, client, db):
+        user = config_eth_account("user1")
+        _issuer_address = user["address"]
+        _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
+        _account_address_1 = "0xb75c7545b9230FEe99b7af370D38eBd3DAD929f7"
+        _account_address_2 = "0x3F198534Bbe3B2a197d3B317d41392F348EAC707"
+        _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
+
+        account = Account()
+        account.issuer_address = _issuer_address
+        db.add(account)
+
+        token = Token()
+        token.type = TokenType.IBET_SHARE.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        token.version = TokenVersion.V_22_12
+        db.add(token)
+
+        # prepare data: account_address_1
+        idx_position_1 = IDXPosition()
+        idx_position_1.token_address = _token_address
+        idx_position_1.account_address = _account_address_1
+        idx_position_1.balance = 10
+        idx_position_1.exchange_balance = 11
+        idx_position_1.exchange_commitment = 12
+        idx_position_1.pending_transfer = 5
+        idx_position_1.created = datetime(2023, 10, 24, 0, 0, 0)
+        idx_position_1.modified = datetime(2023, 10, 24, 0, 0, 0)
+        db.add(idx_position_1)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = _account_address_1
+        idx_personal_info_1.issuer_address = _issuer_address
+        idx_personal_info_1.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(idx_personal_info_1)
+
+        # prepare data: account_address_2
+        idx_position_2 = IDXPosition()
+        idx_position_2.token_address = _token_address
+        idx_position_2.account_address = _account_address_2
+        idx_position_2.balance = 20
+        idx_position_2.exchange_balance = 21
+        idx_position_2.exchange_commitment = 22
+        idx_position_2.pending_transfer = 10
+        idx_position_2.created = datetime(2023, 10, 24, 2, 0, 0)
+        idx_position_2.modified = datetime(2023, 10, 24, 2, 0, 0)
+        db.add(idx_position_2)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 20, 0)
+        db.add(idx_locked_position)
+
+        # prepare data: account_address_3
+        idx_position_3 = IDXPosition()
+        idx_position_3.token_address = _token_address
+        idx_position_3.account_address = _account_address_3
+        idx_position_3.balance = 99
+        idx_position_3.exchange_balance = 99
+        idx_position_3.exchange_commitment = 99
+        idx_position_3.pending_transfer = 99
+        idx_position_3.created = datetime(2023, 10, 24, 3, 0, 0)
+        idx_position_3.modified = datetime(2023, 10, 24, 3, 0, 0)
+        db.add(idx_position_3)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 4, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 5, 0, 0)
+        db.add(idx_locked_position)
+
+        # Other locked position
+        _locked_position = IDXLockedPosition()
+        _locked_position.token_address = "other_token_address"
+        _locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        _locked_position.account_address = _account_address_1
+        _locked_position.value = 5
+        _locked_position.modified = datetime(2023, 10, 25, 0, 2, 0)
+        db.add(_locked_position)
+
+        idx_personal_info_3 = IDXPersonalInfo()
+        idx_personal_info_3.account_address = _account_address_3
+        idx_personal_info_3.issuer_address = _issuer_address
+        idx_personal_info_3.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test3",
+            "postal_code": "postal_code_test3",
+            "address": "address_test3",
+            "email": "email_test3",
+            "birth": "birth_test3",
+            # PersonalInfo is partially registered.
+        }
+        db.add(idx_personal_info_3)
+
+        db.commit()
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address),
+            headers={"issuer-address": _issuer_address},
+            params={"sort_order": 1, "sort_item": "locked"},
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "result_set": {"count": 3, "total": 3, "offset": None, "limit": None},
+            "holders": [
+                {
+                    "account_address": _account_address_3,
+                    "personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test3",
+                        "postal_code": "postal_code_test3",
+                        "address": "address_test3",
+                        "email": "email_test3",
+                        "birth": "birth_test3",
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 99,
+                    "exchange_balance": 99,
+                    "exchange_commitment": 99,
+                    "pending_transfer": 99,
+                    "locked": 30,
+                    "modified": "2023-10-24T05:00:00",
+                },
+                {
+                    "account_address": _account_address_2,
+                    "personal_information": {
+                        "key_manager": None,
+                        "name": None,
+                        "postal_code": None,
+                        "address": None,
+                        "email": None,
+                        "birth": None,
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 20,
+                    "exchange_balance": 21,
+                    "exchange_commitment": 22,
+                    "pending_transfer": 10,
+                    "locked": 20,
+                    "modified": "2023-10-24T02:20:00",
+                },
+                {
+                    "account_address": _account_address_1,
+                    "personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test1",
+                        "postal_code": "postal_code_test1",
+                        "address": "address_test1",
+                        "email": "email_test1",
+                        "birth": "birth_test1",
+                        "is_corporate": False,
+                        "tax_category": 10,
+                    },
+                    "balance": 10,
+                    "exchange_balance": 11,
+                    "exchange_commitment": 12,
+                    "pending_transfer": 5,
+                    "locked": 10,
+                    "modified": "2023-10-24T01:10:00",
+                },
+            ],
+        }
+
+    # <Normal_5_6>
+    # Sort Item: holder_name
+    def test_normal_5_6(self, client, db):
+        user = config_eth_account("user1")
+        _issuer_address = user["address"]
+        _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
+        _account_address_1 = "0xb75c7545b9230FEe99b7af370D38eBd3DAD929f7"
+        _account_address_2 = "0x3F198534Bbe3B2a197d3B317d41392F348EAC707"
+        _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
+        _account_address_4 = "0x917eFFaC072dcda308e2337636f562D0A96F42eA"
+
+        account = Account()
+        account.issuer_address = _issuer_address
+        db.add(account)
+
+        token = Token()
+        token.type = TokenType.IBET_SHARE.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        token.version = TokenVersion.V_22_12
+        db.add(token)
+
+        # prepare data: account_address_1
+        idx_position_1 = IDXPosition()
+        idx_position_1.token_address = _token_address
+        idx_position_1.account_address = _account_address_1
+        idx_position_1.balance = 10
+        idx_position_1.exchange_balance = 11
+        idx_position_1.exchange_commitment = 12
+        idx_position_1.pending_transfer = 5
+        idx_position_1.created = datetime(2023, 10, 24, 0, 0, 0)
+        idx_position_1.modified = datetime(2023, 10, 24, 0, 0, 0)
+        db.add(idx_position_1)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = _account_address_1
+        idx_personal_info_1.issuer_address = _issuer_address
+        idx_personal_info_1.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(idx_personal_info_1)
+
+        # prepare data: account_address_2
+        idx_position_2 = IDXPosition()
+        idx_position_2.token_address = _token_address
+        idx_position_2.account_address = _account_address_2
+        idx_position_2.balance = 20
+        idx_position_2.exchange_balance = 21
+        idx_position_2.exchange_commitment = 22
+        idx_position_2.pending_transfer = 10
+        idx_position_2.created = datetime(2023, 10, 24, 2, 0, 0)
+        idx_position_2.modified = datetime(2023, 10, 24, 2, 0, 0)
+        db.add(idx_position_2)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 20, 0)
+        db.add(idx_locked_position)
+
+        # prepare data: account_address_3
+        idx_position_3 = IDXPosition()
+        idx_position_3.token_address = _token_address
+        idx_position_3.account_address = _account_address_3
+        idx_position_3.balance = 99
+        idx_position_3.exchange_balance = 99
+        idx_position_3.exchange_commitment = 99
+        idx_position_3.pending_transfer = 99
+        idx_position_3.created = datetime(2023, 10, 24, 3, 0, 0)
+        idx_position_3.modified = datetime(2023, 10, 24, 3, 0, 0)
+        db.add(idx_position_3)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 4, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 5, 0, 0)
+        db.add(idx_locked_position)
+
+        # Other locked position
+        _locked_position = IDXLockedPosition()
+        _locked_position.token_address = "other_token_address"
+        _locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        _locked_position.account_address = _account_address_1
+        _locked_position.value = 5
+        _locked_position.modified = datetime(2023, 10, 25, 0, 2, 0)
+        db.add(_locked_position)
+
+        idx_personal_info_3 = IDXPersonalInfo()
+        idx_personal_info_3.account_address = _account_address_3
+        idx_personal_info_3.issuer_address = _issuer_address
+        idx_personal_info_3.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test3",
+            "postal_code": "postal_code_test3",
+            "address": "address_test3",
+            "email": "email_test3",
+            "birth": "birth_test3",
+            # PersonalInfo is partially registered.
+        }
+        db.add(idx_personal_info_3)
+
+        # prepare data: account_address_4
+        idx_position_4 = IDXPosition()
+        idx_position_4.token_address = _token_address
+        idx_position_4.account_address = _account_address_4
+        idx_position_4.balance = 100
+        idx_position_4.exchange_balance = 100
+        idx_position_4.exchange_commitment = 100
+        idx_position_4.pending_transfer = 100
+        idx_position_4.created = datetime(2023, 10, 24, 6, 0, 0)
+        idx_position_4.modified = datetime(2023, 10, 24, 6, 0, 0)
+        db.add(idx_position_4)
+
+        db.commit()
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address),
+            headers={"issuer-address": _issuer_address},
+            params={"sort_order": 1, "sort_item": "holder_name"},
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "result_set": {"count": 4, "total": 4, "offset": None, "limit": None},
+            "holders": [
+                {
+                    "account_address": _account_address_2,
+                    "personal_information": {
+                        "key_manager": None,
+                        "name": None,
+                        "postal_code": None,
+                        "address": None,
+                        "email": None,
+                        "birth": None,
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 20,
+                    "exchange_balance": 21,
+                    "exchange_commitment": 22,
+                    "pending_transfer": 10,
+                    "locked": 20,
+                    "modified": "2023-10-24T02:20:00",
+                },
+                {
+                    "account_address": _account_address_4,
+                    "personal_information": {
+                        "key_manager": None,
+                        "name": None,
+                        "postal_code": None,
+                        "address": None,
+                        "email": None,
+                        "birth": None,
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 100,
+                    "exchange_balance": 100,
+                    "exchange_commitment": 100,
+                    "pending_transfer": 100,
+                    "locked": 0,
+                    "modified": "2023-10-24T06:00:00",
+                },
+                {
+                    "account_address": _account_address_3,
+                    "personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test3",
+                        "postal_code": "postal_code_test3",
+                        "address": "address_test3",
+                        "email": "email_test3",
+                        "birth": "birth_test3",
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 99,
+                    "exchange_balance": 99,
+                    "exchange_commitment": 99,
+                    "pending_transfer": 99,
+                    "locked": 30,
+                    "modified": "2023-10-24T05:00:00",
+                },
+                {
+                    "account_address": _account_address_1,
+                    "personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test1",
+                        "postal_code": "postal_code_test1",
+                        "address": "address_test1",
+                        "email": "email_test1",
+                        "birth": "birth_test1",
+                        "is_corporate": False,
+                        "tax_category": 10,
+                    },
+                    "balance": 10,
+                    "exchange_balance": 11,
+                    "exchange_commitment": 12,
+                    "pending_transfer": 5,
+                    "locked": 10,
+                    "modified": "2023-10-24T01:10:00",
+                },
+            ],
+        }
+
+    # <Normal_6_1>
     # Pagination
-    def test_normal_5_1(self, client, db):
+    def test_normal_6_1(self, client, db):
         user = config_eth_account("user1")
         _issuer_address = user["address"]
         _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
@@ -1159,9 +4402,9 @@ class TestAppRoutersShareTokensTokenAddressHoldersGET:
             ],
         }
 
-    # <Normal_5_2>
+    # <Normal_6_2>
     # Pagination (over offset)
-    def test_normal_5_2(self, client, db):
+    def test_normal_6_2(self, client, db):
         user = config_eth_account("user1")
         _issuer_address = user["address"]
         _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"

--- a/tests/test_app_routers_share_tokens_{token_address}_holders_GET.py
+++ b/tests/test_app_routers_share_tokens_{token_address}_holders_GET.py
@@ -2761,6 +2761,409 @@ class TestAppRoutersShareTokensTokenAddressHoldersGET:
             ],
         }
 
+    # <Normal_4_6>
+    # Search filter: key_manager
+    def test_normal_4_6(self, client, db):
+        user = config_eth_account("user1")
+        _issuer_address = user["address"]
+        _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
+        _account_address_1 = "0xb75c7545b9230FEe99b7af370D38eBd3DAD929f7"
+        _account_address_2 = "0x3F198534Bbe3B2a197d3B317d41392F348EAC707"
+        _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
+
+        account = Account()
+        account.issuer_address = _issuer_address
+        db.add(account)
+
+        token = Token()
+        token.type = TokenType.IBET_SHARE.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        token.version = TokenVersion.V_22_12
+        db.add(token)
+
+        # prepare data: account_address_1
+        idx_position_1 = IDXPosition()
+        idx_position_1.token_address = _token_address
+        idx_position_1.account_address = _account_address_1
+        idx_position_1.balance = 10
+        idx_position_1.exchange_balance = 11
+        idx_position_1.exchange_commitment = 12
+        idx_position_1.pending_transfer = 5
+        idx_position_1.modified = datetime(2023, 10, 24, 0, 0, 0)
+        db.add(idx_position_1)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = _account_address_1
+        idx_personal_info_1.issuer_address = _issuer_address
+        idx_personal_info_1.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(idx_personal_info_1)
+
+        # prepare data: account_address_2
+        idx_position_2 = IDXPosition()
+        idx_position_2.token_address = _token_address
+        idx_position_2.account_address = _account_address_2
+        idx_position_2.balance = 20
+        idx_position_2.exchange_balance = 21
+        idx_position_2.exchange_commitment = 22
+        idx_position_2.pending_transfer = 10
+        idx_position_2.modified = datetime(2023, 10, 24, 2, 0, 0)
+        db.add(idx_position_2)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 20, 0)
+        db.add(idx_locked_position)
+
+        # prepare data: account_address_3
+        idx_position_3 = IDXPosition()
+        idx_position_3.token_address = _token_address
+        idx_position_3.account_address = _account_address_3
+        idx_position_3.balance = 99
+        idx_position_3.exchange_balance = 99
+        idx_position_3.exchange_commitment = 99
+        idx_position_3.pending_transfer = 99
+        idx_position_3.modified = datetime(2023, 10, 24, 3, 0, 0)
+        db.add(idx_position_3)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 4, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 5, 0, 0)
+        db.add(idx_locked_position)
+
+        # Other locked position
+        _locked_position = IDXLockedPosition()
+        _locked_position.token_address = "other_token_address"
+        _locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        _locked_position.account_address = _account_address_1
+        _locked_position.value = 5
+        _locked_position.modified = datetime(2023, 10, 25, 0, 2, 0)
+        db.add(_locked_position)
+
+        idx_personal_info_3 = IDXPersonalInfo()
+        idx_personal_info_3.account_address = _account_address_3
+        idx_personal_info_3.issuer_address = _issuer_address
+        idx_personal_info_3.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test3",
+            "postal_code": "postal_code_test3",
+            "address": "address_test3",
+            "email": "email_test3",
+            "birth": "birth_test3",
+            # PersonalInfo is partially registered.
+        }
+        db.add(idx_personal_info_3)
+
+        db.commit()
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address),
+            headers={"issuer-address": _issuer_address},
+            params={"key_manager": "_test1"},
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "result_set": {"count": 2, "total": 3, "offset": None, "limit": None},
+            "holders": [
+                {
+                    "account_address": _account_address_1,
+                    "personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test1",
+                        "postal_code": "postal_code_test1",
+                        "address": "address_test1",
+                        "email": "email_test1",
+                        "birth": "birth_test1",
+                        "is_corporate": False,
+                        "tax_category": 10,
+                    },
+                    "balance": 10,
+                    "exchange_balance": 11,
+                    "exchange_commitment": 12,
+                    "pending_transfer": 5,
+                    "locked": 10,
+                    "modified": "2023-10-24T01:10:00",
+                },
+                {
+                    "account_address": _account_address_3,
+                    "personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test3",
+                        "postal_code": "postal_code_test3",
+                        "address": "address_test3",
+                        "email": "email_test3",
+                        "birth": "birth_test3",
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 99,
+                    "exchange_balance": 99,
+                    "exchange_commitment": 99,
+                    "pending_transfer": 99,
+                    "locked": 30,
+                    "modified": "2023-10-24T05:00:00",
+                },
+            ],
+        }
+
+    # <Normal_4_7>
+    # Search filter: account_address
+    def test_normal_4_7(self, client, db):
+        user = config_eth_account("user1")
+        _issuer_address = user["address"]
+        _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
+        _account_address_1 = "0xb75c7545b9230FEe99b7af370D38eBd3DAD929f7"
+        _account_address_2 = "0x3F198534Bbe3B2a197d3B317d41392F348EAC707"
+        _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
+
+        account = Account()
+        account.issuer_address = _issuer_address
+        db.add(account)
+
+        token = Token()
+        token.type = TokenType.IBET_SHARE.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        token.version = TokenVersion.V_22_12
+        db.add(token)
+
+        # prepare data: account_address_1
+        idx_position_1 = IDXPosition()
+        idx_position_1.token_address = _token_address
+        idx_position_1.account_address = _account_address_1
+        idx_position_1.balance = 10
+        idx_position_1.exchange_balance = 11
+        idx_position_1.exchange_commitment = 12
+        idx_position_1.pending_transfer = 5
+        idx_position_1.modified = datetime(2023, 10, 24, 0, 0, 0)
+        db.add(idx_position_1)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = _account_address_1
+        idx_personal_info_1.issuer_address = _issuer_address
+        idx_personal_info_1.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(idx_personal_info_1)
+
+        # prepare data: account_address_2
+        idx_position_2 = IDXPosition()
+        idx_position_2.token_address = _token_address
+        idx_position_2.account_address = _account_address_2
+        idx_position_2.balance = 20
+        idx_position_2.exchange_balance = 21
+        idx_position_2.exchange_commitment = 22
+        idx_position_2.pending_transfer = 10
+        idx_position_2.modified = datetime(2023, 10, 24, 2, 0, 0)
+        db.add(idx_position_2)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 20, 0)
+        db.add(idx_locked_position)
+
+        # prepare data: account_address_3
+        idx_position_3 = IDXPosition()
+        idx_position_3.token_address = _token_address
+        idx_position_3.account_address = _account_address_3
+        idx_position_3.balance = 99
+        idx_position_3.exchange_balance = 99
+        idx_position_3.exchange_commitment = 99
+        idx_position_3.pending_transfer = 99
+        idx_position_3.modified = datetime(2023, 10, 24, 3, 0, 0)
+        db.add(idx_position_3)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 4, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 5, 0, 0)
+        db.add(idx_locked_position)
+
+        # Other locked position
+        _locked_position = IDXLockedPosition()
+        _locked_position.token_address = "other_token_address"
+        _locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        _locked_position.account_address = _account_address_1
+        _locked_position.value = 5
+        _locked_position.modified = datetime(2023, 10, 25, 0, 2, 0)
+        db.add(_locked_position)
+
+        idx_personal_info_3 = IDXPersonalInfo()
+        idx_personal_info_3.account_address = _account_address_3
+        idx_personal_info_3.issuer_address = _issuer_address
+        idx_personal_info_3.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test3",
+            "postal_code": "postal_code_test3",
+            "address": "address_test3",
+            "email": "email_test3",
+            "birth": "birth_test3",
+            # PersonalInfo is partially registered.
+        }
+        db.add(idx_personal_info_3)
+
+        db.commit()
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address),
+            headers={"issuer-address": _issuer_address},
+            params={"account_address": _account_address_1[10:20]},
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "result_set": {"count": 1, "total": 3, "offset": None, "limit": None},
+            "holders": [
+                {
+                    "account_address": _account_address_1,
+                    "personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test1",
+                        "postal_code": "postal_code_test1",
+                        "address": "address_test1",
+                        "email": "email_test1",
+                        "birth": "birth_test1",
+                        "is_corporate": False,
+                        "tax_category": 10,
+                    },
+                    "balance": 10,
+                    "exchange_balance": 11,
+                    "exchange_commitment": 12,
+                    "pending_transfer": 5,
+                    "locked": 10,
+                    "modified": "2023-10-24T01:10:00",
+                },
+            ],
+        }
+
     # <Normal_5_1>
     # Sort Item: created
     def test_normal_5_1(self, client, db):
@@ -4154,6 +4557,271 @@ class TestAppRoutersShareTokensTokenAddressHoldersGET:
                     "account_address": _account_address_3,
                     "personal_information": {
                         "key_manager": "key_manager_test1",
+                        "name": "name_test3",
+                        "postal_code": "postal_code_test3",
+                        "address": "address_test3",
+                        "email": "email_test3",
+                        "birth": "birth_test3",
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 99,
+                    "exchange_balance": 99,
+                    "exchange_commitment": 99,
+                    "pending_transfer": 99,
+                    "locked": 30,
+                    "modified": "2023-10-24T05:00:00",
+                },
+                {
+                    "account_address": _account_address_1,
+                    "personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test1",
+                        "postal_code": "postal_code_test1",
+                        "address": "address_test1",
+                        "email": "email_test1",
+                        "birth": "birth_test1",
+                        "is_corporate": False,
+                        "tax_category": 10,
+                    },
+                    "balance": 10,
+                    "exchange_balance": 11,
+                    "exchange_commitment": 12,
+                    "pending_transfer": 5,
+                    "locked": 10,
+                    "modified": "2023-10-24T01:10:00",
+                },
+            ],
+        }
+
+    # <Normal_5_7>
+    # Sort Item: key_manager
+    def test_normal_5_7(self, client, db):
+        user = config_eth_account("user1")
+        _issuer_address = user["address"]
+        _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
+        _account_address_1 = "0xb75c7545b9230FEe99b7af370D38eBd3DAD929f7"
+        _account_address_2 = "0x3F198534Bbe3B2a197d3B317d41392F348EAC707"
+        _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
+        _account_address_4 = "0x917eFFaC072dcda308e2337636f562D0A96F42eA"
+
+        account = Account()
+        account.issuer_address = _issuer_address
+        db.add(account)
+
+        token = Token()
+        token.type = TokenType.IBET_SHARE.value
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = ""
+        token.version = TokenVersion.V_22_12
+        db.add(token)
+
+        # prepare data: account_address_1
+        idx_position_1 = IDXPosition()
+        idx_position_1.token_address = _token_address
+        idx_position_1.account_address = _account_address_1
+        idx_position_1.balance = 10
+        idx_position_1.exchange_balance = 11
+        idx_position_1.exchange_commitment = 12
+        idx_position_1.pending_transfer = 5
+        idx_position_1.created = datetime(2023, 10, 24, 0, 0, 0)
+        idx_position_1.modified = datetime(2023, 10, 24, 0, 0, 0)
+        db.add(idx_position_1)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_1
+        idx_locked_position.value = 5
+        idx_locked_position.modified = datetime(2023, 10, 24, 1, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = _account_address_1
+        idx_personal_info_1.issuer_address = _issuer_address
+        idx_personal_info_1.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(idx_personal_info_1)
+
+        # prepare data: account_address_2
+        idx_position_2 = IDXPosition()
+        idx_position_2.token_address = _token_address
+        idx_position_2.account_address = _account_address_2
+        idx_position_2.balance = 20
+        idx_position_2.exchange_balance = 21
+        idx_position_2.exchange_commitment = 22
+        idx_position_2.pending_transfer = 10
+        idx_position_2.created = datetime(2023, 10, 24, 2, 0, 0)
+        idx_position_2.modified = datetime(2023, 10, 24, 2, 0, 0)
+        db.add(idx_position_2)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 10, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_2
+        idx_locked_position.value = 10
+        idx_locked_position.modified = datetime(2023, 10, 24, 2, 20, 0)
+        db.add(idx_locked_position)
+
+        # prepare data: account_address_3
+        idx_position_3 = IDXPosition()
+        idx_position_3.token_address = _token_address
+        idx_position_3.account_address = _account_address_3
+        idx_position_3.balance = 99
+        idx_position_3.exchange_balance = 99
+        idx_position_3.exchange_commitment = 99
+        idx_position_3.pending_transfer = 99
+        idx_position_3.created = datetime(2023, 10, 24, 3, 0, 0)
+        idx_position_3.modified = datetime(2023, 10, 24, 3, 0, 0)
+        db.add(idx_position_3)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000001"  # lock address 1
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 4, 0, 0)
+        db.add(idx_locked_position)
+
+        idx_locked_position = IDXLockedPosition()
+        idx_locked_position.token_address = _token_address
+        idx_locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        idx_locked_position.account_address = _account_address_3
+        idx_locked_position.value = 15
+        idx_locked_position.modified = datetime(2023, 10, 24, 5, 0, 0)
+        db.add(idx_locked_position)
+
+        # Other locked position
+        _locked_position = IDXLockedPosition()
+        _locked_position.token_address = "other_token_address"
+        _locked_position.lock_address = (
+            "0x1234567890123456789012345678900000000002"  # lock address 2
+        )
+        _locked_position.account_address = _account_address_1
+        _locked_position.value = 5
+        _locked_position.modified = datetime(2023, 10, 25, 0, 2, 0)
+        db.add(_locked_position)
+
+        idx_personal_info_3 = IDXPersonalInfo()
+        idx_personal_info_3.account_address = _account_address_3
+        idx_personal_info_3.issuer_address = _issuer_address
+        idx_personal_info_3.personal_info = {
+            "key_manager": "key_manager_test2",
+            "name": "name_test3",
+            "postal_code": "postal_code_test3",
+            "address": "address_test3",
+            "email": "email_test3",
+            "birth": "birth_test3",
+            # PersonalInfo is partially registered.
+        }
+        db.add(idx_personal_info_3)
+
+        # prepare data: account_address_4
+        idx_position_4 = IDXPosition()
+        idx_position_4.token_address = _token_address
+        idx_position_4.account_address = _account_address_4
+        idx_position_4.balance = 100
+        idx_position_4.exchange_balance = 100
+        idx_position_4.exchange_commitment = 100
+        idx_position_4.pending_transfer = 100
+        idx_position_4.created = datetime(2023, 10, 24, 6, 0, 0)
+        idx_position_4.modified = datetime(2023, 10, 24, 6, 0, 0)
+        db.add(idx_position_4)
+
+        db.commit()
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(_token_address),
+            headers={"issuer-address": _issuer_address},
+            params={"sort_order": 1, "sort_item": "key_manager"},
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "result_set": {"count": 4, "total": 4, "offset": None, "limit": None},
+            "holders": [
+                {
+                    "account_address": _account_address_2,
+                    "personal_information": {
+                        "key_manager": None,
+                        "name": None,
+                        "postal_code": None,
+                        "address": None,
+                        "email": None,
+                        "birth": None,
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 20,
+                    "exchange_balance": 21,
+                    "exchange_commitment": 22,
+                    "pending_transfer": 10,
+                    "locked": 20,
+                    "modified": "2023-10-24T02:20:00",
+                },
+                {
+                    "account_address": _account_address_4,
+                    "personal_information": {
+                        "key_manager": None,
+                        "name": None,
+                        "postal_code": None,
+                        "address": None,
+                        "email": None,
+                        "birth": None,
+                        "is_corporate": None,
+                        "tax_category": None,
+                    },
+                    "balance": 100,
+                    "exchange_balance": 100,
+                    "exchange_commitment": 100,
+                    "pending_transfer": 100,
+                    "locked": 0,
+                    "modified": "2023-10-24T06:00:00",
+                },
+                {
+                    "account_address": _account_address_3,
+                    "personal_information": {
+                        "key_manager": "key_manager_test2",
                         "name": "name_test3",
                         "postal_code": "postal_code_test3",
                         "address": "address_test3",


### PR DESCRIPTION
Close: #601 

- Added query parameter to following holders API in order to filter and sort holders list.
  - GET: `/bond/tokens/{token_address}/holders`
  - GET: `/share/tokens/{token_address}/holders`