### PR TITLE
Add buyer/seller personal information to DvP delivery data

### DIFF
--- a/app/model/schema/__init__.py
+++ b/app/model/schema/__init__.py
@@ -124,8 +124,10 @@ from .settlement import (
     FinishDVPDeliveryRequest,
     ListAllDVPAgentAccountResponse,
     ListAllDVPAgentDeliveriesQuery,
+    ListAllDVPAgentDeliveriesResponse,
     ListAllDVPDeliveriesQuery,
     ListAllDVPDeliveriesResponse,
+    RetrieveDVPAgentDeliveryResponse,
     RetrieveDVPDeliveryResponse,
 )
 from .token import (

--- a/app/model/schema/settlement.py
+++ b/app/model/schema/settlement.py
@@ -27,6 +27,7 @@ from pydantic.dataclasses import dataclass
 
 from app.model import EthereumAddress
 from app.model.schema.base import ResultSet, SortOrder
+from app.model.schema.personal_info import PersonalInfo
 from app.utils.check_utils import check_value_is_encrypted
 from config import E2EE_REQUEST_ENABLED
 
@@ -191,7 +192,9 @@ class RetrieveDVPDeliveryResponse(BaseModel):
     delivery_id: int
     token_address: str
     buyer_address: str
+    buyer_personal_information: Optional[PersonalInfo] = Field(...)
     seller_address: str
+    seller_personal_information: Optional[PersonalInfo] = Field(...)
     amount: int
     agent_address: str
     data: str = Field(examples=["{}", '{"type": "primary"}'])

--- a/app/model/schema/settlement.py
+++ b/app/model/schema/settlement.py
@@ -218,3 +218,36 @@ class ListAllDVPDeliveriesResponse(BaseModel):
 
     result_set: ResultSet
     deliveries: list[RetrieveDVPDeliveryResponse]
+
+
+class RetrieveDVPAgentDeliveryResponse(BaseModel):
+    """Retrieve DVP delivery schema for paying agent (Response)"""
+
+    exchange_address: str
+    delivery_id: int
+    token_address: str
+    buyer_address: str
+    seller_address: str
+    amount: int
+    agent_address: str
+    data: str = Field(examples=["{}", '{"type": "primary"}'])
+    create_blocktimestamp: str
+    create_transaction_hash: str
+    cancel_blocktimestamp: Optional[str] = Field(...)
+    cancel_transaction_hash: Optional[str] = Field(...)
+    confirm_blocktimestamp: Optional[str] = Field(...)
+    confirm_transaction_hash: Optional[str] = Field(...)
+    finish_blocktimestamp: Optional[str] = Field(...)
+    finish_transaction_hash: Optional[str] = Field(...)
+    abort_blocktimestamp: Optional[str] = Field(...)
+    abort_transaction_hash: Optional[str] = Field(...)
+    confirmed: bool
+    valid: bool
+    status: DeliveryStatus
+
+
+class ListAllDVPAgentDeliveriesResponse(BaseModel):
+    """List all DVP delivery schema for paying agent (Response)"""
+
+    result_set: ResultSet
+    deliveries: list[RetrieveDVPAgentDeliveryResponse]

--- a/app/routers/misc/settlement_agent.py
+++ b/app/routers/misc/settlement_agent.py
@@ -48,6 +48,7 @@ from app.model.schema import (
     FinishDVPDeliveryRequest,
     ListAllDVPAgentAccountResponse,
     ListAllDVPAgentDeliveriesQuery,
+    ListAllDVPAgentDeliveriesResponse,
     ListAllDVPDeliveriesResponse,
 )
 from app.utils.docs_utils import get_routers_responses
@@ -249,7 +250,7 @@ async def change_eoa_password(
 @router.get(
     "/dvp/agent/{exchange_address}/deliveries",
     operation_id="ListAllDVPAgentDeliveries",
-    response_model=ListAllDVPDeliveriesResponse,
+    response_model=ListAllDVPAgentDeliveriesResponse,
     responses=get_routers_responses(404, 422, InvalidParameterError),
 )
 async def list_all_dvp_agent_deliveries(

--- a/app/utils/docs_utils.py
+++ b/app/utils/docs_utils.py
@@ -238,6 +238,9 @@ def custom_openapi(app):
                         schema = _get(resp, "content", "application/json", "schema")
                         if schema == {}:
                             resp.pop("content")
+                        any_of: list | None = _get(schema, "anyOf")
+                        if any_of is not None:
+                            schema["anyOf"] = sorted(any_of, key=lambda x: x["$ref"])
 
         return openapi_schema
 

--- a/docs/ibet_prime.yaml
+++ b/docs/ibet_prime.yaml
@@ -8460,7 +8460,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListAllDVPDeliveriesResponse'
+                $ref: '#/components/schemas/ListAllDVPAgentDeliveriesResponse'
         '404':
           description: Not Found Error
           content:
@@ -12231,6 +12231,21 @@ components:
       type: array
       title: ListAllDVPAgentAccountResponse
       description: DVP agent account list reference schema (RESPONSE)
+    ListAllDVPAgentDeliveriesResponse:
+      properties:
+        result_set:
+          $ref: '#/components/schemas/ResultSet'
+        deliveries:
+          items:
+            $ref: '#/components/schemas/RetrieveDVPAgentDeliveryResponse'
+          type: array
+          title: Deliveries
+      type: object
+      required:
+        - result_set
+        - deliveries
+      title: ListAllDVPAgentDeliveriesResponse
+      description: List all DVP delivery schema for paying agent (Response)
     ListAllDVPDeliveriesResponse:
       properties:
         result_set:
@@ -13211,6 +13226,114 @@ components:
         - total
       title: ResultSet
       description: result set for pagination
+    RetrieveDVPAgentDeliveryResponse:
+      properties:
+        exchange_address:
+          type: string
+          title: Exchange Address
+        delivery_id:
+          type: integer
+          title: Delivery Id
+        token_address:
+          type: string
+          title: Token Address
+        buyer_address:
+          type: string
+          title: Buyer Address
+        seller_address:
+          type: string
+          title: Seller Address
+        amount:
+          type: integer
+          title: Amount
+        agent_address:
+          type: string
+          title: Agent Address
+        data:
+          type: string
+          title: Data
+          examples:
+            - '{}'
+            - '{"type": "primary"}'
+        create_blocktimestamp:
+          type: string
+          title: Create Blocktimestamp
+        create_transaction_hash:
+          type: string
+          title: Create Transaction Hash
+        cancel_blocktimestamp:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Cancel Blocktimestamp
+        cancel_transaction_hash:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Cancel Transaction Hash
+        confirm_blocktimestamp:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Confirm Blocktimestamp
+        confirm_transaction_hash:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Confirm Transaction Hash
+        finish_blocktimestamp:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Finish Blocktimestamp
+        finish_transaction_hash:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Finish Transaction Hash
+        abort_blocktimestamp:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Abort Blocktimestamp
+        abort_transaction_hash:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Abort Transaction Hash
+        confirmed:
+          type: boolean
+          title: Confirmed
+        valid:
+          type: boolean
+          title: Valid
+        status:
+          $ref: '#/components/schemas/DeliveryStatus'
+      type: object
+      required:
+        - exchange_address
+        - delivery_id
+        - token_address
+        - buyer_address
+        - seller_address
+        - amount
+        - agent_address
+        - data
+        - create_blocktimestamp
+        - create_transaction_hash
+        - cancel_blocktimestamp
+        - cancel_transaction_hash
+        - confirm_blocktimestamp
+        - confirm_transaction_hash
+        - finish_blocktimestamp
+        - finish_transaction_hash
+        - abort_blocktimestamp
+        - abort_transaction_hash
+        - confirmed
+        - valid
+        - status
+      title: RetrieveDVPAgentDeliveryResponse
+      description: Retrieve DVP delivery schema for paying agent (Response)
     RetrieveDVPDeliveryResponse:
       properties:
         exchange_address:

--- a/docs/ibet_prime.yaml
+++ b/docs/ibet_prime.yaml
@@ -467,8 +467,8 @@ paths:
             application/json:
               schema:
                 anyOf:
-                  - $ref: '#/components/schemas/SendTransactionErrorResponse'
                   - $ref: '#/components/schemas/ContractRevertErrorResponse'
+                  - $ref: '#/components/schemas/SendTransactionErrorResponse'
                 title: Response 400 Issue Token Bond Tokens Post
     get:
       tags:
@@ -607,10 +607,10 @@ paths:
             application/json:
               schema:
                 anyOf:
-                  - $ref: '#/components/schemas/SendTransactionErrorResponse'
-                  - $ref: '#/components/schemas/InvalidParameterErrorResponse'
                   - $ref: '#/components/schemas/ContractRevertErrorResponse'
+                  - $ref: '#/components/schemas/InvalidParameterErrorResponse'
                   - $ref: '#/components/schemas/OperationNotSupportedVersionErrorResponse'
+                  - $ref: '#/components/schemas/SendTransactionErrorResponse'
                 title: Response 400 Update Token Bond Tokens  Token Address  Post
   /bond/tokens/{token_address}/history:
     get:
@@ -882,9 +882,9 @@ paths:
             application/json:
               schema:
                 anyOf:
-                  - $ref: '#/components/schemas/SendTransactionErrorResponse'
-                  - $ref: '#/components/schemas/InvalidParameterErrorResponse'
                   - $ref: '#/components/schemas/ContractRevertErrorResponse'
+                  - $ref: '#/components/schemas/InvalidParameterErrorResponse'
+                  - $ref: '#/components/schemas/SendTransactionErrorResponse'
                 title: Response 400 Additional Issue Bond Tokens  Token Address  Additional
                   Issue Post
   /bond/tokens/{token_address}/additional_issue/batch:
@@ -1242,9 +1242,9 @@ paths:
             application/json:
               schema:
                 anyOf:
-                  - $ref: '#/components/schemas/SendTransactionErrorResponse'
-                  - $ref: '#/components/schemas/InvalidParameterErrorResponse'
                   - $ref: '#/components/schemas/ContractRevertErrorResponse'
+                  - $ref: '#/components/schemas/InvalidParameterErrorResponse'
+                  - $ref: '#/components/schemas/SendTransactionErrorResponse'
                 title: Response 400 Redeem Token Bond Tokens  Token Address  Redeem
                   Post
   /bond/tokens/{token_address}/redeem/batch:
@@ -2062,9 +2062,9 @@ paths:
             application/json:
               schema:
                 anyOf:
-                  - $ref: '#/components/schemas/SendTransactionErrorResponse'
-                  - $ref: '#/components/schemas/InvalidParameterErrorResponse'
                   - $ref: '#/components/schemas/ContractRevertErrorResponse'
+                  - $ref: '#/components/schemas/InvalidParameterErrorResponse'
+                  - $ref: '#/components/schemas/SendTransactionErrorResponse'
                 title: Response 400 Register Holder Personal Info Bond Tokens  Token
                   Address  Personal Info Post
   /bond/tokens/{token_address}/personal_info/batch:
@@ -2474,9 +2474,9 @@ paths:
             application/json:
               schema:
                 anyOf:
-                  - $ref: '#/components/schemas/SendTransactionErrorResponse'
-                  - $ref: '#/components/schemas/InvalidParameterErrorResponse'
                   - $ref: '#/components/schemas/ContractRevertErrorResponse'
+                  - $ref: '#/components/schemas/InvalidParameterErrorResponse'
+                  - $ref: '#/components/schemas/SendTransactionErrorResponse'
                 title: Response 400 Transfer Ownership Bond Transfers Post
   /bond/transfers/{token_address}:
     get:
@@ -2898,10 +2898,10 @@ paths:
             application/json:
               schema:
                 anyOf:
+                  - $ref: '#/components/schemas/ContractRevertErrorResponse'
+                  - $ref: '#/components/schemas/InvalidParameterErrorResponse'
                   - $ref: '#/components/schemas/OperationNotAllowedStateErrorResponse'
                   - $ref: '#/components/schemas/SendTransactionErrorResponse'
-                  - $ref: '#/components/schemas/InvalidParameterErrorResponse'
-                  - $ref: '#/components/schemas/ContractRevertErrorResponse'
                 title: Response 400 Update Transfer Approval Bond Transfer Approvals  Token
                   Address   Id  Post
     get:
@@ -3018,10 +3018,10 @@ paths:
             application/json:
               schema:
                 anyOf:
-                  - $ref: '#/components/schemas/TokenNotExistErrorResponse'
                   - $ref: '#/components/schemas/InvalidParameterErrorResponse'
                   - $ref: '#/components/schemas/MultipleTokenTransferNotAllowedErrorResponse'
                   - $ref: '#/components/schemas/NonTransferableTokenErrorResponse'
+                  - $ref: '#/components/schemas/TokenNotExistErrorResponse'
                 title: Response 400 Bulk Transfer Ownership Bond Bulk Transfer Post
     get:
       tags:
@@ -3148,9 +3148,9 @@ paths:
             application/json:
               schema:
                 anyOf:
-                  - $ref: '#/components/schemas/SendTransactionErrorResponse'
-                  - $ref: '#/components/schemas/InvalidParameterErrorResponse'
                   - $ref: '#/components/schemas/ContractRevertErrorResponse'
+                  - $ref: '#/components/schemas/InvalidParameterErrorResponse'
+                  - $ref: '#/components/schemas/SendTransactionErrorResponse'
                 title: Response 400 Create Account E2E Messaging Accounts Post
   /e2e_messaging/accounts/{account_address}:
     get:
@@ -4556,9 +4556,9 @@ paths:
             application/json:
               schema:
                 anyOf:
-                  - $ref: '#/components/schemas/SendTransactionErrorResponse'
-                  - $ref: '#/components/schemas/InvalidParameterErrorResponse'
                   - $ref: '#/components/schemas/ContractRevertErrorResponse'
+                  - $ref: '#/components/schemas/InvalidParameterErrorResponse'
+                  - $ref: '#/components/schemas/SendTransactionErrorResponse'
                 title: Response 400 Force Unlock Positions  Account Address  Force
                   Unlock Post
   /positions/{account_address}/{token_address}:
@@ -4680,8 +4680,8 @@ paths:
             application/json:
               schema:
                 anyOf:
-                  - $ref: '#/components/schemas/SendTransactionErrorResponse'
                   - $ref: '#/components/schemas/ContractRevertErrorResponse'
+                  - $ref: '#/components/schemas/SendTransactionErrorResponse'
                 title: Response 400 Issue Token Share Tokens Post
     get:
       tags:
@@ -4819,10 +4819,10 @@ paths:
             application/json:
               schema:
                 anyOf:
-                  - $ref: '#/components/schemas/SendTransactionErrorResponse'
-                  - $ref: '#/components/schemas/InvalidParameterErrorResponse'
                   - $ref: '#/components/schemas/ContractRevertErrorResponse'
+                  - $ref: '#/components/schemas/InvalidParameterErrorResponse'
                   - $ref: '#/components/schemas/OperationNotSupportedVersionErrorResponse'
+                  - $ref: '#/components/schemas/SendTransactionErrorResponse'
                 title: Response 400 Update Token Share Tokens  Token Address  Post
   /share/tokens/{token_address}/history:
     get:
@@ -5094,9 +5094,9 @@ paths:
             application/json:
               schema:
                 anyOf:
-                  - $ref: '#/components/schemas/SendTransactionErrorResponse'
-                  - $ref: '#/components/schemas/InvalidParameterErrorResponse'
                   - $ref: '#/components/schemas/ContractRevertErrorResponse'
+                  - $ref: '#/components/schemas/InvalidParameterErrorResponse'
+                  - $ref: '#/components/schemas/SendTransactionErrorResponse'
                 title: Response 400 Additional Issue Share Tokens  Token Address  Additional
                   Issue Post
   /share/tokens/{token_address}/additional_issue/batch:
@@ -5454,9 +5454,9 @@ paths:
             application/json:
               schema:
                 anyOf:
-                  - $ref: '#/components/schemas/SendTransactionErrorResponse'
-                  - $ref: '#/components/schemas/InvalidParameterErrorResponse'
                   - $ref: '#/components/schemas/ContractRevertErrorResponse'
+                  - $ref: '#/components/schemas/InvalidParameterErrorResponse'
+                  - $ref: '#/components/schemas/SendTransactionErrorResponse'
                 title: Response 400 Redeem Token Share Tokens  Token Address  Redeem
                   Post
   /share/tokens/{token_address}/redeem/batch:
@@ -6274,9 +6274,9 @@ paths:
             application/json:
               schema:
                 anyOf:
-                  - $ref: '#/components/schemas/SendTransactionErrorResponse'
-                  - $ref: '#/components/schemas/InvalidParameterErrorResponse'
                   - $ref: '#/components/schemas/ContractRevertErrorResponse'
+                  - $ref: '#/components/schemas/InvalidParameterErrorResponse'
+                  - $ref: '#/components/schemas/SendTransactionErrorResponse'
                 title: Response 400 Register Holder Personal Info Share Tokens  Token
                   Address  Personal Info Post
   /share/tokens/{token_address}/personal_info/batch:
@@ -6686,9 +6686,9 @@ paths:
             application/json:
               schema:
                 anyOf:
-                  - $ref: '#/components/schemas/SendTransactionErrorResponse'
-                  - $ref: '#/components/schemas/InvalidParameterErrorResponse'
                   - $ref: '#/components/schemas/ContractRevertErrorResponse'
+                  - $ref: '#/components/schemas/InvalidParameterErrorResponse'
+                  - $ref: '#/components/schemas/SendTransactionErrorResponse'
                 title: Response 400 Transfer Ownership Share Transfers Post
   /share/transfers/{token_address}:
     get:
@@ -7111,10 +7111,10 @@ paths:
             application/json:
               schema:
                 anyOf:
+                  - $ref: '#/components/schemas/ContractRevertErrorResponse'
+                  - $ref: '#/components/schemas/InvalidParameterErrorResponse'
                   - $ref: '#/components/schemas/OperationNotAllowedStateErrorResponse'
                   - $ref: '#/components/schemas/SendTransactionErrorResponse'
-                  - $ref: '#/components/schemas/InvalidParameterErrorResponse'
-                  - $ref: '#/components/schemas/ContractRevertErrorResponse'
                 title: Response 400 Update Transfer Approval Share Transfer Approvals  Token
                   Address   Id  Post
     get:
@@ -7231,10 +7231,10 @@ paths:
             application/json:
               schema:
                 anyOf:
-                  - $ref: '#/components/schemas/TokenNotExistErrorResponse'
                   - $ref: '#/components/schemas/InvalidParameterErrorResponse'
                   - $ref: '#/components/schemas/MultipleTokenTransferNotAllowedErrorResponse'
                   - $ref: '#/components/schemas/NonTransferableTokenErrorResponse'
+                  - $ref: '#/components/schemas/TokenNotExistErrorResponse'
                 title: Response 400 Bulk Transfer Ownership Share Bulk Transfer Post
     get:
       tags:
@@ -8083,8 +8083,8 @@ paths:
             application/json:
               schema:
                 anyOf:
-                  - $ref: '#/components/schemas/SendTransactionErrorResponse'
                   - $ref: '#/components/schemas/InvalidParameterErrorResponse'
+                  - $ref: '#/components/schemas/SendTransactionErrorResponse'
                 title: Response 400 Createdvpdelivery
   /settlement/dvp/{exchange_address}/delivery/{delivery_id}:
     get:
@@ -8210,8 +8210,8 @@ paths:
             application/json:
               schema:
                 anyOf:
-                  - $ref: '#/components/schemas/SendTransactionErrorResponse'
                   - $ref: '#/components/schemas/InvalidParameterErrorResponse'
+                  - $ref: '#/components/schemas/SendTransactionErrorResponse'
                 title: Response 400 Updatedvpdelivery
   /settlement/dvp/agent/accounts:
     get:
@@ -8531,8 +8531,8 @@ paths:
             application/json:
               schema:
                 anyOf:
-                  - $ref: '#/components/schemas/SendTransactionErrorResponse'
                   - $ref: '#/components/schemas/InvalidParameterErrorResponse'
+                  - $ref: '#/components/schemas/SendTransactionErrorResponse'
                 title: Response 400 Updatedvpagentdelivery
   /blockchain_explorer/block_data:
     get:
@@ -8910,8 +8910,8 @@ paths:
             application/json:
               schema:
                 anyOf:
-                  - $ref: '#/components/schemas/SendTransactionErrorResponse'
                   - $ref: '#/components/schemas/InvalidParameterErrorResponse'
+                  - $ref: '#/components/schemas/SendTransactionErrorResponse'
                 title: Response 400 Recordnewfreezelog
   /freeze_log/logs/{log_index}:
     post:
@@ -8956,8 +8956,8 @@ paths:
             application/json:
               schema:
                 anyOf:
-                  - $ref: '#/components/schemas/SendTransactionErrorResponse'
                   - $ref: '#/components/schemas/InvalidParameterErrorResponse'
+                  - $ref: '#/components/schemas/SendTransactionErrorResponse'
                 title: Response 400 Updatefreezelog
     get:
       tags:
@@ -13225,9 +13225,17 @@ components:
         buyer_address:
           type: string
           title: Buyer Address
+        buyer_personal_information:
+          anyOf:
+            - $ref: '#/components/schemas/PersonalInfo'
+            - type: 'null'
         seller_address:
           type: string
           title: Seller Address
+        seller_personal_information:
+          anyOf:
+            - $ref: '#/components/schemas/PersonalInfo'
+            - type: 'null'
         amount:
           type: integer
           title: Amount
@@ -13300,7 +13308,9 @@ components:
         - delivery_id
         - token_address
         - buyer_address
+        - buyer_personal_information
         - seller_address
+        - seller_personal_information
         - amount
         - agent_address
         - data

--- a/tests/app/test_settlement_dvp_{exchange_address}_deliveries_GET.py
+++ b/tests/app/test_settlement_dvp_{exchange_address}_deliveries_GET.py
@@ -19,7 +19,14 @@ SPDX-License-Identifier: Apache-2.0
 
 from datetime import UTC, datetime
 
-from app.model.db import DeliveryStatus, IDXDelivery, Token, TokenType, TokenVersion
+from app.model.db import (
+    DeliveryStatus,
+    IDXDelivery,
+    IDXPersonalInfo,
+    Token,
+    TokenType,
+    TokenVersion,
+)
 
 
 class TestListAllDVPDeliveries:
@@ -56,9 +63,9 @@ class TestListAllDVPDeliveries:
             "deliveries": [],
         }
 
-    # Normal_2
+    # Normal_2_1
     # Multi record
-    def test_normal_2(self, client, db):
+    def test_normal_2_1(self, client, db):
         exchange_address = "0x1234567890123456789012345678900000000000"
         token_address_1 = "0x1234567890123456789012345678900000000010"
         token_address_2 = "0x1234567890123456789012345678900000000020"
@@ -227,7 +234,9 @@ class TestListAllDVPDeliveries:
                     "delivery_id": 1,
                     "token_address": token_address_1,
                     "buyer_address": buyer_address,
+                    "buyer_personal_information": None,
                     "seller_address": seller_address_1,
+                    "seller_personal_information": None,
                     "amount": 1,
                     "agent_address": agent_address_1,
                     "data": "",
@@ -250,7 +259,9 @@ class TestListAllDVPDeliveries:
                     "delivery_id": 2,
                     "token_address": token_address_1,
                     "buyer_address": buyer_address,
+                    "buyer_personal_information": None,
                     "seller_address": seller_address_1,
+                    "seller_personal_information": None,
                     "amount": 1,
                     "agent_address": agent_address_1,
                     "data": "",
@@ -273,7 +284,9 @@ class TestListAllDVPDeliveries:
                     "delivery_id": 3,
                     "token_address": token_address_1,
                     "buyer_address": buyer_address,
+                    "buyer_personal_information": None,
                     "seller_address": seller_address_1,
+                    "seller_personal_information": None,
                     "amount": 1,
                     "agent_address": agent_address_1,
                     "data": "",
@@ -296,7 +309,9 @@ class TestListAllDVPDeliveries:
                     "delivery_id": 4,
                     "token_address": token_address_1,
                     "buyer_address": buyer_address,
+                    "buyer_personal_information": None,
                     "seller_address": seller_address_1,
+                    "seller_personal_information": None,
                     "amount": 1,
                     "agent_address": agent_address_1,
                     "data": "",
@@ -319,7 +334,9 @@ class TestListAllDVPDeliveries:
                     "delivery_id": 5,
                     "token_address": token_address_1,
                     "buyer_address": buyer_address,
+                    "buyer_personal_information": None,
                     "seller_address": seller_address_1,
+                    "seller_personal_information": None,
                     "amount": 1,
                     "agent_address": agent_address_1,
                     "data": "",
@@ -342,7 +359,473 @@ class TestListAllDVPDeliveries:
                     "delivery_id": 6,
                     "token_address": token_address_2,
                     "buyer_address": buyer_address,
+                    "buyer_personal_information": None,
                     "seller_address": seller_address_2,
+                    "seller_personal_information": None,
+                    "amount": 1,
+                    "agent_address": agent_address_2,
+                    "data": "",
+                    "create_blocktimestamp": "2023-12-31T15:00:00+00:00",
+                    "create_transaction_hash": "tx_hash_1",
+                    "cancel_blocktimestamp": None,
+                    "cancel_transaction_hash": None,
+                    "confirm_blocktimestamp": None,
+                    "confirm_transaction_hash": None,
+                    "finish_blocktimestamp": None,
+                    "finish_transaction_hash": None,
+                    "abort_blocktimestamp": None,
+                    "abort_transaction_hash": None,
+                    "confirmed": False,
+                    "valid": True,
+                    "status": DeliveryStatus.DELIVERY_CREATED,
+                },
+            ],
+        }
+
+    # Normal_2_2
+    # Multi record (PersonalInfo is set)
+    def test_normal_2_2(self, client, db):
+        exchange_address = "0x1234567890123456789012345678900000000000"
+        token_address_1 = "0x1234567890123456789012345678900000000010"
+        token_address_2 = "0x1234567890123456789012345678900000000020"
+
+        issuer_address = "0x1234567890123456789012345678900000000100"
+
+        seller_address_1 = issuer_address
+        seller_address_2 = "0x1234567890123456789012345678900000000200"
+
+        buyer_address = "0x1234567890123456789012345678911111111111"
+
+        agent_address_1 = "0x1234567890123456789012345678900000001000"
+        agent_address_2 = "0x1234567890123456789012345678900000002000"
+
+        # prepare data: Token
+        _token = Token()
+        _token.type = TokenType.IBET_STRAIGHT_BOND.value
+        _token.tx_hash = ""
+        _token.issuer_address = issuer_address
+        _token.token_address = token_address_1
+        _token.abi = {}
+        _token.version = TokenVersion.V_24_09
+        db.add(_token)
+
+        _token = Token()
+        _token.type = TokenType.IBET_STRAIGHT_BOND.value
+        _token.tx_hash = ""
+        _token.issuer_address = issuer_address
+        _token.token_address = token_address_2
+        _token.abi = {}
+        _token.version = TokenVersion.V_24_09
+        db.add(_token)
+
+        # prepare data: IDXPersonalInfo
+        _personal_info = IDXPersonalInfo()
+        _personal_info.account_address = buyer_address
+        _personal_info.issuer_address = issuer_address
+        _personal_info._personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(_personal_info)
+
+        _personal_info = IDXPersonalInfo()
+        _personal_info.account_address = seller_address_1
+        _personal_info.issuer_address = issuer_address
+        _personal_info._personal_info = {
+            "key_manager": "key_manager_test2",
+            "name": "name_test2",
+            "postal_code": "postal_code_test2",
+            "address": "address_test2",
+            "email": "email_test2",
+            "birth": "birth_test2",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(_personal_info)
+
+        _personal_info = IDXPersonalInfo()
+        _personal_info.account_address = seller_address_2
+        _personal_info.issuer_address = "other_issuer_address"  # Other issuer address
+        _personal_info._personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(_personal_info)
+
+        # prepare data: IDXDelivery(Created)
+        _idx_delivery = IDXDelivery()
+        _idx_delivery.exchange_address = exchange_address
+        _idx_delivery.delivery_id = 1
+        _idx_delivery.token_address = token_address_1
+        _idx_delivery.buyer_address = buyer_address
+        _idx_delivery.seller_address = seller_address_1
+        _idx_delivery.amount = 1
+        _idx_delivery.agent_address = agent_address_1
+        _idx_delivery.data = ""
+        _idx_delivery.create_blocktimestamp = datetime(2024, 1, 1, 0, 0, 0, tzinfo=UTC)
+        _idx_delivery.create_transaction_hash = "tx_hash_1"
+        _idx_delivery.confirmed = False
+        _idx_delivery.valid = True
+        _idx_delivery.status = DeliveryStatus.DELIVERY_CREATED.value
+        db.add(_idx_delivery)
+
+        # prepare data: IDXDelivery(Canceled)
+        _idx_delivery = IDXDelivery()
+        _idx_delivery.exchange_address = exchange_address
+        _idx_delivery.delivery_id = 2
+        _idx_delivery.token_address = token_address_1
+        _idx_delivery.buyer_address = buyer_address
+        _idx_delivery.seller_address = seller_address_1
+        _idx_delivery.amount = 1
+        _idx_delivery.agent_address = agent_address_1
+        _idx_delivery.data = ""
+        _idx_delivery.create_blocktimestamp = datetime(2024, 1, 1, 0, 0, 0, tzinfo=UTC)
+        _idx_delivery.create_transaction_hash = "tx_hash_1"
+        _idx_delivery.cancel_blocktimestamp = datetime(2024, 1, 1, 0, 0, 1, tzinfo=UTC)
+        _idx_delivery.cancel_transaction_hash = "tx_hash_2"
+        _idx_delivery.confirmed = False
+        _idx_delivery.valid = False
+        _idx_delivery.status = DeliveryStatus.DELIVERY_CANCELED.value
+        db.add(_idx_delivery)
+
+        # prepare data: IDXDelivery(Confirmed)
+        _idx_delivery = IDXDelivery()
+        _idx_delivery.exchange_address = exchange_address
+        _idx_delivery.delivery_id = 3
+        _idx_delivery.token_address = token_address_1
+        _idx_delivery.buyer_address = buyer_address
+        _idx_delivery.seller_address = seller_address_1
+        _idx_delivery.amount = 1
+        _idx_delivery.agent_address = agent_address_1
+        _idx_delivery.data = ""
+        _idx_delivery.create_blocktimestamp = datetime(2024, 1, 1, 0, 0, 0, tzinfo=UTC)
+        _idx_delivery.create_transaction_hash = "tx_hash_1"
+        _idx_delivery.confirm_blocktimestamp = datetime(2024, 1, 1, 0, 0, 2, tzinfo=UTC)
+        _idx_delivery.confirm_transaction_hash = "tx_hash_3"
+        _idx_delivery.confirmed = True
+        _idx_delivery.valid = True
+        _idx_delivery.status = DeliveryStatus.DELIVERY_CONFIRMED.value
+        db.add(_idx_delivery)
+
+        # prepare data: IDXDelivery(Finished)
+        _idx_delivery = IDXDelivery()
+        _idx_delivery.exchange_address = exchange_address
+        _idx_delivery.delivery_id = 4
+        _idx_delivery.token_address = token_address_1
+        _idx_delivery.buyer_address = buyer_address
+        _idx_delivery.seller_address = seller_address_1
+        _idx_delivery.amount = 1
+        _idx_delivery.agent_address = agent_address_1
+        _idx_delivery.data = ""
+        _idx_delivery.create_blocktimestamp = datetime(2024, 1, 1, 0, 0, 0, tzinfo=UTC)
+        _idx_delivery.create_transaction_hash = "tx_hash_1"
+        _idx_delivery.confirm_blocktimestamp = datetime(2024, 1, 1, 0, 0, 2, tzinfo=UTC)
+        _idx_delivery.confirm_transaction_hash = "tx_hash_3"
+        _idx_delivery.finish_blocktimestamp = datetime(2024, 1, 1, 0, 0, 3, tzinfo=UTC)
+        _idx_delivery.finish_transaction_hash = "tx_hash_4"
+        _idx_delivery.confirmed = True
+        _idx_delivery.valid = True
+        _idx_delivery.status = DeliveryStatus.DELIVERY_FINISHED.value
+        db.add(_idx_delivery)
+
+        # prepare data: IDXDelivery(Aborted)
+        _idx_delivery = IDXDelivery()
+        _idx_delivery.exchange_address = exchange_address
+        _idx_delivery.delivery_id = 5
+        _idx_delivery.token_address = token_address_1
+        _idx_delivery.buyer_address = buyer_address
+        _idx_delivery.seller_address = seller_address_1
+        _idx_delivery.amount = 1
+        _idx_delivery.agent_address = agent_address_1
+        _idx_delivery.data = ""
+        _idx_delivery.create_blocktimestamp = datetime(2024, 1, 1, 0, 0, 0, tzinfo=UTC)
+        _idx_delivery.create_transaction_hash = "tx_hash_1"
+        _idx_delivery.confirm_blocktimestamp = datetime(2024, 1, 1, 0, 0, 2, tzinfo=UTC)
+        _idx_delivery.confirm_transaction_hash = "tx_hash_3"
+        _idx_delivery.finish_blocktimestamp = None
+        _idx_delivery.finish_transaction_hash = None
+        _idx_delivery.abort_blocktimestamp = datetime(2024, 1, 1, 0, 0, 4, tzinfo=UTC)
+        _idx_delivery.abort_transaction_hash = "tx_hash_5"
+        _idx_delivery.confirmed = True
+        _idx_delivery.valid = False
+        _idx_delivery.status = DeliveryStatus.DELIVERY_ABORTED.value
+        db.add(_idx_delivery)
+
+        # prepare data: IDXDelivery(Created)
+        _idx_delivery = IDXDelivery()
+        _idx_delivery.exchange_address = exchange_address
+        _idx_delivery.delivery_id = 6
+        _idx_delivery.token_address = token_address_2
+        _idx_delivery.buyer_address = buyer_address
+        _idx_delivery.seller_address = seller_address_2
+        _idx_delivery.amount = 1
+        _idx_delivery.agent_address = agent_address_2
+        _idx_delivery.data = ""
+        _idx_delivery.create_blocktimestamp = datetime(2024, 1, 1, 0, 0, 0, tzinfo=UTC)
+        _idx_delivery.create_transaction_hash = "tx_hash_1"
+        _idx_delivery.confirmed = False
+        _idx_delivery.valid = True
+        _idx_delivery.status = DeliveryStatus.DELIVERY_CREATED.value
+        db.add(_idx_delivery)
+        db.commit()
+
+        # request target api
+        resp = client.get(
+            self.base_url.format(exchange_address=exchange_address),
+            headers={
+                "issuer-address": issuer_address,
+            },
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "result_set": {"count": 6, "limit": None, "offset": None, "total": 6},
+            "deliveries": [
+                {
+                    "exchange_address": exchange_address,
+                    "delivery_id": 1,
+                    "token_address": token_address_1,
+                    "buyer_address": buyer_address,
+                    "buyer_personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test1",
+                        "postal_code": "postal_code_test1",
+                        "address": "address_test1",
+                        "email": "email_test1",
+                        "birth": "birth_test1",
+                        "is_corporate": False,
+                        "tax_category": 10,
+                    },
+                    "seller_address": seller_address_1,
+                    "seller_personal_information": {
+                        "key_manager": "key_manager_test2",
+                        "name": "name_test2",
+                        "postal_code": "postal_code_test2",
+                        "address": "address_test2",
+                        "email": "email_test2",
+                        "birth": "birth_test2",
+                        "is_corporate": False,
+                        "tax_category": 10,
+                    },
+                    "amount": 1,
+                    "agent_address": agent_address_1,
+                    "data": "",
+                    "create_blocktimestamp": "2023-12-31T15:00:00+00:00",
+                    "create_transaction_hash": "tx_hash_1",
+                    "cancel_blocktimestamp": None,
+                    "cancel_transaction_hash": None,
+                    "confirm_blocktimestamp": None,
+                    "confirm_transaction_hash": None,
+                    "finish_blocktimestamp": None,
+                    "finish_transaction_hash": None,
+                    "abort_blocktimestamp": None,
+                    "abort_transaction_hash": None,
+                    "confirmed": False,
+                    "valid": True,
+                    "status": DeliveryStatus.DELIVERY_CREATED,
+                },
+                {
+                    "exchange_address": exchange_address,
+                    "delivery_id": 2,
+                    "token_address": token_address_1,
+                    "buyer_address": buyer_address,
+                    "buyer_personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test1",
+                        "postal_code": "postal_code_test1",
+                        "address": "address_test1",
+                        "email": "email_test1",
+                        "birth": "birth_test1",
+                        "is_corporate": False,
+                        "tax_category": 10,
+                    },
+                    "seller_address": seller_address_1,
+                    "seller_personal_information": {
+                        "key_manager": "key_manager_test2",
+                        "name": "name_test2",
+                        "postal_code": "postal_code_test2",
+                        "address": "address_test2",
+                        "email": "email_test2",
+                        "birth": "birth_test2",
+                        "is_corporate": False,
+                        "tax_category": 10,
+                    },
+                    "amount": 1,
+                    "agent_address": agent_address_1,
+                    "data": "",
+                    "create_blocktimestamp": "2023-12-31T15:00:00+00:00",
+                    "create_transaction_hash": "tx_hash_1",
+                    "cancel_blocktimestamp": "2023-12-31T15:00:01+00:00",
+                    "cancel_transaction_hash": "tx_hash_2",
+                    "confirm_blocktimestamp": None,
+                    "confirm_transaction_hash": None,
+                    "finish_blocktimestamp": None,
+                    "finish_transaction_hash": None,
+                    "abort_blocktimestamp": None,
+                    "abort_transaction_hash": None,
+                    "confirmed": False,
+                    "valid": False,
+                    "status": DeliveryStatus.DELIVERY_CANCELED,
+                },
+                {
+                    "exchange_address": exchange_address,
+                    "delivery_id": 3,
+                    "token_address": token_address_1,
+                    "buyer_address": buyer_address,
+                    "buyer_personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test1",
+                        "postal_code": "postal_code_test1",
+                        "address": "address_test1",
+                        "email": "email_test1",
+                        "birth": "birth_test1",
+                        "is_corporate": False,
+                        "tax_category": 10,
+                    },
+                    "seller_address": seller_address_1,
+                    "seller_personal_information": {
+                        "key_manager": "key_manager_test2",
+                        "name": "name_test2",
+                        "postal_code": "postal_code_test2",
+                        "address": "address_test2",
+                        "email": "email_test2",
+                        "birth": "birth_test2",
+                        "is_corporate": False,
+                        "tax_category": 10,
+                    },
+                    "amount": 1,
+                    "agent_address": agent_address_1,
+                    "data": "",
+                    "create_blocktimestamp": "2023-12-31T15:00:00+00:00",
+                    "create_transaction_hash": "tx_hash_1",
+                    "cancel_blocktimestamp": None,
+                    "cancel_transaction_hash": None,
+                    "confirm_blocktimestamp": "2023-12-31T15:00:02+00:00",
+                    "confirm_transaction_hash": "tx_hash_3",
+                    "finish_blocktimestamp": None,
+                    "finish_transaction_hash": None,
+                    "abort_blocktimestamp": None,
+                    "abort_transaction_hash": None,
+                    "confirmed": True,
+                    "valid": True,
+                    "status": DeliveryStatus.DELIVERY_CONFIRMED,
+                },
+                {
+                    "exchange_address": exchange_address,
+                    "delivery_id": 4,
+                    "token_address": token_address_1,
+                    "buyer_address": buyer_address,
+                    "buyer_personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test1",
+                        "postal_code": "postal_code_test1",
+                        "address": "address_test1",
+                        "email": "email_test1",
+                        "birth": "birth_test1",
+                        "is_corporate": False,
+                        "tax_category": 10,
+                    },
+                    "seller_address": seller_address_1,
+                    "seller_personal_information": {
+                        "key_manager": "key_manager_test2",
+                        "name": "name_test2",
+                        "postal_code": "postal_code_test2",
+                        "address": "address_test2",
+                        "email": "email_test2",
+                        "birth": "birth_test2",
+                        "is_corporate": False,
+                        "tax_category": 10,
+                    },
+                    "amount": 1,
+                    "agent_address": agent_address_1,
+                    "data": "",
+                    "create_blocktimestamp": "2023-12-31T15:00:00+00:00",
+                    "create_transaction_hash": "tx_hash_1",
+                    "cancel_blocktimestamp": None,
+                    "cancel_transaction_hash": None,
+                    "confirm_blocktimestamp": "2023-12-31T15:00:02+00:00",
+                    "confirm_transaction_hash": "tx_hash_3",
+                    "finish_blocktimestamp": "2023-12-31T15:00:03+00:00",
+                    "finish_transaction_hash": "tx_hash_4",
+                    "abort_blocktimestamp": None,
+                    "abort_transaction_hash": None,
+                    "confirmed": True,
+                    "valid": True,
+                    "status": DeliveryStatus.DELIVERY_FINISHED,
+                },
+                {
+                    "exchange_address": exchange_address,
+                    "delivery_id": 5,
+                    "token_address": token_address_1,
+                    "buyer_address": buyer_address,
+                    "buyer_personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test1",
+                        "postal_code": "postal_code_test1",
+                        "address": "address_test1",
+                        "email": "email_test1",
+                        "birth": "birth_test1",
+                        "is_corporate": False,
+                        "tax_category": 10,
+                    },
+                    "seller_address": seller_address_1,
+                    "seller_personal_information": {
+                        "key_manager": "key_manager_test2",
+                        "name": "name_test2",
+                        "postal_code": "postal_code_test2",
+                        "address": "address_test2",
+                        "email": "email_test2",
+                        "birth": "birth_test2",
+                        "is_corporate": False,
+                        "tax_category": 10,
+                    },
+                    "amount": 1,
+                    "agent_address": agent_address_1,
+                    "data": "",
+                    "create_blocktimestamp": "2023-12-31T15:00:00+00:00",
+                    "create_transaction_hash": "tx_hash_1",
+                    "cancel_blocktimestamp": None,
+                    "cancel_transaction_hash": None,
+                    "confirm_blocktimestamp": "2023-12-31T15:00:02+00:00",
+                    "confirm_transaction_hash": "tx_hash_3",
+                    "finish_blocktimestamp": None,
+                    "finish_transaction_hash": None,
+                    "abort_blocktimestamp": "2023-12-31T15:00:04+00:00",
+                    "abort_transaction_hash": "tx_hash_5",
+                    "confirmed": True,
+                    "valid": False,
+                    "status": DeliveryStatus.DELIVERY_ABORTED,
+                },
+                {
+                    "exchange_address": exchange_address,
+                    "delivery_id": 6,
+                    "token_address": token_address_2,
+                    "buyer_address": buyer_address,
+                    "buyer_personal_information": {
+                        "key_manager": "key_manager_test1",
+                        "name": "name_test1",
+                        "postal_code": "postal_code_test1",
+                        "address": "address_test1",
+                        "email": "email_test1",
+                        "birth": "birth_test1",
+                        "is_corporate": False,
+                        "tax_category": 10,
+                    },
+                    "seller_address": seller_address_2,
+                    "seller_personal_information": None,
                     "amount": 1,
                     "agent_address": agent_address_2,
                     "data": "",
@@ -535,7 +1018,9 @@ class TestListAllDVPDeliveries:
                     "delivery_id": 1,
                     "token_address": token_address_1,
                     "buyer_address": buyer_address,
+                    "buyer_personal_information": None,
                     "seller_address": seller_address_1,
+                    "seller_personal_information": None,
                     "amount": 1,
                     "agent_address": agent_address_1,
                     "data": "",
@@ -558,7 +1043,9 @@ class TestListAllDVPDeliveries:
                     "delivery_id": 2,
                     "token_address": token_address_1,
                     "buyer_address": buyer_address,
+                    "buyer_personal_information": None,
                     "seller_address": seller_address_1,
+                    "seller_personal_information": None,
                     "amount": 1,
                     "agent_address": agent_address_1,
                     "data": "",
@@ -581,7 +1068,9 @@ class TestListAllDVPDeliveries:
                     "delivery_id": 3,
                     "token_address": token_address_1,
                     "buyer_address": buyer_address,
+                    "buyer_personal_information": None,
                     "seller_address": seller_address_1,
+                    "seller_personal_information": None,
                     "amount": 1,
                     "agent_address": agent_address_1,
                     "data": "",
@@ -604,7 +1093,9 @@ class TestListAllDVPDeliveries:
                     "delivery_id": 4,
                     "token_address": token_address_1,
                     "buyer_address": buyer_address,
+                    "buyer_personal_information": None,
                     "seller_address": seller_address_1,
+                    "seller_personal_information": None,
                     "amount": 1,
                     "agent_address": agent_address_1,
                     "data": "",
@@ -627,7 +1118,9 @@ class TestListAllDVPDeliveries:
                     "delivery_id": 5,
                     "token_address": token_address_1,
                     "buyer_address": buyer_address,
+                    "buyer_personal_information": None,
                     "seller_address": seller_address_1,
+                    "seller_personal_information": None,
                     "amount": 1,
                     "agent_address": agent_address_1,
                     "data": "",
@@ -820,7 +1313,9 @@ class TestListAllDVPDeliveries:
                     "delivery_id": 1,
                     "token_address": token_address_1,
                     "buyer_address": buyer_address,
+                    "buyer_personal_information": None,
                     "seller_address": seller_address_1,
+                    "seller_personal_information": None,
                     "amount": 1,
                     "agent_address": agent_address_1,
                     "data": "",
@@ -843,7 +1338,9 @@ class TestListAllDVPDeliveries:
                     "delivery_id": 2,
                     "token_address": token_address_1,
                     "buyer_address": buyer_address,
+                    "buyer_personal_information": None,
                     "seller_address": seller_address_1,
+                    "seller_personal_information": None,
                     "amount": 1,
                     "agent_address": agent_address_1,
                     "data": "",
@@ -866,7 +1363,9 @@ class TestListAllDVPDeliveries:
                     "delivery_id": 3,
                     "token_address": token_address_1,
                     "buyer_address": buyer_address,
+                    "buyer_personal_information": None,
                     "seller_address": seller_address_1,
+                    "seller_personal_information": None,
                     "amount": 1,
                     "agent_address": agent_address_1,
                     "data": "",
@@ -889,7 +1388,9 @@ class TestListAllDVPDeliveries:
                     "delivery_id": 4,
                     "token_address": token_address_1,
                     "buyer_address": buyer_address,
+                    "buyer_personal_information": None,
                     "seller_address": seller_address_1,
+                    "seller_personal_information": None,
                     "amount": 1,
                     "agent_address": agent_address_1,
                     "data": "",
@@ -912,7 +1413,9 @@ class TestListAllDVPDeliveries:
                     "delivery_id": 5,
                     "token_address": token_address_1,
                     "buyer_address": buyer_address,
+                    "buyer_personal_information": None,
                     "seller_address": seller_address_1,
+                    "seller_personal_information": None,
                     "amount": 1,
                     "agent_address": agent_address_1,
                     "data": "",
@@ -1105,7 +1608,9 @@ class TestListAllDVPDeliveries:
                     "delivery_id": 1,
                     "token_address": token_address_1,
                     "buyer_address": buyer_address,
+                    "buyer_personal_information": None,
                     "seller_address": seller_address_1,
+                    "seller_personal_information": None,
                     "amount": 1,
                     "agent_address": agent_address_1,
                     "data": "",
@@ -1128,7 +1633,9 @@ class TestListAllDVPDeliveries:
                     "delivery_id": 2,
                     "token_address": token_address_1,
                     "buyer_address": buyer_address,
+                    "buyer_personal_information": None,
                     "seller_address": seller_address_1,
+                    "seller_personal_information": None,
                     "amount": 1,
                     "agent_address": agent_address_1,
                     "data": "",
@@ -1151,7 +1658,9 @@ class TestListAllDVPDeliveries:
                     "delivery_id": 3,
                     "token_address": token_address_1,
                     "buyer_address": buyer_address,
+                    "buyer_personal_information": None,
                     "seller_address": seller_address_1,
+                    "seller_personal_information": None,
                     "amount": 1,
                     "agent_address": agent_address_1,
                     "data": "",
@@ -1174,7 +1683,9 @@ class TestListAllDVPDeliveries:
                     "delivery_id": 4,
                     "token_address": token_address_1,
                     "buyer_address": buyer_address,
+                    "buyer_personal_information": None,
                     "seller_address": seller_address_1,
+                    "seller_personal_information": None,
                     "amount": 1,
                     "agent_address": agent_address_1,
                     "data": "",
@@ -1197,7 +1708,9 @@ class TestListAllDVPDeliveries:
                     "delivery_id": 5,
                     "token_address": token_address_1,
                     "buyer_address": buyer_address,
+                    "buyer_personal_information": None,
                     "seller_address": seller_address_1,
+                    "seller_personal_information": None,
                     "amount": 1,
                     "agent_address": agent_address_1,
                     "data": "",
@@ -1390,7 +1903,9 @@ class TestListAllDVPDeliveries:
                     "delivery_id": 2,
                     "token_address": token_address_1,
                     "buyer_address": buyer_address,
+                    "buyer_personal_information": None,
                     "seller_address": seller_address_1,
+                    "seller_personal_information": None,
                     "amount": 1,
                     "agent_address": agent_address_1,
                     "data": "",
@@ -1413,7 +1928,9 @@ class TestListAllDVPDeliveries:
                     "delivery_id": 5,
                     "token_address": token_address_1,
                     "buyer_address": buyer_address,
+                    "buyer_personal_information": None,
                     "seller_address": seller_address_1,
+                    "seller_personal_information": None,
                     "amount": 1,
                     "agent_address": agent_address_1,
                     "data": "",
@@ -1606,7 +2123,9 @@ class TestListAllDVPDeliveries:
                     "delivery_id": 4,
                     "token_address": token_address_1,
                     "buyer_address": buyer_address,
+                    "buyer_personal_information": None,
                     "seller_address": seller_address_1,
+                    "seller_personal_information": None,
                     "amount": 1,
                     "agent_address": agent_address_1,
                     "data": "",
@@ -1799,7 +2318,9 @@ class TestListAllDVPDeliveries:
                     "delivery_id": 1,
                     "token_address": token_address_1,
                     "buyer_address": buyer_address,
+                    "buyer_personal_information": None,
                     "seller_address": seller_address_1,
+                    "seller_personal_information": None,
                     "amount": 1,
                     "agent_address": agent_address_1,
                     "data": "",
@@ -1992,7 +2513,9 @@ class TestListAllDVPDeliveries:
                     "delivery_id": 2,
                     "token_address": token_address_1,
                     "buyer_address": buyer_address,
+                    "buyer_personal_information": None,
                     "seller_address": seller_address_1,
+                    "seller_personal_information": None,
                     "amount": 1,
                     "agent_address": agent_address_1,
                     "data": "",
@@ -2015,7 +2538,9 @@ class TestListAllDVPDeliveries:
                     "delivery_id": 1,
                     "token_address": token_address_1,
                     "buyer_address": buyer_address,
+                    "buyer_personal_information": None,
                     "seller_address": seller_address_1,
+                    "seller_personal_information": None,
                     "amount": 1,
                     "agent_address": agent_address_1,
                     "data": "",
@@ -2211,7 +2736,9 @@ class TestListAllDVPDeliveries:
                     "delivery_id": 2,
                     "token_address": token_address_1,
                     "buyer_address": buyer_address,
+                    "buyer_personal_information": None,
                     "seller_address": seller_address_1,
+                    "seller_personal_information": None,
                     "amount": 1,
                     "agent_address": agent_address_1,
                     "data": "",
@@ -2404,7 +2931,9 @@ class TestListAllDVPDeliveries:
                     "delivery_id": 1,
                     "token_address": token_address_1,
                     "buyer_address": buyer_address,
+                    "buyer_personal_information": None,
                     "seller_address": seller_address_1,
+                    "seller_personal_information": None,
                     "amount": 1,
                     "agent_address": agent_address_1,
                     "data": "",
@@ -2427,7 +2956,9 @@ class TestListAllDVPDeliveries:
                     "delivery_id": 2,
                     "token_address": token_address_1,
                     "buyer_address": buyer_address,
+                    "buyer_personal_information": None,
                     "seller_address": seller_address_1,
+                    "seller_personal_information": None,
                     "amount": 1,
                     "agent_address": agent_address_1,
                     "data": "",
@@ -2450,7 +2981,9 @@ class TestListAllDVPDeliveries:
                     "delivery_id": 3,
                     "token_address": token_address_1,
                     "buyer_address": buyer_address,
+                    "buyer_personal_information": None,
                     "seller_address": seller_address_1,
+                    "seller_personal_information": None,
                     "amount": 1,
                     "agent_address": agent_address_1,
                     "data": "",
@@ -2473,7 +3006,9 @@ class TestListAllDVPDeliveries:
                     "delivery_id": 4,
                     "token_address": token_address_1,
                     "buyer_address": buyer_address,
+                    "buyer_personal_information": None,
                     "seller_address": seller_address_1,
+                    "seller_personal_information": None,
                     "amount": 1,
                     "agent_address": agent_address_1,
                     "data": "",
@@ -2496,7 +3031,9 @@ class TestListAllDVPDeliveries:
                     "delivery_id": 5,
                     "token_address": token_address_1,
                     "buyer_address": buyer_address,
+                    "buyer_personal_information": None,
                     "seller_address": seller_address_1,
+                    "seller_personal_information": None,
                     "amount": 1,
                     "agent_address": agent_address_1,
                     "data": "",
@@ -2519,7 +3056,9 @@ class TestListAllDVPDeliveries:
                     "delivery_id": 6,
                     "token_address": token_address_2,
                     "buyer_address": buyer_address,
+                    "buyer_personal_information": None,
                     "seller_address": seller_address_2,
+                    "seller_personal_information": None,
                     "amount": 1,
                     "agent_address": agent_address_2,
                     "data": "",
@@ -2712,7 +3251,9 @@ class TestListAllDVPDeliveries:
                     "delivery_id": 2,
                     "token_address": token_address_1,
                     "buyer_address": buyer_address,
+                    "buyer_personal_information": None,
                     "seller_address": seller_address_1,
+                    "seller_personal_information": None,
                     "amount": 1,
                     "agent_address": agent_address_1,
                     "data": "",
@@ -2735,7 +3276,9 @@ class TestListAllDVPDeliveries:
                     "delivery_id": 3,
                     "token_address": token_address_1,
                     "buyer_address": buyer_address,
+                    "buyer_personal_information": None,
                     "seller_address": seller_address_1,
+                    "seller_personal_information": None,
                     "amount": 1,
                     "agent_address": agent_address_1,
                     "data": "",

--- a/tests/app/test_settlement_dvp_{exchange_address}_delivery_{delivery_id}_GET.py
+++ b/tests/app/test_settlement_dvp_{exchange_address}_delivery_{delivery_id}_GET.py
@@ -19,7 +19,14 @@ SPDX-License-Identifier: Apache-2.0
 
 from datetime import UTC, datetime
 
-from app.model.db import DeliveryStatus, IDXDelivery, Token, TokenType, TokenVersion
+from app.model.db import (
+    DeliveryStatus,
+    IDXDelivery,
+    IDXPersonalInfo,
+    Token,
+    TokenType,
+    TokenVersion,
+)
 from tests.account_config import config_eth_account
 
 
@@ -36,7 +43,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemBatchBatchIdGET:
     # Normal Case
     ###########################################################################
 
-    # Normal_1
+    # Normal_1_1
     def test_normal_1_1(self, client, db):
         exchange_address = "0x1234567890123456789012345678900000000000"
         token_address_1 = "0x1234567890123456789012345678900000000010"
@@ -58,6 +65,37 @@ class TestAppRoutersShareTokensTokenAddressRedeemBatchBatchIdGET:
         _token.abi = {}
         _token.version = TokenVersion.V_24_09
         db.add(_token)
+
+        # prepare data: IDXPersonalInfo
+        _personal_info = IDXPersonalInfo()
+        _personal_info.account_address = buyer_address
+        _personal_info.issuer_address = issuer_address
+        _personal_info._personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(_personal_info)
+
+        _personal_info = IDXPersonalInfo()
+        _personal_info.account_address = seller_address_1
+        _personal_info.issuer_address = issuer_address
+        _personal_info._personal_info = {
+            "key_manager": "key_manager_test2",
+            "name": "name_test2",
+            "postal_code": "postal_code_test2",
+            "address": "address_test2",
+            "email": "email_test2",
+            "birth": "birth_test2",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(_personal_info)
 
         # prepare data: IDXDelivery(Created)
         _idx_delivery = IDXDelivery()
@@ -93,7 +131,136 @@ class TestAppRoutersShareTokensTokenAddressRedeemBatchBatchIdGET:
             "delivery_id": 1,
             "token_address": token_address_1,
             "buyer_address": buyer_address,
+            "buyer_personal_information": {
+                "key_manager": "key_manager_test1",
+                "name": "name_test1",
+                "postal_code": "postal_code_test1",
+                "address": "address_test1",
+                "email": "email_test1",
+                "birth": "birth_test1",
+                "is_corporate": False,
+                "tax_category": 10,
+            },
             "seller_address": seller_address_1,
+            "seller_personal_information": {
+                "key_manager": "key_manager_test2",
+                "name": "name_test2",
+                "postal_code": "postal_code_test2",
+                "address": "address_test2",
+                "email": "email_test2",
+                "birth": "birth_test2",
+                "is_corporate": False,
+                "tax_category": 10,
+            },
+            "amount": 1,
+            "agent_address": agent_address_1,
+            "data": "",
+            "create_blocktimestamp": "2023-12-31T15:00:00+00:00",
+            "create_transaction_hash": "tx_hash_1",
+            "cancel_blocktimestamp": None,
+            "cancel_transaction_hash": None,
+            "confirm_blocktimestamp": None,
+            "confirm_transaction_hash": None,
+            "finish_blocktimestamp": None,
+            "finish_transaction_hash": None,
+            "abort_blocktimestamp": None,
+            "abort_transaction_hash": None,
+            "confirmed": False,
+            "valid": True,
+            "status": DeliveryStatus.DELIVERY_CREATED,
+        }
+
+    # Normal_1_2 (PersonalInfo is not set)
+    def test_normal_1_2(self, client, db):
+        exchange_address = "0x1234567890123456789012345678900000000000"
+        token_address_1 = "0x1234567890123456789012345678900000000010"
+
+        issuer_address = "0x1234567890123456789012345678900000000100"
+
+        seller_address_1 = issuer_address
+
+        buyer_address = "0x1234567890123456789012345678911111111111"
+
+        agent_address_1 = "0x1234567890123456789012345678900000001000"
+
+        # prepare data: Token
+        _token = Token()
+        _token.type = TokenType.IBET_STRAIGHT_BOND.value
+        _token.tx_hash = ""
+        _token.issuer_address = issuer_address
+        _token.token_address = token_address_1
+        _token.abi = {}
+        _token.version = TokenVersion.V_24_09
+        db.add(_token)
+
+        # prepare data: IDXPersonalInfo
+        _personal_info = IDXPersonalInfo()
+        _personal_info.account_address = buyer_address
+        _personal_info.issuer_address = "other_issuer_address"  # Other issuer
+        _personal_info._personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(_personal_info)
+
+        _personal_info = IDXPersonalInfo()
+        _personal_info.account_address = seller_address_1
+        _personal_info.issuer_address = "other_issuer_address"  # Other issuer
+        _personal_info._personal_info = {
+            "key_manager": "key_manager_test2",
+            "name": "name_test2",
+            "postal_code": "postal_code_test2",
+            "address": "address_test2",
+            "email": "email_test2",
+            "birth": "birth_test2",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        db.add(_personal_info)
+
+        # prepare data: IDXDelivery(Created)
+        _idx_delivery = IDXDelivery()
+        _idx_delivery.exchange_address = exchange_address
+        _idx_delivery.delivery_id = 1
+        _idx_delivery.token_address = token_address_1
+        _idx_delivery.buyer_address = buyer_address
+        _idx_delivery.seller_address = seller_address_1
+        _idx_delivery.amount = 1
+        _idx_delivery.agent_address = agent_address_1
+        _idx_delivery.data = ""
+        _idx_delivery.create_blocktimestamp = datetime(2024, 1, 1, 0, 0, 0, tzinfo=UTC)
+        _idx_delivery.create_transaction_hash = "tx_hash_1"
+        _idx_delivery.confirmed = False
+        _idx_delivery.valid = True
+        _idx_delivery.status = DeliveryStatus.DELIVERY_CREATED.value
+        db.add(_idx_delivery)
+
+        db.commit()
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(exchange_address=exchange_address, delivery_id=1),
+            headers={
+                "issuer-address": issuer_address,
+            },
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "exchange_address": exchange_address,
+            "delivery_id": 1,
+            "token_address": token_address_1,
+            "buyer_address": buyer_address,
+            "buyer_personal_information": None,
+            "seller_address": seller_address_1,
+            "seller_personal_information": None,
             "amount": 1,
             "agent_address": agent_address_1,
             "data": "",


### PR DESCRIPTION
- There is a need to refer to personal information registered for issuers for buyers/sellers in DVP settlement.
- Add personal information to the API response items of delivery data.