### PR TITLE
Manage the issuer's child keys as a deterministic wallet

### DIFF
--- a/app/exceptions.py
+++ b/app/exceptions.py
@@ -87,6 +87,12 @@ class MultipleTokenTransferNotAllowedError(BadRequestError):
     code = 9
 
 
+class OperationNotPermittedForOlderIssuers(BadRequestError):
+    """An operation not permitted for older issuers"""
+
+    code = 10
+
+
 class OperationNotAllowedStateError(BadRequestError):
     """
     Error returned when server-side data is not ready to process the request

--- a/app/model/db/__init__.py
+++ b/app/model/db/__init__.py
@@ -17,7 +17,13 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-from .account import Account, AccountRsaKeyTemporary, AccountRsaStatus
+from .account import (
+    Account,
+    AccountRsaKeyTemporary,
+    AccountRsaStatus,
+    ChildAccount,
+    ChildAccountIndex,
+)
 from .auth_token import AuthToken
 from .base import Base
 from .batch_issue_redeem import (
@@ -55,6 +61,7 @@ from .idx_personal_info import (
     IDXPersonalInfo,
     IDXPersonalInfoBlockNumber,
     IDXPersonalInfoHistory,
+    PersonalInfoDataSource,
     PersonalInfoEventType,
 )
 from .idx_position import (

--- a/app/model/db/account.py
+++ b/app/model/db/account.py
@@ -19,7 +19,7 @@ SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum
 
-from sqlalchemy import JSON, Boolean, Integer, String
+from sqlalchemy import JSON, BigInteger, Boolean, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from .base import Base
@@ -32,9 +32,12 @@ class Account(Base):
 
     # issuer address
     issuer_address: Mapped[str] = mapped_column(String(42), primary_key=True)
-    # ethereum keyfile
+    # issuer public key (hex encoded)
+    # - NOTE: The value will be set in versions after v24.12.
+    issuer_public_key: Mapped[str | None] = mapped_column(String(66))
+    # ethereum private-key keyfile
     keyfile: Mapped[str | None] = mapped_column(JSON)
-    # ethereum account password (encrypted)
+    # keyfile password (encrypted)
     eoa_password: Mapped[str | None] = mapped_column(String(2000))
     # rsa private key
     rsa_private_key: Mapped[str | None] = mapped_column(String(8000))
@@ -75,3 +78,27 @@ class AccountRsaKeyTemporary(Base):
     rsa_public_key: Mapped[str | None] = mapped_column(String(2000))
     # rsa passphrase (encrypted)
     rsa_passphrase: Mapped[str | None] = mapped_column(String(2000))
+
+
+class ChildAccountIndex(Base):
+    """Latest index of child account"""
+
+    __tablename__ = "child_account_index"
+
+    # issuer address
+    issuer_address: Mapped[str] = mapped_column(String(42), primary_key=True)
+    # latest index
+    latest_index: Mapped[int] = mapped_column(BigInteger, nullable=False)
+
+
+class ChildAccount(Base):
+    """Issuer's Child Account"""
+
+    __tablename__ = "child_account"
+
+    # issuer address
+    issuer_address: Mapped[str] = mapped_column(String(42), primary_key=True)
+    # child account index
+    child_account_index: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    # child account address
+    child_account_address: Mapped[str] = mapped_column(String(42), nullable=False)

--- a/app/model/db/account.py
+++ b/app/model/db/account.py
@@ -87,8 +87,8 @@ class ChildAccountIndex(Base):
 
     # issuer address
     issuer_address: Mapped[str] = mapped_column(String(42), primary_key=True)
-    # latest index
-    latest_index: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    # next index
+    next_index: Mapped[int] = mapped_column(BigInteger, nullable=False)
 
 
 class ChildAccount(Base):

--- a/app/model/schema/__init__.py
+++ b/app/model/schema/__init__.py
@@ -25,6 +25,11 @@ from .account import (
     AccountCreateKeyRequest,
     AccountGenerateRsaKeyRequest,
     AccountResponse,
+    ChildAccountResponse,
+    CreateChildAccountResponse,
+    CreateUpdateChildAccountRequest,
+    ListAllChildAccountQuery,
+    ListAllChildAccountResponse,
 )
 from .batch_issue_redeem import (
     BatchIssueRedeemUploadIdResponse,

--- a/app/routers/issuer/account.py
+++ b/app/routers/issuer/account.py
@@ -29,22 +29,30 @@ import pytz
 from coincurve import PublicKey
 from Crypto.PublicKey import RSA
 from eth_utils import keccak, to_checksum_address
-from fastapi import APIRouter, Header, Request
+from fastapi import APIRouter, Depends, Header, Request
 from fastapi.exceptions import HTTPException
-from sqlalchemy import select
-from sqlalchemy.exc import IntegrityError as SAIntegrityError
+from sqlalchemy import and_, asc, desc, func, select
+from sqlalchemy.exc import IntegrityError as SAIntegrityError, OperationalError
 
 from app.database import DBAsyncSession
 from app.exceptions import (
     AuthorizationError,
     AuthTokenAlreadyExistsError,
     InvalidParameterError,
+    OperationNotPermittedForOlderIssuers,
+    ServiceUnavailableError,
 )
 from app.model.db import (
     Account,
     AccountRsaKeyTemporary,
     AccountRsaStatus,
     AuthToken,
+    ChildAccount,
+    ChildAccountIndex,
+    IDXPersonalInfo,
+    IDXPersonalInfoHistory,
+    PersonalInfoDataSource,
+    PersonalInfoEventType,
     TransactionLock,
 )
 from app.model.schema import (
@@ -55,6 +63,11 @@ from app.model.schema import (
     AccountCreateKeyRequest,
     AccountGenerateRsaKeyRequest,
     AccountResponse,
+    ChildAccountResponse,
+    CreateChildAccountResponse,
+    CreateUpdateChildAccountRequest,
+    ListAllChildAccountQuery,
+    ListAllChildAccountResponse,
 )
 from app.utils.check_utils import (
     address_is_valid_address,
@@ -108,8 +121,8 @@ async def create_issuer_key(db: DBAsyncSession, data: AccountCreateKeyRequest):
         private_key = keccak(result.get("Plaintext"))
     else:
         private_key = keccak(secrets.token_bytes(32))
-    public_key = PublicKey.from_valid_secret(private_key).format(compressed=False)[1:]
-    addr = to_checksum_address(keccak(public_key)[-20:])
+    public_key = PublicKey.from_valid_secret(private_key)
+    addr = to_checksum_address(keccak(public_key.format(compressed=False)[1:])[-20:])
     keyfile_json = eth_keyfile.create_keyfile_json(
         private_key=private_key, password=eoa_password.encode("utf-8"), kdf="pbkdf2"
     )
@@ -117,13 +130,20 @@ async def create_issuer_key(db: DBAsyncSession, data: AccountCreateKeyRequest):
     # Register key data to the DB
     _account = Account()
     _account.issuer_address = addr
+    _account.issuer_public_key = public_key.format().hex()
     _account.keyfile = keyfile_json
     _account.eoa_password = E2EEUtils.encrypt(eoa_password)
     _account.rsa_status = AccountRsaStatus.UNSET.value
     _account.is_deleted = False
     db.add(_account)
 
-    # Insert initial transaction execution management record
+    # Insert an initial record for the child account index.
+    _child_idx = ChildAccountIndex()
+    _child_idx.issuer_address = addr
+    _child_idx.latest_index = 1
+    db.add(_child_idx)
+
+    # Insert an initial record for transaction execution management.
     _tm = TransactionLock()
     _tm.tx_from = addr
     db.add(_tm)
@@ -553,4 +573,375 @@ async def delete_issuer_auth_token(
 
     await db.delete(_auth_token)
     await db.commit()
+    return
+
+
+# POST: /accounts/{issuer_address}/child_accounts
+@router.post(
+    "/accounts/{issuer_address}/child_accounts",
+    operation_id="CreateChildAccount",
+    response_model=CreateChildAccountResponse,
+    responses=get_routers_responses(
+        404, OperationNotPermittedForOlderIssuers, ServiceUnavailableError
+    ),
+)
+async def create_child_account(
+    db: DBAsyncSession,
+    issuer_address: str,
+    account_req: CreateUpdateChildAccountRequest,
+):
+    """Create the child account"""
+
+    # Check if the issuer exists.
+    _account = (
+        await db.scalars(
+            select(Account).where(Account.issuer_address == issuer_address).limit(1)
+        )
+    ).first()
+    if _account is None:
+        raise HTTPException(status_code=404, detail="issuer does not exist")
+
+    # Check if the issuer was created in version 24.12 or later.
+    if _account.issuer_public_key is None:
+        raise OperationNotPermittedForOlderIssuers
+
+    issuer_pk = PublicKey(data=bytes.fromhex(_account.issuer_public_key))
+
+    # Lock child account index table
+    try:
+        _child_index = (
+            await db.scalars(
+                select(ChildAccountIndex)
+                .where(ChildAccountIndex.issuer_address == issuer_address)
+                .limit(1)
+                .with_for_update(nowait=True)
+            )
+        ).first()
+    except OperationalError:
+        await db.rollback()
+        await db.close()
+        raise ServiceUnavailableError(
+            "Creation of child accounts for this issuer is temporarily unavailable"
+        )
+
+    index = _child_index.latest_index
+    index_sk = int(index).to_bytes(32)
+    index_pk = PublicKey.from_valid_secret(index_sk)
+
+    # Derive the child address
+    child_pk = PublicKey.combine_keys([issuer_pk, index_pk])
+    child_addr = to_checksum_address(
+        keccak(child_pk.format(compressed=False)[1:])[-20:]
+    )
+
+    # Insert child account record and update index
+    _child_account = ChildAccount()
+    _child_account.issuer_address = _account.issuer_address
+    _child_account.child_account_index = index
+    _child_account.child_account_address = child_addr
+    db.add(_child_account)
+
+    _child_index.latest_index = index + 1
+    await db.merge(_child_index)
+
+    # Insert offchain personal information
+    personal_info = account_req.personal_information.model_dump()
+    personal_info["key_manager"] = "SELF"
+    _off_personal_info = IDXPersonalInfo()
+    _off_personal_info.issuer_address = _account.issuer_address
+    _off_personal_info.account_address = child_addr
+    _off_personal_info.personal_info = personal_info
+    _off_personal_info.data_source = PersonalInfoDataSource.OFF_CHAIN
+    db.add(_off_personal_info)
+
+    # Insert personal information history
+    _personal_info_history = IDXPersonalInfoHistory()
+    _personal_info_history.issuer_address = issuer_address
+    _personal_info_history.account_address = child_addr
+    _personal_info_history.event_type = PersonalInfoEventType.REGISTER
+    _personal_info_history.personal_info = personal_info
+    db.add(_personal_info_history)
+
+    await db.commit()
+
+    return json_response({"child_account_index": index})
+
+
+# GET: /accounts/{issuer_address}/child_accounts
+@router.get(
+    "/accounts/{issuer_address}/child_accounts",
+    operation_id="ListAllChildAccount",
+    response_model=ListAllChildAccountResponse,
+    responses=get_routers_responses(404),
+)
+async def list_all_child_account(
+    db: DBAsyncSession,
+    issuer_address: str,
+    get_query: ListAllChildAccountQuery = Depends(),
+):
+    """List all child accounts"""
+
+    # Check if the issuer exists.
+    _account = (
+        await db.scalars(
+            select(Account).where(Account.issuer_address == issuer_address).limit(1)
+        )
+    ).first()
+    if _account is None:
+        raise HTTPException(status_code=404, detail="issuer does not exist")
+
+    # Search child accounts
+    stmt = (
+        select(ChildAccount, IDXPersonalInfo)
+        .where(ChildAccount.issuer_address == issuer_address)
+        .outerjoin(
+            IDXPersonalInfo,
+            and_(
+                ChildAccount.issuer_address == IDXPersonalInfo.issuer_address,
+                ChildAccount.child_account_address == IDXPersonalInfo.account_address,
+                IDXPersonalInfo.data_source == PersonalInfoDataSource.OFF_CHAIN,
+            ),
+        )
+    )
+    total = await db.scalar(select(func.count()).select_from(stmt.subquery()))
+    count = total
+
+    # Sort
+    if get_query.sort_order == 0:  # ASC
+        stmt = stmt.order_by(asc(ChildAccount.child_account_index))
+    else:  # DESC
+        stmt = stmt.order_by(desc(ChildAccount.child_account_index))
+
+    # Pagination
+    if get_query.limit is not None:
+        stmt = stmt.limit(get_query.limit)
+    if get_query.offset is not None:
+        stmt = stmt.offset(get_query.offset)
+
+    _tmp_child_accounts: Sequence[tuple[ChildAccount, IDXPersonalInfo | None]] = (
+        (await db.execute(stmt)).tuples().all()
+    )
+
+    child_accounts = []
+    for _tmp_child_account in _tmp_child_accounts:
+        child_accounts.append(
+            {
+                "issuer_address": _tmp_child_account[0].issuer_address,
+                "child_account_index": _tmp_child_account[0].child_account_index,
+                "child_account_address": _tmp_child_account[0].child_account_address,
+                "personal_information": _tmp_child_account[1].personal_info
+                if _tmp_child_account[1] is not None
+                else None,
+            }
+        )
+
+    return json_response(
+        {
+            "result_set": {
+                "count": count,
+                "total": total,
+                "limit": get_query.limit,
+                "offset": get_query.offset,
+            },
+            "child_accounts": child_accounts,
+        }
+    )
+
+
+# GET: /accounts/{issuer_address}/child_accounts/{child_account_index}
+@router.get(
+    "/accounts/{issuer_address}/child_accounts/{child_account_index}",
+    operation_id="RetrieveChildAccount",
+    response_model=ChildAccountResponse,
+    responses=get_routers_responses(404),
+)
+async def retrieve_child_account(
+    db: DBAsyncSession, issuer_address: str, child_account_index: int
+):
+    """Retrieve the child account"""
+
+    # Check if the issuer exists.
+    _account = (
+        await db.scalars(
+            select(Account).where(Account.issuer_address == issuer_address).limit(1)
+        )
+    ).first()
+    if _account is None:
+        raise HTTPException(status_code=404, detail="issuer does not exist")
+
+    # Search child accounts
+    _child_account = (
+        (
+            await db.execute(
+                select(ChildAccount, IDXPersonalInfo)
+                .where(
+                    and_(
+                        ChildAccount.issuer_address == issuer_address,
+                        ChildAccount.child_account_index == child_account_index,
+                    )
+                )
+                .outerjoin(
+                    IDXPersonalInfo,
+                    and_(
+                        ChildAccount.issuer_address == IDXPersonalInfo.issuer_address,
+                        ChildAccount.child_account_address
+                        == IDXPersonalInfo.account_address,
+                        IDXPersonalInfo.data_source == PersonalInfoDataSource.OFF_CHAIN,
+                    ),
+                )
+                .limit(1)
+            )
+        )
+        .tuples()
+        .first()
+    )
+    if _child_account is None:
+        raise HTTPException(status_code=404, detail="child account does not exist")
+
+    return json_response(
+        {
+            "issuer_address": _child_account[0].issuer_address,
+            "child_account_index": _child_account[0].child_account_index,
+            "child_account_address": _child_account[0].child_account_address,
+            "personal_information": _child_account[1].personal_info
+            if _child_account[1] is not None
+            else None,
+        }
+    )
+
+
+# POST: /accounts/{issuer_address}/child_accounts/{child_account_index}
+@router.post(
+    "/accounts/{issuer_address}/child_accounts/{child_account_index}",
+    operation_id="UpdateChildAccount",
+    response_model=None,
+    responses=get_routers_responses(404),
+)
+async def update_child_account(
+    db: DBAsyncSession,
+    issuer_address: str,
+    child_account_index: int,
+    account_req: CreateUpdateChildAccountRequest,
+):
+    """Update the personal information of the child account"""
+
+    # Check if the issuer exists.
+    _account = (
+        await db.scalars(
+            select(Account).where(Account.issuer_address == issuer_address).limit(1)
+        )
+    ).first()
+    if _account is None:
+        raise HTTPException(status_code=404, detail="issuer does not exist")
+
+    # Check if the child account exists.
+    _child_account = (
+        await db.scalars(
+            select(ChildAccount)
+            .where(
+                and_(
+                    ChildAccount.issuer_address == issuer_address,
+                    ChildAccount.child_account_index == child_account_index,
+                )
+            )
+            .limit(1)
+        )
+    ).first()
+    if _child_account is None:
+        raise HTTPException(status_code=404, detail="child account does not exist")
+
+    # Update offchain personal information
+    _offchain_personal_info = (
+        await db.scalars(
+            select(IDXPersonalInfo)
+            .where(
+                and_(
+                    IDXPersonalInfo.issuer_address == issuer_address,
+                    IDXPersonalInfo.account_address
+                    == _child_account.child_account_address,
+                    IDXPersonalInfo.data_source == PersonalInfoDataSource.OFF_CHAIN,
+                )
+            )
+            .limit(1)
+        )
+    ).first()
+    if _offchain_personal_info is not None:
+        personal_info = account_req.personal_information.model_dump()
+        personal_info["key_manager"] = "SELF"
+        _offchain_personal_info.personal_info = personal_info
+        await db.merge(_offchain_personal_info)
+
+        # Insert personal information history
+        _personal_info_history = IDXPersonalInfoHistory()
+        _personal_info_history.issuer_address = issuer_address
+        _personal_info_history.account_address = _child_account.child_account_address
+        _personal_info_history.event_type = PersonalInfoEventType.MODIFY
+        _personal_info_history.personal_info = personal_info
+        db.add(_personal_info_history)
+
+    await db.commit()
+
+    return
+
+
+# DELETE: /accounts/{issuer_address}/child_accounts/{child_account_index}
+@router.delete(
+    "/accounts/{issuer_address}/child_accounts/{child_account_index}",
+    operation_id="DeleteChildAccount",
+    response_model=None,
+    responses=get_routers_responses(404),
+)
+async def delete_child_account(
+    db: DBAsyncSession, issuer_address: str, child_account_index: int
+):
+    """Delete the child account and its off-chain personal information"""
+
+    # Check if the issuer exists.
+    _account = (
+        await db.scalars(
+            select(Account).where(Account.issuer_address == issuer_address).limit(1)
+        )
+    ).first()
+    if _account is None:
+        raise HTTPException(status_code=404, detail="issuer does not exist")
+
+    # Check if the child account exists.
+    _child_account = (
+        await db.scalars(
+            select(ChildAccount)
+            .where(
+                and_(
+                    ChildAccount.issuer_address == issuer_address,
+                    ChildAccount.child_account_index == child_account_index,
+                )
+            )
+            .limit(1)
+        )
+    ).first()
+    if _child_account is None:
+        raise HTTPException(status_code=404, detail="child account does not exist")
+
+    # Delete child account
+    await db.delete(_child_account)
+
+    # Delete offchain personal information
+    _offchain_personal_info = (
+        await db.scalars(
+            select(IDXPersonalInfo)
+            .where(
+                and_(
+                    IDXPersonalInfo.issuer_address == issuer_address,
+                    IDXPersonalInfo.account_address
+                    == _child_account.child_account_address,
+                    IDXPersonalInfo.data_source == PersonalInfoDataSource.OFF_CHAIN,
+                )
+            )
+            .limit(1)
+        )
+    ).first()
+    if _offchain_personal_info is not None:
+        await db.delete(_offchain_personal_info)
+
+    await db.commit()
+
     return

--- a/app/routers/issuer/account.py
+++ b/app/routers/issuer/account.py
@@ -140,7 +140,7 @@ async def create_issuer_key(db: DBAsyncSession, data: AccountCreateKeyRequest):
     # Insert an initial record for the child account index.
     _child_idx = ChildAccountIndex()
     _child_idx.issuer_address = addr
-    _child_idx.latest_index = 1
+    _child_idx.next_index = 1
     db.add(_child_idx)
 
     # Insert an initial record for transaction execution management.
@@ -624,7 +624,7 @@ async def create_child_account(
             "Creation of child accounts for this issuer is temporarily unavailable"
         )
 
-    index = _child_index.latest_index
+    index = _child_index.next_index
     index_sk = int(index).to_bytes(32)
     index_pk = PublicKey.from_valid_secret(index_sk)
 
@@ -641,7 +641,7 @@ async def create_child_account(
     _child_account.child_account_address = child_addr
     db.add(_child_account)
 
-    _child_index.latest_index = index + 1
+    _child_index.next_index = index + 1
     await db.merge(_child_index)
 
     # Insert offchain personal information

--- a/batch/indexer_personal_info.py
+++ b/batch/indexer_personal_info.py
@@ -41,6 +41,7 @@ from app.model.db import (
     IDXPersonalInfo,
     IDXPersonalInfoBlockNumber,
     IDXPersonalInfoHistory,
+    PersonalInfoDataSource,
     PersonalInfoEventType,
     Token,
     TokenType,
@@ -278,6 +279,7 @@ class Processor:
                         == to_checksum_address(account_address),
                         IDXPersonalInfo.issuer_address
                         == to_checksum_address(issuer_address),
+                        IDXPersonalInfo.data_source == PersonalInfoDataSource.ON_CHAIN,
                     )
                 )
                 .limit(1)
@@ -295,6 +297,7 @@ class Processor:
             _personal_info.account_address = account_address
             _personal_info.issuer_address = issuer_address
             _personal_info.personal_info = personal_info
+            _personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
             _personal_info.created = timestamp
             _personal_info.modified = timestamp
             db_session.add(_personal_info)

--- a/batch/processor_modify_personal_info.py
+++ b/batch/processor_modify_personal_info.py
@@ -40,6 +40,7 @@ from app.model.db import (
     AccountRsaKeyTemporary,
     AccountRsaStatus,
     IDXPersonalInfo,
+    PersonalInfoDataSource,
     Token,
     TokenType,
 )
@@ -97,7 +98,12 @@ class Processor:
                 idx_personal_info_list: Sequence[IDXPersonalInfo] = (
                     await db_session.scalars(
                         select(IDXPersonalInfo).where(
-                            IDXPersonalInfo.issuer_address == temporary.issuer_address
+                            and_(
+                                IDXPersonalInfo.issuer_address
+                                == temporary.issuer_address,
+                                IDXPersonalInfo.data_source
+                                == PersonalInfoDataSource.ON_CHAIN,
+                            )
                         )
                     )
                 ).all()

--- a/docs/ibet_prime.yaml
+++ b/docs/ibet_prime.yaml
@@ -402,6 +402,205 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AuthorizationErrorResponse'
+  /accounts/{issuer_address}/child_accounts:
+    post:
+      tags:
+        - account
+      summary: Create Child Account
+      description: Create the child account
+      operationId: CreateChildAccount
+      parameters:
+        - name: issuer_address
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Issuer Address
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateUpdateChildAccountRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateChildAccountResponse'
+        '404':
+          description: Not Found Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404Model'
+        '400':
+          description: Invalid Parameter Error / Send Transaction Error / Contract
+            Revert Error etc
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OperationNotPermittedForOlderIssuersResponse'
+        '503':
+          description: Service Unavailable Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableErrorResponse'
+    get:
+      tags:
+        - account
+      summary: List All Child Account
+      description: List all child accounts
+      operationId: ListAllChildAccount
+      parameters:
+        - name: issuer_address
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Issuer Address
+        - name: sort_order
+          in: query
+          required: false
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/SortOrder'
+            description: The sort order of the child_account_index. 0:asc, 1:desc
+            default: 0
+            title: Sort Order
+          description: The sort order of the child_account_index. 0:asc, 1:desc
+        - name: offset
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: integer
+                minimum: 0
+              - type: 'null'
+            description: Start position
+            title: Offset
+          description: Start position
+        - name: limit
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: integer
+                minimum: 0
+              - type: 'null'
+            description: Number of set
+            title: Limit
+          description: Number of set
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListAllChildAccountResponse'
+        '404':
+          description: Not Found Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404Model'
+  /accounts/{issuer_address}/child_accounts/{child_account_index}:
+    get:
+      tags:
+        - account
+      summary: Retrieve Child Account
+      description: Retrieve the child account
+      operationId: RetrieveChildAccount
+      parameters:
+        - name: issuer_address
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Issuer Address
+        - name: child_account_index
+          in: path
+          required: true
+          schema:
+            type: integer
+            title: Child Account Index
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChildAccountResponse'
+        '404':
+          description: Not Found Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404Model'
+    post:
+      tags:
+        - account
+      summary: Update Child Account
+      description: Update the personal information of the child account
+      operationId: UpdateChildAccount
+      parameters:
+        - name: issuer_address
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Issuer Address
+        - name: child_account_index
+          in: path
+          required: true
+          schema:
+            type: integer
+            title: Child Account Index
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateUpdateChildAccountRequest'
+      responses:
+        '200':
+          description: Successful Response
+        '404':
+          description: Not Found Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404Model'
+    delete:
+      tags:
+        - account
+      summary: Delete Child Account
+      description: Delete the child account and its off-chain personal information
+      operationId: DeleteChildAccount
+      parameters:
+        - name: issuer_address
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Issuer Address
+        - name: child_account_index
+          in: path
+          required: true
+          schema:
+            type: integer
+            title: Child Account Index
+      responses:
+        '200':
+          description: Successful Response
+        '404':
+          description: Not Found Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404Model'
   /bond/tokens:
     post:
       tags:
@@ -8324,8 +8523,831 @@ paths:
                   - $ref: '#/components/schemas/InvalidParameterErrorResponse'
                   - $ref: '#/components/schemas/SendTransactionErrorResponse'
                 title: Response 400 Updatedvpdelivery
+  /settlement/dvp/agent/accounts:
+    get:
+      tags:
+        - '[misc] settlement_agent'
+      summary: List All Accounts
+      description: List all DVP-Payment Agent accounts
+      operationId: ListAllDVPAgentAccounts
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListAllDVPAgentAccountResponse'
+    post:
+      tags:
+        - '[misc] settlement_agent'
+      summary: Create Account
+      description: Create DVP-Payment Agent Account
+      operationId: CreateDVPAgentAccount
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateDVPAgentAccountRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DVPAgentAccountResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error422Model'
+        '400':
+          description: Invalid Parameter Error / Send Transaction Error / Contract
+            Revert Error etc
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvalidParameterErrorResponse'
+  /settlement/dvp/agent/account/{account_address}:
+    delete:
+      tags:
+        - '[misc] settlement_agent'
+      summary: Delete Account
+      description: Logically delete an DVP-Payment Agent Account
+      operationId: DeleteDVPAgentAccount
+      parameters:
+        - name: account_address
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Account Address
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DVPAgentAccountResponse'
+        '404':
+          description: Not Found Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404Model'
+  /settlement/dvp/agent/account/{account_address}/eoa_password:
+    post:
+      tags:
+        - '[misc] settlement_agent'
+      summary: Change Eoa Password
+      description: Change Agent's EOA Password
+      operationId: ChangeDVPAgentAccountPassword
+      parameters:
+        - name: account_address
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Account Address
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DVPAgentAccountChangeEOAPasswordRequest'
+      responses:
+        '200':
+          description: Successful Response
+        '404':
+          description: Not Found Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404Model'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error422Model'
+        '400':
+          description: Invalid Parameter Error / Send Transaction Error / Contract
+            Revert Error etc
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvalidParameterErrorResponse'
+  /settlement/dvp/agent/{exchange_address}/deliveries:
+    get:
+      tags:
+        - '[misc] settlement_agent'
+      summary: List All Dvp Agent Deliveries
+      description: List all DVP deliveries for paying agent
+      operationId: ListAllDVPAgentDeliveries
+      parameters:
+        - name: exchange_address
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Exchange Address
+        - name: agent_address
+          in: query
+          required: true
+          schema:
+            type: string
+            description: Agent address
+            title: Agent Address
+          description: Agent address
+        - name: token_address
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: 'null'
+            description: Token address
+            title: Token Address
+          description: Token address
+        - name: seller_address
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: 'null'
+            description: Seller address
+            title: Seller Address
+          description: Seller address
+        - name: buyer_address
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: 'null'
+            description: Buyer address
+            title: Buyer Address
+          description: Buyer address
+        - name: valid
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: boolean
+              - type: 'null'
+            description: Valid flag
+            title: Valid
+          description: Valid flag
+        - name: status
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - $ref: '#/components/schemas/DeliveryStatus'
+              - type: 'null'
+            description: Delivery status
+            title: Status
+          description: Delivery status
+        - name: create_blocktimestamp_from
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: string
+                format: date-time
+              - type: 'null'
+            description: Create block timestamp filter(From)
+            title: Create Blocktimestamp From
+          description: Create block timestamp filter(From)
+        - name: create_blocktimestamp_to
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: string
+                format: date-time
+              - type: 'null'
+            description: Create block timestamp filter(To)
+            title: Create Blocktimestamp To
+          description: Create block timestamp filter(To)
+        - name: sort_order
+          in: query
+          required: false
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/SortOrder'
+            description: 0:asc, 1:desc
+            default: 1
+            title: Sort Order
+          description: 0:asc, 1:desc
+        - name: offset
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: integer
+                minimum: 0
+              - type: 'null'
+            description: Start position
+            title: Offset
+          description: Start position
+        - name: limit
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: integer
+                minimum: 0
+              - type: 'null'
+            description: Number of set
+            title: Limit
+          description: Number of set
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListAllDVPAgentDeliveriesResponse'
+        '404':
+          description: Not Found Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404Model'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error422Model'
+        '400':
+          description: Invalid Parameter Error / Send Transaction Error / Contract
+            Revert Error etc
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvalidParameterErrorResponse'
+  /settlement/dvp/agent/{exchange_address}/delivery/{delivery_id}:
+    post:
+      tags:
+        - '[misc] settlement_agent'
+      summary: Update Dvp Agent Delivery
+      description: Finish/Abort DVP delivery
+      operationId: UpdateDVPAgentDelivery
+      parameters:
+        - name: exchange_address
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Exchange Address
+        - name: delivery_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Delivery Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              anyOf:
+                - $ref: '#/components/schemas/FinishDVPDeliveryRequest'
+                - $ref: '#/components/schemas/AbortDVPDeliveryRequest'
+              title: Data
+      responses:
+        '200':
+          description: Successful Response
+        '404':
+          description: Not Found Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404Model'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error422Model'
+        '400':
+          description: Invalid Parameter Error / Send Transaction Error / Contract
+            Revert Error etc
+          content:
+            application/json:
+              schema:
+                anyOf:
+                  - $ref: '#/components/schemas/InvalidParameterErrorResponse'
+                  - $ref: '#/components/schemas/SendTransactionErrorResponse'
+                title: Response 400 Updatedvpagentdelivery
+  /blockchain_explorer/block_data:
+    get:
+      tags:
+        - '[misc] blockchain_explorer'
+      summary: '[ibet Blockchain Explorer] List block data'
+      description: |-
+        Returns a list of block data within the specified block number range.
+        The maximum number of search results is 1000.
+      operationId: ListBlockData
+      parameters:
+        - name: offset
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: integer
+                minimum: 0
+              - type: 'null'
+            description: start position
+            title: Offset
+          description: start position
+        - name: limit
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: integer
+                minimum: 0
+              - type: 'null'
+            description: number of set
+            title: Limit
+          description: number of set
+        - name: from_block_number
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: integer
+                minimum: 0
+              - type: 'null'
+            title: From Block Number
+        - name: to_block_number
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: integer
+                minimum: 0
+              - type: 'null'
+            title: To Block Number
+        - name: sort_order
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - $ref: '#/components/schemas/SortOrder'
+              - type: 'null'
+            description: 'sort order(0: ASC, 1: DESC)'
+            default: 0
+            title: Sort Order
+          description: 'sort order(0: ASC, 1: DESC)'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BlockDataListResponse'
+        '404':
+          description: Not Found Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404Model'
+        '400':
+          description: Invalid Parameter Error / Send Transaction Error / Contract
+            Revert Error etc
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseLimitExceededErrorResponse'
+  /blockchain_explorer/block_data/{block_number}:
+    get:
+      tags:
+        - '[misc] blockchain_explorer'
+      summary: '[ibet Blockchain Explorer] Retrieve block data'
+      description: Returns block data in the specified block number.
+      operationId: GetBlockData
+      parameters:
+        - name: block_number
+          in: path
+          required: true
+          schema:
+            type: integer
+            minimum: 0
+            description: Block number
+            title: Block Number
+          description: Block number
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BlockDataResponse'
+        '404':
+          description: Not Found Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404Model'
+  /blockchain_explorer/tx_data:
+    get:
+      tags:
+        - '[misc] blockchain_explorer'
+      summary: '[ibet Blockchain Explorer] List tx data'
+      description: |-
+        Returns a list of transactions by various search parameters.
+        The maximum number of search results is 10000.
+      operationId: ListTxData
+      parameters:
+        - name: offset
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: integer
+                minimum: 0
+              - type: 'null'
+            description: start position
+            title: Offset
+          description: start position
+        - name: limit
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: integer
+                minimum: 0
+              - type: 'null'
+            description: number of set
+            title: Limit
+          description: number of set
+        - name: block_number
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: integer
+                minimum: 0
+              - type: 'null'
+            description: block number
+            title: Block Number
+          description: block number
+        - name: from_address
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: 'null'
+            description: tx from
+            title: From Address
+          description: tx from
+        - name: to_address
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: 'null'
+            description: tx to
+            title: To Address
+          description: tx to
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TxDataListResponse'
+        '404':
+          description: Not Found Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404Model'
+        '400':
+          description: Invalid Parameter Error / Send Transaction Error / Contract
+            Revert Error etc
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseLimitExceededErrorResponse'
+  /blockchain_explorer/tx_data/{hash}:
+    get:
+      tags:
+        - '[misc] blockchain_explorer'
+      summary: '[ibet Blockchain Explorer] Retrieve transaction data'
+      description: Searching for the transaction by transaction hash
+      operationId: GetTxData
+      parameters:
+        - name: hash
+          in: path
+          required: true
+          schema:
+            type: string
+            description: Transaction hash
+            title: Hash
+          description: Transaction hash
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TxDataResponse'
+        '404':
+          description: Not Found Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404Model'
+  /freeze_log/accounts:
+    get:
+      tags:
+        - '[misc] freeze_log'
+      summary: List All Accounts
+      description: List all freeze-logging accounts
+      operationId: ListAllFreezeLogAccount
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListAllFreezeLogAccountResponse'
+    post:
+      tags:
+        - '[misc] freeze_log'
+      summary: Create Account
+      description: Create Freeze-Logging Account
+      operationId: CreateFreezeLogAccount
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateFreezeLogAccountRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FreezeLogAccountResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error422Model'
+        '400':
+          description: Invalid Parameter Error / Send Transaction Error / Contract
+            Revert Error etc
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvalidParameterErrorResponse'
+  /freeze_log/accounts/{account_address}:
+    delete:
+      tags:
+        - '[misc] freeze_log'
+      summary: Delete Account
+      description: Logically delete an freeze-logging account
+      operationId: DeleteFreezeLogAccount
+      parameters:
+        - name: account_address
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Account Address
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FreezeLogAccountResponse'
+        '404':
+          description: Not Found Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404Model'
+  /freeze_log/accounts/{account_address}/eoa_password:
+    post:
+      tags:
+        - '[misc] freeze_log'
+      summary: Change Eoa Password
+      description: Change Account's EOA Password
+      operationId: ChangeFreezeLogAccountPassword
+      parameters:
+        - name: account_address
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Account Address
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FreezeLogAccountChangeEOAPasswordRequest'
+      responses:
+        '200':
+          description: Successful Response
+        '404':
+          description: Not Found Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404Model'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error422Model'
+        '400':
+          description: Invalid Parameter Error / Send Transaction Error / Contract
+            Revert Error etc
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvalidParameterErrorResponse'
+  /freeze_log/logs:
+    post:
+      tags:
+        - '[misc] freeze_log'
+      summary: Record New Log
+      operationId: RecordNewFreezeLog
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RecordNewFreezeLogRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecordNewFreezeLogResponse'
+        '404':
+          description: Not Found Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404Model'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error422Model'
+        '400':
+          description: Invalid Parameter Error / Send Transaction Error / Contract
+            Revert Error etc
+          content:
+            application/json:
+              schema:
+                anyOf:
+                  - $ref: '#/components/schemas/InvalidParameterErrorResponse'
+                  - $ref: '#/components/schemas/SendTransactionErrorResponse'
+                title: Response 400 Recordnewfreezelog
+  /freeze_log/logs/{log_index}:
+    post:
+      tags:
+        - '[misc] freeze_log'
+      summary: Update Log
+      operationId: UpdateFreezeLog
+      parameters:
+        - name: log_index
+          in: path
+          required: true
+          schema:
+            type: integer
+            description: Log index
+            title: Log Index
+          description: Log index
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateFreezeLogRequest'
+      responses:
+        '200':
+          description: Successful Response
+        '404':
+          description: Not Found Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404Model'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error422Model'
+        '400':
+          description: Invalid Parameter Error / Send Transaction Error / Contract
+            Revert Error etc
+          content:
+            application/json:
+              schema:
+                anyOf:
+                  - $ref: '#/components/schemas/InvalidParameterErrorResponse'
+                  - $ref: '#/components/schemas/SendTransactionErrorResponse'
+                title: Response 400 Updatefreezelog
+    get:
+      tags:
+        - '[misc] freeze_log'
+      summary: Retrieve Log
+      operationId: RetrieveFreezeLog
+      parameters:
+        - name: log_index
+          in: path
+          required: true
+          schema:
+            type: integer
+            description: Log index
+            title: Log Index
+          description: Log index
+        - name: account_address
+          in: query
+          required: true
+          schema:
+            type: string
+            description: Logging account address
+            title: Account Address
+          description: Logging account address
+      responses:
+        '200':
+          description: Successful Response
+        '404':
+          description: Not Found Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404Model'
 components:
   schemas:
+    AbortDVPDeliveryRequest:
+      properties:
+        operation_type:
+          type: string
+          enum:
+            - Abort
+          const: Abort
+          title: Operation Type
+        account_address:
+          type: string
+          title: Account Address
+          description: Agent account address
+        eoa_password:
+          type: string
+          title: Eoa Password
+          description: Agent account key file password
+      type: object
+      required:
+        - operation_type
+        - account_address
+        - eoa_password
+      title: AbortDVPDeliveryRequest
+      description: DVP delivery abort schema (REQUEST)
+    Account:
+      properties:
+        issuer_address:
+          type: string
+          title: Issuer Address
+        rsa_public_key:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Rsa Public Key
+        rsa_status:
+          $ref: '#/components/schemas/AccountRsaStatus'
+        is_deleted:
+          type: boolean
+          title: Is Deleted
+      type: object
+      required:
+        - issuer_address
+        - rsa_public_key
+        - rsa_status
+        - is_deleted
+      title: Account
+      description: Account schema
     AccountAuthTokenRequest:
       properties:
         valid_duration:
@@ -8404,26 +9426,8 @@ components:
       title: AccountGenerateRsaKeyRequest
       description: Account Change Rsa Key schema (REQUEST)
     AccountResponse:
-      properties:
-        issuer_address:
-          type: string
-          title: Issuer Address
-        rsa_public_key:
-          anyOf:
-            - type: string
-            - type: 'null'
-          title: Rsa Public Key
-        rsa_status:
-          $ref: '#/components/schemas/AccountRsaStatus'
-        is_deleted:
-          type: boolean
-          title: Is Deleted
-      type: object
-      required:
-        - issuer_address
-        - rsa_public_key
-        - rsa_status
-        - is_deleted
+      allOf:
+        - $ref: '#/components/schemas/Account'
       title: AccountResponse
       description: Account schema (Response)
     AccountRsaStatus:
@@ -8775,6 +9779,148 @@ components:
         - failed
       title: BatchRegisterPersonalInfoUploadStatus
       description: Batch Register PersonalInfo Upload Status
+    BlockData:
+      properties:
+        number:
+          type: integer
+          minimum: 0.0
+          title: Number
+          description: Block number
+        hash:
+          type: string
+          title: Hash
+          description: Block hash
+        transactions:
+          items:
+            type: string
+          type: array
+          title: Transactions
+          description: Transaction list
+        timestamp:
+          type: integer
+          title: Timestamp
+        gas_limit:
+          type: integer
+          title: Gas Limit
+        gas_used:
+          type: integer
+          title: Gas Used
+        size:
+          type: integer
+          minimum: 0.0
+          title: Size
+      type: object
+      required:
+        - number
+        - hash
+        - transactions
+        - timestamp
+        - gas_limit
+        - gas_used
+        - size
+      title: BlockData
+    BlockDataDetail:
+      properties:
+        number:
+          type: integer
+          minimum: 0.0
+          title: Number
+          description: Block number
+        parent_hash:
+          type: string
+          title: Parent Hash
+        sha3_uncles:
+          type: string
+          title: Sha3 Uncles
+        miner:
+          type: string
+          title: Miner
+        state_root:
+          type: string
+          title: State Root
+        transactions_root:
+          type: string
+          title: Transactions Root
+        receipts_root:
+          type: string
+          title: Receipts Root
+        logs_bloom:
+          type: string
+          title: Logs Bloom
+        difficulty:
+          type: integer
+          title: Difficulty
+        gas_limit:
+          type: integer
+          title: Gas Limit
+        gas_used:
+          type: integer
+          title: Gas Used
+        timestamp:
+          type: integer
+          title: Timestamp
+        proof_of_authority_data:
+          type: string
+          title: Proof Of Authority Data
+        mix_hash:
+          type: string
+          title: Mix Hash
+        nonce:
+          type: string
+          title: Nonce
+        hash:
+          type: string
+          title: Hash
+          description: Block hash
+        size:
+          type: integer
+          minimum: 0.0
+          title: Size
+        transactions:
+          items:
+            type: string
+          type: array
+          title: Transactions
+          description: Transaction list
+      type: object
+      required:
+        - number
+        - parent_hash
+        - sha3_uncles
+        - miner
+        - state_root
+        - transactions_root
+        - receipts_root
+        - logs_bloom
+        - difficulty
+        - gas_limit
+        - gas_used
+        - timestamp
+        - proof_of_authority_data
+        - mix_hash
+        - nonce
+        - hash
+        - size
+        - transactions
+      title: BlockDataDetail
+    BlockDataListResponse:
+      properties:
+        result_set:
+          $ref: '#/components/schemas/ResultSet'
+        block_data:
+          items:
+            $ref: '#/components/schemas/BlockData'
+          type: array
+          title: Block Data
+      type: object
+      required:
+        - result_set
+        - block_data
+      title: BlockDataListResponse
+    BlockDataResponse:
+      allOf:
+        - $ref: '#/components/schemas/BlockDataDetail'
+      title: BlockDataResponse
     BlockNumberResponse:
       properties:
         block_number:
@@ -8966,6 +10112,34 @@ components:
         - operation_type
       title: CancelDVPDeliveryRequest
       description: DVP delivery cancel schema (REQUEST)
+    ChildAccount:
+      properties:
+        issuer_address:
+          type: string
+          title: Issuer Address
+        child_account_index:
+          type: integer
+          title: Child Account Index
+        child_account_address:
+          type: string
+          title: Child Account Address
+        personal_information:
+          anyOf:
+            - $ref: '#/components/schemas/PersonalInfo'
+            - type: 'null'
+      type: object
+      required:
+        - issuer_address
+        - child_account_index
+        - child_account_address
+        - personal_information
+      title: ChildAccount
+      description: Child account schema
+    ChildAccountResponse:
+      allOf:
+        - $ref: '#/components/schemas/ChildAccount'
+      title: ChildAccountResponse
+      description: Child account schema (Response)
     ContractRevertErrorCode:
       type: integer
       enum:
@@ -9183,6 +10357,27 @@ components:
 
         - Error code: https://github.com/BoostryJP/ibet-SmartContract/blob/master/docs/Errors.md
         - If contract doesn't throw error code, 0 is returned.
+    CreateChildAccountResponse:
+      properties:
+        child_account_index:
+          type: integer
+          title: Child Account Index
+      type: object
+      required:
+        - child_account_index
+      title: CreateChildAccountResponse
+      description: Create a issuer's child account schema (RESPONSE)
+    CreateDVPAgentAccountRequest:
+      properties:
+        eoa_password:
+          type: string
+          title: Eoa Password
+          description: EOA keyfile password
+      type: object
+      required:
+        - eoa_password
+      title: CreateDVPAgentAccountRequest
+      description: DVP agent account create schema (REQUEST)
     CreateDVPDeliveryRequest:
       properties:
         token_address:
@@ -9215,6 +10410,17 @@ components:
         - settlement_service_type
       title: CreateDVPDeliveryRequest
       description: DVP delivery create schema (REQUEST)
+    CreateFreezeLogAccountRequest:
+      properties:
+        eoa_password:
+          type: string
+          title: Eoa Password
+          description: EOA keyfile password
+      type: object
+      required:
+        - eoa_password
+      title: CreateFreezeLogAccountRequest
+      description: Freeze-Logging account create schema (REQUEST)
     CreateLedgerInfoMetaInfo:
       properties:
         token_address:
@@ -9305,6 +10511,15 @@ components:
       examples:
         - list_id: cfd83622-34dc-4efe-a68b-2cc275d3d824
           status: pending
+    CreateUpdateChildAccountRequest:
+      properties:
+        personal_information:
+          $ref: '#/components/schemas/PersonalInfoInput'
+      type: object
+      required:
+        - personal_information
+      title: CreateUpdateChildAccountRequest
+      description: Create or update a issuer's child account schema (REQUEST)
     CreateUpdateLedgerDetailsDataRequest:
       properties:
         name:
@@ -9425,6 +10640,36 @@ components:
         - details
       title: CreateUpdateLedgerTemplateRequest
       description: Create or Update Ledger Template schema (Request)
+    DVPAgentAccountChangeEOAPasswordRequest:
+      properties:
+        old_eoa_password:
+          type: string
+          title: Old Eoa Password
+          description: EOA keyfile password (old)
+        eoa_password:
+          type: string
+          title: Eoa Password
+          description: EOA keyfile password (new)
+      type: object
+      required:
+        - old_eoa_password
+        - eoa_password
+      title: DVPAgentAccountChangeEOAPasswordRequest
+      description: DVP agent account change EOA password schema (REQUEST)
+    DVPAgentAccountResponse:
+      properties:
+        account_address:
+          type: string
+          title: Account Address
+        is_deleted:
+          type: boolean
+          title: Is Deleted
+      type: object
+      required:
+        - account_address
+        - is_deleted
+      title: DVPAgentAccountResponse
+      description: DVP agent account reference schema (RESPONSE)
     DVPDeliveryData:
       properties:
         delivery_type:
@@ -9904,6 +11149,29 @@ components:
         - created
       title: FileResponse
       description: File schema (Response)
+    FinishDVPDeliveryRequest:
+      properties:
+        operation_type:
+          type: string
+          enum:
+            - Finish
+          const: Finish
+          title: Operation Type
+        account_address:
+          type: string
+          title: Account Address
+          description: Agent account address
+        eoa_password:
+          type: string
+          title: Eoa Password
+          description: Agent account key file password
+      type: object
+      required:
+        - operation_type
+        - account_address
+        - eoa_password
+      title: FinishDVPDeliveryRequest
+      description: DVP delivery finish schema (REQUEST)
     ForceUnlockRequest:
       properties:
         token_address:
@@ -9930,6 +11198,36 @@ components:
         - recipient_address
         - value
       title: ForceUnlockRequest
+    FreezeLogAccountChangeEOAPasswordRequest:
+      properties:
+        old_eoa_password:
+          type: string
+          title: Old Eoa Password
+          description: EOA keyfile password (old)
+        eoa_password:
+          type: string
+          title: Eoa Password
+          description: EOA keyfile password (new)
+      type: object
+      required:
+        - old_eoa_password
+        - eoa_password
+      title: FreezeLogAccountChangeEOAPasswordRequest
+      description: Freeze-Logging account change EOA password schema (REQUEST)
+    FreezeLogAccountResponse:
+      properties:
+        account_address:
+          type: string
+          title: Account Address
+        is_deleted:
+          type: boolean
+          title: Is Deleted
+      type: object
+      required:
+        - account_address
+        - is_deleted
+      title: FreezeLogAccountResponse
+      description: Freeze-logging account reference schema (RESPONSE)
     GetBatchIssueRedeemResponse:
       properties:
         processed:
@@ -11328,6 +12626,42 @@ components:
         - footers
       title: LedgerTemplateResponse
       description: Ledger Template schema (Response)
+    ListAllChildAccountResponse:
+      properties:
+        result_set:
+          $ref: '#/components/schemas/ResultSet'
+        child_accounts:
+          items:
+            $ref: '#/components/schemas/ChildAccount'
+          type: array
+          title: Child Accounts
+      type: object
+      required:
+        - result_set
+        - child_accounts
+      title: ListAllChildAccountResponse
+      description: List all child accounts schema (RESPONSE)
+    ListAllDVPAgentAccountResponse:
+      items:
+        $ref: '#/components/schemas/DVPAgentAccountResponse'
+      type: array
+      title: ListAllDVPAgentAccountResponse
+      description: DVP agent account list reference schema (RESPONSE)
+    ListAllDVPAgentDeliveriesResponse:
+      properties:
+        result_set:
+          $ref: '#/components/schemas/ResultSet'
+        deliveries:
+          items:
+            $ref: '#/components/schemas/RetrieveDVPAgentDeliveryResponse'
+          type: array
+          title: Deliveries
+      type: object
+      required:
+        - result_set
+        - deliveries
+      title: ListAllDVPAgentDeliveriesResponse
+      description: List all DVP delivery schema for paying agent (Response)
     ListAllDVPDeliveriesResponse:
       properties:
         result_set:
@@ -11373,6 +12707,12 @@ components:
         - files
       title: ListAllFilesResponse
       description: List All Files schema (Response)
+    ListAllFreezeLogAccountResponse:
+      items:
+        $ref: '#/components/schemas/FreezeLogAccountResponse'
+      type: array
+      title: ListAllFreezeLogAccountResponse
+      description: Freeze-logging account list reference schema (RESPONSE)
     ListAllHoldersSortItem:
       type: string
       enum:
@@ -11943,6 +13283,42 @@ components:
       title: OperationNotAllowedStateErrorResponse
       description: Error returned when server-side data is not ready to process the
         request
+    OperationNotPermittedForOlderIssuersCode:
+      type: integer
+      enum:
+        - 10
+      const: 10
+      title: OperationNotPermittedForOlderIssuersCode
+    OperationNotPermittedForOlderIssuersMetainfo:
+      properties:
+        code:
+          allOf:
+            - $ref: '#/components/schemas/OperationNotPermittedForOlderIssuersCode'
+          examples:
+            - 10
+        title:
+          type: string
+          title: Title
+          examples:
+            - OperationNotPermittedForOlderIssuers
+      type: object
+      required:
+        - code
+        - title
+      title: OperationNotPermittedForOlderIssuersMetainfo
+    OperationNotPermittedForOlderIssuersResponse:
+      properties:
+        meta:
+          $ref: '#/components/schemas/OperationNotPermittedForOlderIssuersMetainfo'
+        detail:
+          type: string
+          title: Detail
+      type: object
+      required:
+        - meta
+        - detail
+      title: OperationNotPermittedForOlderIssuersResponse
+      description: An operation not permitted for older issuers
     OperationNotSupportedVersionErrorCode:
       type: integer
       enum:
@@ -12095,6 +13471,46 @@ components:
         - modified
       title: PersonalInfoIndex
       description: Personal Information Index schema
+    PersonalInfoInput:
+      properties:
+        name:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Name
+        postal_code:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Postal Code
+        address:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Address
+        email:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Email
+        birth:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Birth
+        is_corporate:
+          anyOf:
+            - type: boolean
+            - type: 'null'
+          title: Is Corporate
+        tax_category:
+          anyOf:
+            - type: integer
+            - type: 'null'
+          title: Tax Category
+      type: object
+      title: PersonalInfoInput
+      description: Personal Information Input schema
     Position:
       properties:
         issuer_address:
@@ -12151,6 +13567,43 @@ components:
         - $ref: '#/components/schemas/Position'
       title: PositionResponse
       description: Position schema (Response)
+    RecordNewFreezeLogRequest:
+      properties:
+        account_address:
+          type: string
+          title: Account Address
+          description: Logging account address
+        eoa_password:
+          type: string
+          title: Eoa Password
+          description: Logging account key file password
+        log_message:
+          type: string
+          title: Log Message
+          description: Log message
+        freezing_grace_block_count:
+          type: integer
+          exclusiveMinimum: 0.0
+          title: Freezing Grace Block Count
+          description: Freezing grace block count
+      type: object
+      required:
+        - account_address
+        - eoa_password
+        - log_message
+        - freezing_grace_block_count
+      title: RecordNewFreezeLogRequest
+      description: Record new freeze log schema (REQUEST)
+    RecordNewFreezeLogResponse:
+      properties:
+        log_index:
+          type: integer
+          title: Log Index
+      type: object
+      required:
+        - log_index
+      title: RecordNewFreezeLogResponse
+      description: New freeze-log recording schema (RESPONSE)
     RegisterPersonalInfoRequest:
       properties:
         name:
@@ -12200,6 +13653,41 @@ components:
         - key_manager
       title: RegisterPersonalInfoRequest
       description: Register Personal Information schema (REQUEST)
+    ResponseLimitExceededErrorCode:
+      type: integer
+      enum:
+        - 4
+      const: 4
+      title: ResponseLimitExceededErrorCode
+    ResponseLimitExceededErrorMetainfo:
+      properties:
+        code:
+          allOf:
+            - $ref: '#/components/schemas/ResponseLimitExceededErrorCode'
+          examples:
+            - 4
+        title:
+          type: string
+          title: Title
+          examples:
+            - ResponseLimitExceededError
+      type: object
+      required:
+        - code
+        - title
+      title: ResponseLimitExceededErrorMetainfo
+    ResponseLimitExceededErrorResponse:
+      properties:
+        meta:
+          $ref: '#/components/schemas/ResponseLimitExceededErrorMetainfo'
+        detail:
+          type: string
+          title: Detail
+      type: object
+      required:
+        - meta
+        - detail
+      title: ResponseLimitExceededErrorResponse
     ResultSet:
       properties:
         count:
@@ -12230,6 +13718,118 @@ components:
         - total
       title: ResultSet
       description: result set for pagination
+    RetrieveDVPAgentDeliveryResponse:
+      properties:
+        exchange_address:
+          type: string
+          title: Exchange Address
+        delivery_id:
+          type: integer
+          title: Delivery Id
+        token_address:
+          type: string
+          title: Token Address
+        buyer_address:
+          type: string
+          title: Buyer Address
+        seller_address:
+          type: string
+          title: Seller Address
+        amount:
+          type: integer
+          title: Amount
+        agent_address:
+          type: string
+          title: Agent Address
+        data:
+          anyOf:
+            - $ref: '#/components/schemas/DVPDeliveryData'
+            - type: 'null'
+        settlement_service_type:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Settlement Service Type
+        create_blocktimestamp:
+          type: string
+          title: Create Blocktimestamp
+        create_transaction_hash:
+          type: string
+          title: Create Transaction Hash
+        cancel_blocktimestamp:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Cancel Blocktimestamp
+        cancel_transaction_hash:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Cancel Transaction Hash
+        confirm_blocktimestamp:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Confirm Blocktimestamp
+        confirm_transaction_hash:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Confirm Transaction Hash
+        finish_blocktimestamp:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Finish Blocktimestamp
+        finish_transaction_hash:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Finish Transaction Hash
+        abort_blocktimestamp:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Abort Blocktimestamp
+        abort_transaction_hash:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Abort Transaction Hash
+        confirmed:
+          type: boolean
+          title: Confirmed
+        valid:
+          type: boolean
+          title: Valid
+        status:
+          $ref: '#/components/schemas/DeliveryStatus'
+      type: object
+      required:
+        - exchange_address
+        - delivery_id
+        - token_address
+        - buyer_address
+        - seller_address
+        - amount
+        - agent_address
+        - data
+        - settlement_service_type
+        - create_blocktimestamp
+        - create_transaction_hash
+        - cancel_blocktimestamp
+        - cancel_transaction_hash
+        - confirm_blocktimestamp
+        - confirm_transaction_hash
+        - finish_blocktimestamp
+        - finish_transaction_hash
+        - abort_blocktimestamp
+        - abort_transaction_hash
+        - confirmed
+        - valid
+        - status
+      title: RetrieveDVPAgentDeliveryResponse
+      description: Retrieve DVP delivery schema for paying agent (Response)
     RetrieveDVPDeliveryResponse:
       properties:
         exchange_address:
@@ -13250,6 +14850,130 @@ components:
         - Transfer
         - Unlock
       title: TransferSourceEventType
+    TxData:
+      properties:
+        hash:
+          type: string
+          title: Hash
+          description: Transaction hash
+        block_hash:
+          type: string
+          title: Block Hash
+        block_number:
+          type: integer
+          minimum: 0.0
+          title: Block Number
+        transaction_index:
+          type: integer
+          minimum: 0.0
+          title: Transaction Index
+        from_address:
+          type: string
+          title: From Address
+        to_address:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: To Address
+      type: object
+      required:
+        - hash
+        - block_hash
+        - block_number
+        - transaction_index
+        - from_address
+        - to_address
+      title: TxData
+    TxDataDetail:
+      properties:
+        hash:
+          type: string
+          title: Hash
+          description: Transaction hash
+        block_hash:
+          type: string
+          title: Block Hash
+        block_number:
+          type: integer
+          minimum: 0.0
+          title: Block Number
+        transaction_index:
+          type: integer
+          minimum: 0.0
+          title: Transaction Index
+        from_address:
+          type: string
+          title: From Address
+        to_address:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: To Address
+        contract_name:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Contract Name
+        contract_function:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Contract Function
+        contract_parameters:
+          anyOf:
+            - type: object
+            - type: 'null'
+          title: Contract Parameters
+        gas:
+          type: integer
+          minimum: 0.0
+          title: Gas
+        gas_price:
+          type: integer
+          minimum: 0.0
+          title: Gas Price
+        value:
+          type: integer
+          minimum: 0.0
+          title: Value
+        nonce:
+          type: integer
+          minimum: 0.0
+          title: Nonce
+      type: object
+      required:
+        - hash
+        - block_hash
+        - block_number
+        - transaction_index
+        - from_address
+        - to_address
+        - contract_name
+        - contract_function
+        - contract_parameters
+        - gas
+        - gas_price
+        - value
+        - nonce
+      title: TxDataDetail
+    TxDataListResponse:
+      properties:
+        result_set:
+          $ref: '#/components/schemas/ResultSet'
+        tx_data:
+          items:
+            $ref: '#/components/schemas/TxData'
+          type: array
+          title: Tx Data
+      type: object
+      required:
+        - result_set
+        - tx_data
+      title: TxDataListResponse
+    TxDataResponse:
+      allOf:
+        - $ref: '#/components/schemas/TxDataDetail'
+      title: TxDataResponse
     UnlockInfoMetaInfo:
       properties:
         token_address:
@@ -13320,6 +15044,27 @@ components:
         - notice_type
         - metainfo
       title: UnlockInfoNotification
+    UpdateFreezeLogRequest:
+      properties:
+        account_address:
+          type: string
+          title: Account Address
+          description: Logging account address
+        eoa_password:
+          type: string
+          title: Eoa Password
+          description: Logging account key file password
+        log_message:
+          type: string
+          title: Log Message
+          description: Log message
+      type: object
+      required:
+        - account_address
+        - eoa_password
+        - log_message
+      title: UpdateFreezeLogRequest
+      description: Update freeze log schema (REQUEST)
     UpdateTransferApprovalOperationType:
       type: string
       enum:
@@ -13420,3 +15165,9 @@ tags:
     description: Utility functions
   - name: '[misc] messaging'
     description: Messaging functions with external systems
+  - name: '[misc] settlement_agent'
+    description: Settlement related features for paying agent
+  - name: '[misc] blockchain_explorer'
+    description: Blockchain explorer
+  - name: '[misc] freeze_log'
+    description: Freeze log contract

--- a/migrations/versions/3977b822f983_v24_12_0_feature_682.py
+++ b/migrations/versions/3977b822f983_v24_12_0_feature_682.py
@@ -1,0 +1,76 @@
+"""v24_12_0_feature_682
+
+Revision ID: 3977b822f983
+Revises: f728fd994b80
+Create Date: 2024-09-28 01:10:07.686046
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import update
+
+from app.database import get_db_schema
+from app.model.db import IDXPersonalInfo, PersonalInfoDataSource
+
+# revision identifiers, used by Alembic.
+revision = "3977b822f983"
+down_revision = "f728fd994b80"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Create TBL - ChildAccountIndex
+    op.create_table(
+        "child_account_index",
+        sa.Column("issuer_address", sa.String(length=42), nullable=False),
+        sa.Column("latest_index", sa.BigInteger(), nullable=False),
+        sa.Column("created", sa.DateTime(), nullable=True),
+        sa.Column("modified", sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint("issuer_address"),
+        schema=get_db_schema(),
+    )
+
+    # Create TBL - ChildAccount
+    op.create_table(
+        "child_account",
+        sa.Column("issuer_address", sa.String(length=42), nullable=False),
+        sa.Column("child_account_index", sa.BigInteger(), nullable=False),
+        sa.Column("child_account_address", sa.String(length=42), nullable=False),
+        sa.Column("created", sa.DateTime(), nullable=True),
+        sa.Column("modified", sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint("issuer_address", "child_account_index"),
+        schema=get_db_schema(),
+    )
+
+    # Add column - Account
+    op.add_column(
+        "account",
+        sa.Column("issuer_public_key", sa.String(length=66), nullable=True),
+        schema=get_db_schema(),
+    )
+
+    # Add column - IDXPersonalInfo
+    op.add_column(
+        "idx_personal_info",
+        sa.Column("data_source", sa.String(length=10), nullable=True),
+        schema=get_db_schema(),
+    )
+    op.get_bind().execute(
+        update(IDXPersonalInfo).values(data_source=PersonalInfoDataSource.ON_CHAIN)
+    )
+    op.alter_column(
+        "idx_personal_info",
+        "data_source",
+        existing_type=sa.String(length=10),
+        nullable=False,
+        schema=get_db_schema(),
+    )
+
+
+def downgrade():
+    op.drop_column("idx_personal_info", "data_source", schema=get_db_schema())
+    op.drop_column("account", "issuer_public_key", schema=get_db_schema())
+    op.drop_table("child_account_index", schema=get_db_schema())
+    op.drop_table("child_account", schema=get_db_schema())

--- a/migrations/versions/3977b822f983_v24_12_0_feature_682.py
+++ b/migrations/versions/3977b822f983_v24_12_0_feature_682.py
@@ -25,7 +25,7 @@ def upgrade():
     op.create_table(
         "child_account_index",
         sa.Column("issuer_address", sa.String(length=42), nullable=False),
-        sa.Column("latest_index", sa.BigInteger(), nullable=False),
+        sa.Column("next_index", sa.BigInteger(), nullable=False),
         sa.Column("created", sa.DateTime(), nullable=True),
         sa.Column("modified", sa.DateTime(), nullable=True),
         sa.PrimaryKeyConstraint("issuer_address"),

--- a/tests/app/test_accounts_CreateChildAccount.py
+++ b/tests/app/test_accounts_CreateChildAccount.py
@@ -1,0 +1,380 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import datetime
+import secrets
+
+import pytest
+from coincurve import PublicKey
+from eth_utils import keccak, to_checksum_address
+from sqlalchemy import select
+
+from app.model.db import (
+    Account,
+    ChildAccount,
+    ChildAccountIndex,
+    IDXPersonalInfo,
+    IDXPersonalInfoHistory,
+    PersonalInfoDataSource,
+    PersonalInfoEventType,
+)
+
+
+class TestCreateChildAccount:
+    sk_1 = secrets.token_bytes(32)
+    pk_1 = PublicKey.from_valid_secret(sk_1)
+
+    issuer_pub_key = pk_1.format().hex()
+    issuer_address = to_checksum_address(
+        keccak(pk_1.format(compressed=False)[1:])[-20:]
+    )
+
+    index = 1
+    sk_2 = int(index).to_bytes(32)
+    pk_2 = PublicKey.from_valid_secret(sk_2)
+
+    child_1_pub_key = PublicKey.combine_keys([pk_1, pk_2])
+    child_1_address = to_checksum_address(
+        keccak(child_1_pub_key.format(compressed=False)[1:])[-20:]
+    )
+
+    # Target API endpoint
+    base_url = "/accounts/{}/child_accounts"
+
+    ###########################################################################
+    # Normal Case
+    ###########################################################################
+
+    # <Normal_0>
+    # Verify the deterministic wallet
+    def test_normal_0(self, client, db):
+        # Generate a child public key from two private keys.
+        child_sk_1 = ((int.from_bytes(self.sk_1) + self.index) % (2**256)).to_bytes(32)
+        child_pk_1 = PublicKey.from_valid_secret(child_sk_1)
+
+        # Generate a child public key from two public keys.
+        child_pk_2 = PublicKey.combine_keys([self.pk_1, self.pk_2])
+
+        assert child_pk_1 == child_pk_2
+
+    # <Normal_1_1>
+    # Successfully generated the child key
+    @pytest.mark.freeze_time("2024-09-28 12:34:56")
+    def test_normal_1_1(self, client, db):
+        # Prepare data
+        _account = Account()
+        _account.issuer_address = self.issuer_address
+        _account.issuer_public_key = self.issuer_pub_key
+        db.add(_account)
+
+        _child_index = ChildAccountIndex()
+        _child_index.issuer_address = self.issuer_address
+        _child_index.latest_index = 1
+        db.add(_child_index)
+
+        db.commit()
+
+        # Call API
+        resp = client.post(
+            self.base_url.format(self.issuer_address),
+            json={
+                "personal_information": {
+                    "name": "name_test",
+                    "postal_code": "postal_code_test",
+                    "address": "address_test",
+                    "email": "email_test",
+                    "birth": "birth_test",
+                    "is_corporate": False,
+                    "tax_category": 10,
+                }
+            },
+        )
+
+        # Assertion
+        assert resp.status_code == 200
+        assert resp.json() == {"child_account_index": 1}
+
+        _child_account = db.scalars(
+            select(ChildAccount).where(
+                ChildAccount.issuer_address == self.issuer_address
+            )
+        ).all()
+        assert len(_child_account) == 1
+        assert _child_account[0].issuer_address == self.issuer_address
+        assert _child_account[0].child_account_index == 1
+        assert _child_account[0].child_account_address == self.child_1_address
+
+        _child_index = db.scalars(
+            select(ChildAccountIndex)
+            .where(ChildAccountIndex.issuer_address == self.issuer_address)
+            .limit(1)
+        ).first()
+        assert _child_index.latest_index == 2
+
+        _off_personal_info = db.scalars(
+            select(IDXPersonalInfo)
+            .where(IDXPersonalInfo.issuer_address == self.issuer_address)
+            .limit(1)
+        ).first()
+        assert _off_personal_info.issuer_address == self.issuer_address
+        assert (
+            _off_personal_info.account_address
+            == _child_account[0].child_account_address
+        )
+        assert _off_personal_info.personal_info == {
+            "key_manager": "SELF",
+            "name": "name_test",
+            "postal_code": "postal_code_test",
+            "address": "address_test",
+            "email": "email_test",
+            "birth": "birth_test",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        assert _off_personal_info.data_source == PersonalInfoDataSource.OFF_CHAIN
+
+        _personal_info_history = db.scalars(
+            select(IDXPersonalInfoHistory)
+            .where(IDXPersonalInfoHistory.issuer_address == self.issuer_address)
+            .limit(1)
+        ).first()
+        assert _personal_info_history.issuer_address == self.issuer_address
+        assert (
+            _personal_info_history.account_address
+            == _child_account[0].child_account_address
+        )
+        assert _personal_info_history.event_type == PersonalInfoEventType.REGISTER
+        assert _personal_info_history.personal_info == _off_personal_info.personal_info
+        assert _personal_info_history.block_timestamp == datetime.datetime(
+            2024, 9, 28, 12, 34, 56
+        )
+
+    # <Normal_1_2>
+    # Personal information is blank
+    @pytest.mark.freeze_time("2024-09-28 12:34:56")
+    def test_normal_1_2(self, client, db):
+        # Prepare data
+        _account = Account()
+        _account.issuer_address = self.issuer_address
+        _account.issuer_public_key = self.issuer_pub_key
+        db.add(_account)
+
+        _child_index = ChildAccountIndex()
+        _child_index.issuer_address = self.issuer_address
+        _child_index.latest_index = 1
+        db.add(_child_index)
+
+        db.commit()
+
+        # Call API
+        resp = client.post(
+            self.base_url.format(self.issuer_address), json={"personal_information": {}}
+        )
+
+        # Assertion
+        assert resp.status_code == 200
+        assert resp.json() == {"child_account_index": 1}
+
+        _child_account = db.scalars(
+            select(ChildAccount).where(
+                ChildAccount.issuer_address == self.issuer_address
+            )
+        ).all()
+        assert len(_child_account) == 1
+        assert _child_account[0].issuer_address == self.issuer_address
+        assert _child_account[0].child_account_index == 1
+        assert _child_account[0].child_account_address == self.child_1_address
+
+        _child_index = db.scalars(
+            select(ChildAccountIndex)
+            .where(ChildAccountIndex.issuer_address == self.issuer_address)
+            .limit(1)
+        ).first()
+        assert _child_index.latest_index == 2
+
+        _off_personal_info = db.scalars(
+            select(IDXPersonalInfo)
+            .where(IDXPersonalInfo.issuer_address == self.issuer_address)
+            .limit(1)
+        ).first()
+        assert _off_personal_info.issuer_address == self.issuer_address
+        assert (
+            _off_personal_info.account_address
+            == _child_account[0].child_account_address
+        )
+        assert _off_personal_info.personal_info == {
+            "key_manager": "SELF",
+            "name": None,
+            "postal_code": None,
+            "address": None,
+            "email": None,
+            "birth": None,
+            "is_corporate": None,
+            "tax_category": None,
+        }
+        assert _off_personal_info.data_source == PersonalInfoDataSource.OFF_CHAIN
+
+        _personal_info_history = db.scalars(
+            select(IDXPersonalInfoHistory)
+            .where(IDXPersonalInfoHistory.issuer_address == self.issuer_address)
+            .limit(1)
+        ).first()
+        assert _personal_info_history.issuer_address == self.issuer_address
+        assert (
+            _personal_info_history.account_address
+            == _child_account[0].child_account_address
+        )
+        assert _personal_info_history.event_type == PersonalInfoEventType.REGISTER
+        assert _personal_info_history.personal_info == _off_personal_info.personal_info
+        assert _personal_info_history.block_timestamp == datetime.datetime(
+            2024, 9, 28, 12, 34, 56
+        )
+
+    ###########################################################################
+    # Error Case
+    ###########################################################################
+
+    # <Error_1>
+    # RequestValidationError
+    # - Missing body
+    def test_error_1(self, client, db):
+        # Call API
+        resp = client.post(self.base_url.format(self.issuer_address), json={})
+
+        assert resp.status_code == 422
+        assert resp.json() == {
+            "meta": {"code": 1, "title": "RequestValidationError"},
+            "detail": [
+                {
+                    "type": "missing",
+                    "loc": ["body", "personal_information"],
+                    "msg": "Field required",
+                    "input": {},
+                }
+            ],
+        }
+
+    # <Error_2>
+    # 404: Issuer does not exist
+    def test_error_2(self, client, db):
+        # Call API
+        resp = client.post(
+            self.base_url.format(self.issuer_address),
+            json={
+                "personal_information": {
+                    "name": "name_test",
+                    "postal_code": "postal_code_test",
+                    "address": "address_test",
+                    "email": "email_test",
+                    "birth": "birth_test",
+                    "is_corporate": False,
+                    "tax_category": 10,
+                }
+            },
+        )
+
+        # Assertion
+        assert resp.status_code == 404
+        assert resp.json() == {
+            "meta": {"code": 1, "title": "NotFound"},
+            "detail": "issuer does not exist",
+        }
+
+    # <Error_3>
+    # OperationNotPermittedForOlderIssuers
+    def test_error_3(self, client, db):
+        # Prepare data
+        _account = Account()
+        _account.issuer_address = self.issuer_address
+        _account.issuer_public_key = None  # public-key is not set
+        db.add(_account)
+        db.commit()
+
+        # Call API
+        resp = client.post(
+            self.base_url.format(self.issuer_address),
+            json={
+                "personal_information": {
+                    "name": "name_test",
+                    "postal_code": "postal_code_test",
+                    "address": "address_test",
+                    "email": "email_test",
+                    "birth": "birth_test",
+                    "is_corporate": False,
+                    "tax_category": 10,
+                }
+            },
+        )
+
+        # Assertion
+        assert resp.status_code == 400
+        assert resp.json() == {
+            "meta": {"code": 10, "title": "OperationNotPermittedForOlderIssuers"}
+        }
+
+    # <Error_4>
+    # ServiceUnavailableError
+    # - Lock timeout for index table
+    def test_error_4(self, client, db):
+        # Prepare data
+        _account = Account()
+        _account.issuer_address = self.issuer_address
+        _account.issuer_public_key = self.issuer_pub_key
+        db.add(_account)
+
+        _child_index = ChildAccountIndex()
+        _child_index.issuer_address = self.issuer_address
+        _child_index.latest_index = 2
+        db.add(_child_index)
+
+        db.commit()
+
+        # Lock child account index table
+        _child_index = db.scalars(
+            select(ChildAccountIndex)
+            .where(ChildAccountIndex.issuer_address == self.issuer_address)
+            .limit(1)
+            .with_for_update(nowait=True)
+        ).first()
+
+        # Call API
+        resp = client.post(
+            self.base_url.format(self.issuer_address),
+            json={
+                "personal_information": {
+                    "name": "name_test",
+                    "postal_code": "postal_code_test",
+                    "address": "address_test",
+                    "email": "email_test",
+                    "birth": "birth_test",
+                    "is_corporate": False,
+                    "tax_category": 10,
+                }
+            },
+        )
+
+        # Assertion
+        assert resp.status_code == 503
+        assert resp.json() == {
+            "meta": {"code": 1, "title": "ServiceUnavailableError"},
+            "detail": "Creation of child accounts for this issuer is temporarily unavailable",
+        }
+
+        db.rollback()
+        db.close()

--- a/tests/app/test_accounts_CreateChildAccount.py
+++ b/tests/app/test_accounts_CreateChildAccount.py
@@ -85,7 +85,7 @@ class TestCreateChildAccount:
 
         _child_index = ChildAccountIndex()
         _child_index.issuer_address = self.issuer_address
-        _child_index.latest_index = 1
+        _child_index.next_index = 1
         db.add(_child_index)
 
         db.commit()
@@ -125,7 +125,7 @@ class TestCreateChildAccount:
             .where(ChildAccountIndex.issuer_address == self.issuer_address)
             .limit(1)
         ).first()
-        assert _child_index.latest_index == 2
+        assert _child_index.next_index == 2
 
         _off_personal_info = db.scalars(
             select(IDXPersonalInfo)
@@ -177,7 +177,7 @@ class TestCreateChildAccount:
 
         _child_index = ChildAccountIndex()
         _child_index.issuer_address = self.issuer_address
-        _child_index.latest_index = 1
+        _child_index.next_index = 1
         db.add(_child_index)
 
         db.commit()
@@ -206,7 +206,7 @@ class TestCreateChildAccount:
             .where(ChildAccountIndex.issuer_address == self.issuer_address)
             .limit(1)
         ).first()
-        assert _child_index.latest_index == 2
+        assert _child_index.next_index == 2
 
         _off_personal_info = db.scalars(
             select(IDXPersonalInfo)
@@ -340,7 +340,7 @@ class TestCreateChildAccount:
 
         _child_index = ChildAccountIndex()
         _child_index.issuer_address = self.issuer_address
-        _child_index.latest_index = 2
+        _child_index.next_index = 2
         db.add(_child_index)
 
         db.commit()

--- a/tests/app/test_accounts_CreateIssuerKey.py
+++ b/tests/app/test_accounts_CreateIssuerKey.py
@@ -71,7 +71,7 @@ class TestCreateIssuerKey:
 
         child_idx = db.scalars(select(ChildAccountIndex).limit(1)).first()
         assert child_idx.issuer_address == account_1.issuer_address
-        assert child_idx.latest_index == 1
+        assert child_idx.next_index == 1
 
         tx_lock = db.scalars(select(TransactionLock).limit(1)).first()
         assert tx_lock.tx_from == account_1.issuer_address
@@ -120,7 +120,7 @@ class TestCreateIssuerKey:
 
         child_idx = db.scalars(select(ChildAccountIndex).limit(1)).first()
         assert child_idx.issuer_address == account_1.issuer_address
-        assert child_idx.latest_index == 1
+        assert child_idx.next_index == 1
 
         tx_lock = db.scalars(select(TransactionLock).limit(1)).first()
         assert tx_lock.tx_from == account_1.issuer_address

--- a/tests/app/test_accounts_DeleteChildAccount.py
+++ b/tests/app/test_accounts_DeleteChildAccount.py
@@ -1,0 +1,110 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+from sqlalchemy import select
+
+from app.model.db import Account, ChildAccount, IDXPersonalInfo, PersonalInfoDataSource
+
+
+class TestDeleteChildAccount:
+    issuer_address = "0x89082C5dEcB1Ad23eda99B692A9B594F7044B846"
+    child_account_address = "0x9f07d281F2f78891637cD72C7a4a1b5da309449A"
+
+    # Target API endpoint
+    base_url = "/accounts/{}/child_accounts/{}"
+
+    ###########################################################################
+    # Normal Case
+    ###########################################################################
+
+    # <Normal_1>
+    def test_normal_1(self, client, db):
+        # Prepare data
+        _account = Account()
+        _account.issuer_address = self.issuer_address
+        db.add(_account)
+
+        _child_account = ChildAccount()
+        _child_account.issuer_address = self.issuer_address
+        _child_account.child_account_index = 1
+        _child_account.child_account_address = self.child_account_address
+        db.add(_child_account)
+
+        _off_personal_info = IDXPersonalInfo()
+        _off_personal_info.issuer_address = self.issuer_address
+        _off_personal_info.account_address = self.child_account_address
+        _off_personal_info.personal_info = {
+            "key_manager": "SELF",
+            "name": "name_test",
+            "postal_code": "postal_code_test",
+            "address": "address_test",
+            "email": "email_test",
+            "birth": "birth_test",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        _off_personal_info.data_source = PersonalInfoDataSource.OFF_CHAIN
+        db.add(_off_personal_info)
+
+        db.commit()
+
+        # Call API
+        resp = client.delete(self.base_url.format(self.issuer_address, 1))
+
+        # Assertion
+        assert resp.status_code == 200
+
+        assert db.scalars(select(ChildAccount).limit(1)).first() is None
+        assert db.scalars(select(IDXPersonalInfo).limit(1)).first() is None
+
+    ###########################################################################
+    # Error Case
+    ###########################################################################
+
+    # <Error_1>
+    # 404: Issuer does not exist
+    def test_error_1(self, client, db):
+        # Call API
+        resp = client.delete(self.base_url.format(self.issuer_address, 1))
+
+        # Assertion
+        assert resp.status_code == 404
+        assert resp.json() == {
+            "meta": {"code": 1, "title": "NotFound"},
+            "detail": "issuer does not exist",
+        }
+
+    # <Error_2>
+    # 404: Issuer does not exist
+    def test_error_2(self, client, db):
+        # Prepare data
+        _account = Account()
+        _account.issuer_address = self.issuer_address
+        db.add(_account)
+        db.commit()
+
+        # Call API
+        resp = client.delete(self.base_url.format(self.issuer_address, 1))
+
+        # Assertion
+        assert resp.status_code == 404
+        assert resp.json() == {
+            "meta": {"code": 1, "title": "NotFound"},
+            "detail": "child account does not exist",
+        }

--- a/tests/app/test_accounts_ListAllChildAccount.py
+++ b/tests/app/test_accounts_ListAllChildAccount.py
@@ -1,0 +1,311 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+from app.model.db import Account, ChildAccount, IDXPersonalInfo, PersonalInfoDataSource
+
+
+class TestListAllChildAccount:
+    issuer_address = "0x89082C5dEcB1Ad23eda99B692A9B594F7044B846"
+
+    child_account_address = [
+        "0x9f07d281F2f78891637cD72C7a4a1b5da309449A",
+        "0xfc4c13C222ddc98E9b409a543a725fe99911f978",
+        "0xD4E5978FA40AC5f7aFe0E5E592B6408DfaEeA8b5",
+        "0x36d82Ff9b5B9865F7a7Db7089833F098EC734d8d",
+        "0xA59c9Ca97Fb946A0b61A1E86dC2c6918A47E2656",
+    ]
+
+    # Target API endpoint
+    base_url = "/accounts/{}/child_accounts"
+
+    ###########################################################################
+    # Normal Case
+    ###########################################################################
+
+    # <Normal_1_1>
+    # Normal search
+    # - Personal information is not set
+    def test_normal_1_1(self, client, db):
+        # Prepare data
+        _account = Account()
+        _account.issuer_address = self.issuer_address
+        db.add(_account)
+
+        for i in range(1, 6):
+            _child_account = ChildAccount()
+            _child_account.issuer_address = self.issuer_address
+            _child_account.child_account_index = i
+            _child_account.child_account_address = self.child_account_address[i - 1]
+            db.add(_child_account)
+
+        db.commit()
+
+        # Call API
+        resp = client.get(self.base_url.format(self.issuer_address), params=None)
+
+        # Assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "result_set": {"count": 5, "offset": None, "limit": None, "total": 5},
+            "child_accounts": [
+                {
+                    "issuer_address": self.issuer_address,
+                    "child_account_index": 1,
+                    "child_account_address": self.child_account_address[0],
+                    "personal_information": None,
+                },
+                {
+                    "issuer_address": self.issuer_address,
+                    "child_account_index": 2,
+                    "child_account_address": self.child_account_address[1],
+                    "personal_information": None,
+                },
+                {
+                    "issuer_address": self.issuer_address,
+                    "child_account_index": 3,
+                    "child_account_address": self.child_account_address[2],
+                    "personal_information": None,
+                },
+                {
+                    "issuer_address": self.issuer_address,
+                    "child_account_index": 4,
+                    "child_account_address": self.child_account_address[3],
+                    "personal_information": None,
+                },
+                {
+                    "issuer_address": self.issuer_address,
+                    "child_account_index": 5,
+                    "child_account_address": self.child_account_address[4],
+                    "personal_information": None,
+                },
+            ],
+        }
+
+    # <Normal_1_2>
+    # Normal search
+    # - Personal information is set
+    def test_normal_1_2(self, client, db):
+        # Prepare data
+        _account = Account()
+        _account.issuer_address = self.issuer_address
+        db.add(_account)
+
+        for i in range(1, 4):
+            _child_account = ChildAccount()
+            _child_account.issuer_address = self.issuer_address
+            _child_account.child_account_index = i
+            _child_account.child_account_address = self.child_account_address[i - 1]
+            db.add(_child_account)
+
+            _off_personal_info = IDXPersonalInfo()
+            _off_personal_info.issuer_address = self.issuer_address
+            _off_personal_info.account_address = self.child_account_address[i - 1]
+            _off_personal_info.personal_info = {
+                "key_manager": "SELF",
+                "name": f"name_test_{i}",
+                "postal_code": f"postal_code_test_{i}",
+                "address": f"address_test_{i}",
+                "email": f"email_test_{i}",
+                "birth": f"birth_test_{i}",
+                "is_corporate": False,
+                "tax_category": i,
+            }
+            _off_personal_info.data_source = PersonalInfoDataSource.OFF_CHAIN
+            db.add(_off_personal_info)
+
+        db.commit()
+
+        # Call API
+        resp = client.get(self.base_url.format(self.issuer_address), params=None)
+
+        # Assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "result_set": {"count": 3, "offset": None, "limit": None, "total": 3},
+            "child_accounts": [
+                {
+                    "issuer_address": self.issuer_address,
+                    "child_account_index": 1,
+                    "child_account_address": self.child_account_address[0],
+                    "personal_information": {
+                        "key_manager": "SELF",
+                        "name": "name_test_1",
+                        "postal_code": "postal_code_test_1",
+                        "address": "address_test_1",
+                        "email": "email_test_1",
+                        "birth": "birth_test_1",
+                        "is_corporate": False,
+                        "tax_category": 1,
+                    },
+                },
+                {
+                    "issuer_address": self.issuer_address,
+                    "child_account_index": 2,
+                    "child_account_address": self.child_account_address[1],
+                    "personal_information": {
+                        "key_manager": "SELF",
+                        "name": "name_test_2",
+                        "postal_code": "postal_code_test_2",
+                        "address": "address_test_2",
+                        "email": "email_test_2",
+                        "birth": "birth_test_2",
+                        "is_corporate": False,
+                        "tax_category": 2,
+                    },
+                },
+                {
+                    "issuer_address": self.issuer_address,
+                    "child_account_index": 3,
+                    "child_account_address": self.child_account_address[2],
+                    "personal_information": {
+                        "key_manager": "SELF",
+                        "name": "name_test_3",
+                        "postal_code": "postal_code_test_3",
+                        "address": "address_test_3",
+                        "email": "email_test_3",
+                        "birth": "birth_test_3",
+                        "is_corporate": False,
+                        "tax_category": 3,
+                    },
+                },
+            ],
+        }
+
+    # <Normal_2>
+    # Sort order
+    def test_normal_2(self, client, db):
+        # Prepare data
+        _account = Account()
+        _account.issuer_address = self.issuer_address
+        db.add(_account)
+
+        for i in range(1, 6):
+            _child_account = ChildAccount()
+            _child_account.issuer_address = self.issuer_address
+            _child_account.child_account_index = i
+            _child_account.child_account_address = self.child_account_address[i - 1]
+            db.add(_child_account)
+
+        db.commit()
+
+        # Call API
+        resp = client.get(
+            self.base_url.format(self.issuer_address), params={"sort_order": 1}
+        )
+
+        # Assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "result_set": {"count": 5, "offset": None, "limit": None, "total": 5},
+            "child_accounts": [
+                {
+                    "issuer_address": self.issuer_address,
+                    "child_account_index": 5,
+                    "child_account_address": self.child_account_address[4],
+                    "personal_information": None,
+                },
+                {
+                    "issuer_address": self.issuer_address,
+                    "child_account_index": 4,
+                    "child_account_address": self.child_account_address[3],
+                    "personal_information": None,
+                },
+                {
+                    "issuer_address": self.issuer_address,
+                    "child_account_index": 3,
+                    "child_account_address": self.child_account_address[2],
+                    "personal_information": None,
+                },
+                {
+                    "issuer_address": self.issuer_address,
+                    "child_account_index": 2,
+                    "child_account_address": self.child_account_address[1],
+                    "personal_information": None,
+                },
+                {
+                    "issuer_address": self.issuer_address,
+                    "child_account_index": 1,
+                    "child_account_address": self.child_account_address[0],
+                    "personal_information": None,
+                },
+            ],
+        }
+
+    # <Normal_3>
+    # Offset / Limit
+    def test_normal_3(self, client, db):
+        # Prepare data
+        _account = Account()
+        _account.issuer_address = self.issuer_address
+        db.add(_account)
+
+        for i in range(1, 6):
+            _child_account = ChildAccount()
+            _child_account.issuer_address = self.issuer_address
+            _child_account.child_account_index = i
+            _child_account.child_account_address = self.child_account_address[i - 1]
+            db.add(_child_account)
+
+        db.commit()
+
+        # Call API
+        resp = client.get(
+            self.base_url.format(self.issuer_address), params={"offset": 2, "limit": 1}
+        )
+
+        # Assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "result_set": {"count": 5, "offset": 2, "limit": 1, "total": 5},
+            "child_accounts": [
+                {
+                    "issuer_address": self.issuer_address,
+                    "child_account_index": 3,
+                    "child_account_address": self.child_account_address[2],
+                    "personal_information": None,
+                },
+            ],
+        }
+
+    ###########################################################################
+    # Error Case
+    ###########################################################################
+
+    # <Error_1>
+    # 404: Issuer does not exist
+    def test_error_1(self, client, db):
+        # Prepare data
+        for i in range(1, 6):
+            _child_account = ChildAccount()
+            _child_account.issuer_address = self.issuer_address
+            _child_account.child_account_index = i
+            _child_account.child_account_address = self.child_account_address[i - 1]
+            db.add(_child_account)
+
+        db.commit()
+
+        # Call API
+        resp = client.get(self.base_url.format(self.issuer_address), params=None)
+
+        # Assertion
+        assert resp.status_code == 404
+        assert resp.json() == {
+            "meta": {"code": 1, "title": "NotFound"},
+            "detail": "issuer does not exist",
+        }

--- a/tests/app/test_accounts_RetrieveChildAccount.py
+++ b/tests/app/test_accounts_RetrieveChildAccount.py
@@ -1,0 +1,149 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+from app.model.db import Account, ChildAccount, IDXPersonalInfo, PersonalInfoDataSource
+
+
+class TestRetrieveChildAccount:
+    issuer_address = "0x89082C5dEcB1Ad23eda99B692A9B594F7044B846"
+    child_account_address = "0x9f07d281F2f78891637cD72C7a4a1b5da309449A"
+
+    # Target API endpoint
+    base_url = "/accounts/{}/child_accounts/{}"
+
+    ###########################################################################
+    # Normal Case
+    ###########################################################################
+
+    # <Normal_1_1>
+    # Personal information is not set
+    def test_normal_1_1(self, client, db):
+        # Prepare data
+        _account = Account()
+        _account.issuer_address = self.issuer_address
+        db.add(_account)
+
+        _child_account = ChildAccount()
+        _child_account.issuer_address = self.issuer_address
+        _child_account.child_account_index = 1
+        _child_account.child_account_address = self.child_account_address
+        db.add(_child_account)
+
+        db.commit()
+
+        # Call API
+        resp = client.get(self.base_url.format(self.issuer_address, 1))
+
+        # Assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "issuer_address": self.issuer_address,
+            "child_account_index": 1,
+            "child_account_address": self.child_account_address,
+            "personal_information": None,
+        }
+
+    # <Normal_1_2>
+    # Personal information is set
+    def test_normal_1_2(self, client, db):
+        # Prepare data
+        _account = Account()
+        _account.issuer_address = self.issuer_address
+        db.add(_account)
+
+        _child_account = ChildAccount()
+        _child_account.issuer_address = self.issuer_address
+        _child_account.child_account_index = 1
+        _child_account.child_account_address = self.child_account_address
+        db.add(_child_account)
+
+        _off_personal_info = IDXPersonalInfo()
+        _off_personal_info.issuer_address = self.issuer_address
+        _off_personal_info.account_address = self.child_account_address
+        _off_personal_info.personal_info = {
+            "key_manager": "SELF",
+            "name": "name_test",
+            "postal_code": "postal_code_test",
+            "address": "address_test",
+            "email": "email_test",
+            "birth": "birth_test",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        _off_personal_info.data_source = PersonalInfoDataSource.OFF_CHAIN
+        db.add(_off_personal_info)
+
+        db.commit()
+
+        # Call API
+        resp = client.get(self.base_url.format(self.issuer_address, 1))
+
+        # Assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "issuer_address": self.issuer_address,
+            "child_account_index": 1,
+            "child_account_address": self.child_account_address,
+            "personal_information": {
+                "key_manager": "SELF",
+                "name": "name_test",
+                "postal_code": "postal_code_test",
+                "address": "address_test",
+                "email": "email_test",
+                "birth": "birth_test",
+                "is_corporate": False,
+                "tax_category": 10,
+            },
+        }
+
+    ###########################################################################
+    # Error Case
+    ###########################################################################
+
+    # <Error_1>
+    # 404: Issuer does not exist
+    def test_error_1(self, client, db):
+        # Call API
+        resp = client.get(self.base_url.format(self.issuer_address, 1))
+
+        # Assertion
+        assert resp.status_code == 404
+        assert resp.json() == {
+            "meta": {"code": 1, "title": "NotFound"},
+            "detail": "issuer does not exist",
+        }
+
+    # <Error_2>
+    # 404: Issuer does not exist
+    def test_error_2(self, client, db):
+        # Prepare data
+        _account = Account()
+        _account.issuer_address = self.issuer_address
+        db.add(_account)
+        db.commit()
+
+        # Call API
+        resp = client.get(self.base_url.format(self.issuer_address, 1))
+
+        # Assertion
+        assert resp.status_code == 404
+        assert resp.json() == {
+            "meta": {"code": 1, "title": "NotFound"},
+            "detail": "child account does not exist",
+        }

--- a/tests/app/test_accounts_UpdateChildAccount.py
+++ b/tests/app/test_accounts_UpdateChildAccount.py
@@ -1,0 +1,213 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import datetime
+
+import pytest
+from sqlalchemy import and_, select
+
+from app.model.db import (
+    Account,
+    ChildAccount,
+    IDXPersonalInfo,
+    IDXPersonalInfoHistory,
+    PersonalInfoDataSource,
+    PersonalInfoEventType,
+)
+
+
+class TestUpdateChildAccount:
+    issuer_address = "0x89082C5dEcB1Ad23eda99B692A9B594F7044B846"
+    child_account_address = "0x9f07d281F2f78891637cD72C7a4a1b5da309449A"
+
+    # Target API endpoint
+    base_url = "/accounts/{}/child_accounts/{}"
+
+    ###########################################################################
+    # Normal Case
+    ###########################################################################
+
+    # <Normal_1>
+    @pytest.mark.freeze_time("2024-09-28 12:34:56")
+    def test_normal_1(self, client, db):
+        # Prepare data
+        _account = Account()
+        _account.issuer_address = self.issuer_address
+        db.add(_account)
+
+        _child_account = ChildAccount()
+        _child_account.issuer_address = self.issuer_address
+        _child_account.child_account_index = 1
+        _child_account.child_account_address = self.child_account_address
+        db.add(_child_account)
+
+        _off_personal_info = IDXPersonalInfo()
+        _off_personal_info.issuer_address = self.issuer_address
+        _off_personal_info.account_address = self.child_account_address
+        _off_personal_info.personal_info = {
+            "key_manager": "SELF",
+            "name": "name_test",
+            "postal_code": "postal_code_test",
+            "address": "address_test",
+            "email": "email_test",
+            "birth": "birth_test",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        _off_personal_info.data_source = PersonalInfoDataSource.OFF_CHAIN
+        db.add(_off_personal_info)
+
+        db.commit()
+
+        # Call API
+        resp = client.post(
+            self.base_url.format(self.issuer_address, 1),
+            json={
+                "personal_information": {
+                    "name": "name_test_af",
+                    "postal_code": "postal_code_test_af",
+                    "address": "address_test_af",
+                    "email": "email_test_af",
+                    "birth": "birth_test_af",
+                    "is_corporate": True,
+                    "tax_category": 20,
+                }
+            },
+        )
+
+        # Assertion
+        assert resp.status_code == 200
+
+        _off_personal_info_af = db.scalars(
+            select(IDXPersonalInfo)
+            .where(
+                and_(
+                    IDXPersonalInfo.issuer_address == self.issuer_address,
+                    IDXPersonalInfo.account_address == self.child_account_address,
+                    IDXPersonalInfo.data_source == PersonalInfoDataSource.OFF_CHAIN,
+                )
+            )
+            .limit(1)
+        ).first()
+        assert _off_personal_info.personal_info == {
+            "key_manager": "SELF",
+            "name": "name_test_af",
+            "postal_code": "postal_code_test_af",
+            "address": "address_test_af",
+            "email": "email_test_af",
+            "birth": "birth_test_af",
+            "is_corporate": True,
+            "tax_category": 20,
+        }
+
+        _personal_info_history = db.scalars(
+            select(IDXPersonalInfoHistory)
+            .where(IDXPersonalInfoHistory.issuer_address == self.issuer_address)
+            .limit(1)
+        ).first()
+        assert _personal_info_history.issuer_address == self.issuer_address
+        assert _personal_info_history.account_address == self.child_account_address
+        assert _personal_info_history.event_type == PersonalInfoEventType.MODIFY
+        assert _personal_info_history.personal_info == _off_personal_info.personal_info
+        assert _personal_info_history.block_timestamp == datetime.datetime(
+            2024, 9, 28, 12, 34, 56
+        )
+
+    ###########################################################################
+    # Error Case
+    ###########################################################################
+
+    # <Error_1>
+    # RequestValidationError
+    # - Missing body
+    def test_error_1(self, client, db):
+        # Call API
+        resp = client.post(self.base_url.format(self.issuer_address, 1), json={})
+
+        # Assertion
+        assert resp.status_code == 422
+        assert resp.json() == {
+            "meta": {"code": 1, "title": "RequestValidationError"},
+            "detail": [
+                {
+                    "type": "missing",
+                    "loc": ["body", "personal_information"],
+                    "msg": "Field required",
+                    "input": {},
+                }
+            ],
+        }
+
+    # <Error_2>
+    # 404: Issuer does not exist
+    def test_error_2(self, client, db):
+        # Call API
+        resp = client.post(
+            self.base_url.format(self.issuer_address, 1),
+            json={
+                "personal_information": {
+                    "name": "name_test_af",
+                    "postal_code": "postal_code_test_af",
+                    "address": "address_test_af",
+                    "email": "email_test_af",
+                    "birth": "birth_test_af",
+                    "is_corporate": True,
+                    "tax_category": 20,
+                }
+            },
+        )
+
+        # Assertion
+        assert resp.status_code == 404
+        assert resp.json() == {
+            "meta": {"code": 1, "title": "NotFound"},
+            "detail": "issuer does not exist",
+        }
+
+    # <Error_3>
+    # 404: Issuer does not exist
+    def test_error_3(self, client, db):
+        # Prepare data
+        _account = Account()
+        _account.issuer_address = self.issuer_address
+        db.add(_account)
+        db.commit()
+
+        # Call API
+        resp = client.post(
+            self.base_url.format(self.issuer_address, 1),
+            json={
+                "personal_information": {
+                    "name": "name_test_af",
+                    "postal_code": "postal_code_test_af",
+                    "address": "address_test_af",
+                    "email": "email_test_af",
+                    "birth": "birth_test_af",
+                    "is_corporate": True,
+                    "tax_category": 20,
+                }
+            },
+        )
+
+        # Assertion
+        assert resp.status_code == 404
+        assert resp.json() == {
+            "meta": {"code": 1, "title": "NotFound"},
+            "detail": "child account does not exist",
+        }

--- a/tests/app/test_bond_additional_issue_RetrieveBatchAdditionalBondIssueStatus.py
+++ b/tests/app/test_bond_additional_issue_RetrieveBatchAdditionalBondIssueStatus.py
@@ -23,6 +23,7 @@ from app.model.db import (
     BatchIssueRedeemProcessingCategory,
     BatchIssueRedeemUpload,
     IDXPersonalInfo,
+    PersonalInfoDataSource,
     Token,
     TokenType,
     TokenVersion,
@@ -103,6 +104,7 @@ class TestRetrieveBatchAdditionalBondIssueStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         db.commit()
@@ -190,6 +192,7 @@ class TestRetrieveBatchAdditionalBondIssueStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         db.commit()
@@ -277,6 +280,7 @@ class TestRetrieveBatchAdditionalBondIssueStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         batch_record = BatchIssueRedeem()

--- a/tests/app/test_bond_holders_ListAllBondTokenHolders.py
+++ b/tests/app/test_bond_holders_ListAllBondTokenHolders.py
@@ -24,6 +24,7 @@ from app.model.db import (
     IDXLockedPosition,
     IDXPersonalInfo,
     IDXPosition,
+    PersonalInfoDataSource,
     Token,
     TokenType,
     TokenVersion,
@@ -31,7 +32,7 @@ from app.model.db import (
 from tests.account_config import config_eth_account
 
 
-class TestAppRoutersBondTokensTokenAddressHoldersGET:
+class TestListAllBondTokenHolders:
     # target API endpoint
     base_url = "/bond/tokens/{}/holders"
 
@@ -155,6 +156,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         db.commit()
@@ -259,6 +261,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -346,6 +349,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         db.commit()
@@ -602,6 +606,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         idx_position_2 = IDXPosition()
@@ -636,6 +641,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         db.commit()
@@ -780,6 +786,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -867,6 +874,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         db.commit()
@@ -972,6 +980,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -1059,6 +1068,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         db.commit()
@@ -1183,6 +1193,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -1270,6 +1281,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         db.commit()
@@ -1394,6 +1406,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -1481,6 +1494,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         db.commit()
@@ -1586,6 +1600,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -1673,6 +1688,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         db.commit()
@@ -1797,6 +1813,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -1884,6 +1901,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         db.commit()
@@ -2008,6 +2026,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -2095,6 +2114,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         db.commit()
@@ -2200,6 +2220,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -2287,6 +2308,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         db.commit()
@@ -2412,6 +2434,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -2499,6 +2522,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         # prepare data: account_address_4
@@ -2653,6 +2677,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -2740,6 +2765,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         db.commit()
@@ -2848,6 +2874,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -2935,6 +2962,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         db.commit()
@@ -3062,6 +3090,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -3149,6 +3178,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         db.commit()
@@ -3257,6 +3287,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -3344,6 +3375,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         db.commit()
@@ -3449,6 +3481,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -3536,6 +3569,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         db.commit()
@@ -3660,6 +3694,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -3747,6 +3782,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         db.commit()
@@ -3853,6 +3889,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -3942,6 +3979,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         db.commit()
@@ -4086,6 +4124,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -4175,6 +4214,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         db.commit()
@@ -4319,6 +4359,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -4408,6 +4449,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         db.commit()
@@ -4552,6 +4594,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -4641,6 +4684,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         db.commit()
@@ -4785,6 +4829,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -4874,6 +4919,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         db.commit()
@@ -5018,6 +5064,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -5107,6 +5154,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         db.commit()
@@ -5252,6 +5300,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -5341,6 +5390,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         # prepare data: account_address_4
@@ -5517,6 +5567,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -5606,6 +5657,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         # prepare data: account_address_4
@@ -5780,6 +5832,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -5867,6 +5920,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         db.commit()
@@ -5991,6 +6045,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -6078,6 +6133,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersGET:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         db.commit()

--- a/tests/app/test_bond_holders_RetrieveBondTokenHolder.py
+++ b/tests/app/test_bond_holders_RetrieveBondTokenHolder.py
@@ -24,6 +24,7 @@ from app.model.db import (
     IDXLockedPosition,
     IDXPersonalInfo,
     IDXPosition,
+    PersonalInfoDataSource,
     Token,
     TokenType,
     TokenVersion,
@@ -31,7 +32,7 @@ from app.model.db import (
 from tests.account_config import config_eth_account
 
 
-class TestAppRoutersBondTokensTokenAddressHoldersAccountAddressGET:
+class TestRetrieveBondTokenHolder:
     # target API endpoint
     base_url = "/bond/tokens/{}/holders/{}"
 
@@ -77,6 +78,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersAccountAddressGET:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         db.commit()
@@ -158,6 +160,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersAccountAddressGET:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         db.commit()
@@ -260,6 +263,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersAccountAddressGET:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         db.commit()
@@ -398,6 +402,7 @@ class TestAppRoutersBondTokensTokenAddressHoldersAccountAddressGET:
             "birth": "birth_test1",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         db.commit()

--- a/tests/app/test_bond_redeem_RetrieveBatchBondRedemptionStatus.py
+++ b/tests/app/test_bond_redeem_RetrieveBatchBondRedemptionStatus.py
@@ -23,6 +23,7 @@ from app.model.db import (
     BatchIssueRedeemProcessingCategory,
     BatchIssueRedeemUpload,
     IDXPersonalInfo,
+    PersonalInfoDataSource,
     Token,
     TokenType,
     TokenVersion,
@@ -31,7 +32,7 @@ from app.utils.e2ee_utils import E2EEUtils
 from tests.account_config import config_eth_account
 
 
-class TestAppRoutersBondTokensTokenAddressRedeemBatchBatchIdGET:
+class TestRetrieveBatchBondRedemptionStatus:
     # target API endpoint
     base_url = "/bond/tokens/{}/redeem/batch/{}"
 
@@ -103,6 +104,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemBatchBatchIdGET:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         db.commit()
@@ -190,6 +192,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemBatchBatchIdGET:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         db.commit()
@@ -277,6 +280,7 @@ class TestAppRoutersBondTokensTokenAddressRedeemBatchBatchIdGET:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         batch_record = BatchIssueRedeem()

--- a/tests/app/test_bond_transfer_approvals_ListSpecificBondTokenTransferApprovalHistory.py
+++ b/tests/app/test_bond_transfer_approvals_ListSpecificBondTokenTransferApprovalHistory.py
@@ -25,6 +25,7 @@ import config
 from app.model.db import (
     IDXPersonalInfo,
     IDXTransferApproval,
+    PersonalInfoDataSource,
     Token,
     TokenType,
     TokenVersion,
@@ -152,6 +153,7 @@ class TestListSpecificBondTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _from_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_from_personal_info)
 
         # prepare data: IDXPersonalInfo
@@ -167,6 +169,7 @@ class TestListSpecificBondTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _to_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_to_personal_info)
 
         # prepare data: IDXTransferApproval
@@ -346,6 +349,7 @@ class TestListSpecificBondTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _from_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_from_personal_info)
 
         # prepare data: IDXPersonalInfo
@@ -361,6 +365,7 @@ class TestListSpecificBondTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _to_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_to_personal_info)
 
         # prepare data: IDXTransferApproval
@@ -466,6 +471,7 @@ class TestListSpecificBondTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _from_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_from_personal_info)
 
         # prepare data: IDXPersonalInfo
@@ -481,6 +487,7 @@ class TestListSpecificBondTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _to_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_to_personal_info)
 
         # prepare data: IDXTransferApproval
@@ -670,6 +677,7 @@ class TestListSpecificBondTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _from_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_from_personal_info)
 
         # prepare data: IDXPersonalInfo
@@ -685,6 +693,7 @@ class TestListSpecificBondTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _to_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_to_personal_info)
 
         # prepare data: IDXTransferApproval
@@ -783,6 +792,7 @@ class TestListSpecificBondTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _from_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_from_personal_info)
 
         # prepare data: IDXPersonalInfo
@@ -798,6 +808,7 @@ class TestListSpecificBondTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _to_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_to_personal_info)
 
         # prepare data: IDXTransferApproval
@@ -897,6 +908,7 @@ class TestListSpecificBondTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _from_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_from_personal_info)
 
         # prepare data: IDXPersonalInfo
@@ -912,6 +924,7 @@ class TestListSpecificBondTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _to_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_to_personal_info)
 
         # prepare data: IDXTransferApproval
@@ -1043,6 +1056,7 @@ class TestListSpecificBondTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _from_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_from_personal_info)
 
         # prepare data: IDXPersonalInfo
@@ -1058,6 +1072,7 @@ class TestListSpecificBondTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _to_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_to_personal_info)
 
         # prepare data: IDXTransferApproval
@@ -1423,6 +1438,7 @@ class TestListSpecificBondTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _from_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_from_personal_info)
 
         # prepare data: IDXPersonalInfo
@@ -1438,6 +1454,7 @@ class TestListSpecificBondTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _to_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_to_personal_info)
 
         # prepare data: IDXTransferApproval
@@ -1643,6 +1660,7 @@ class TestListSpecificBondTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _from_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_from_personal_info)
 
         # prepare data: IDXPersonalInfo
@@ -1658,6 +1676,7 @@ class TestListSpecificBondTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _to_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_to_personal_info)
 
         # prepare data: IDXTransferApproval
@@ -1895,6 +1914,7 @@ class TestListSpecificBondTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _from_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_from_personal_info)
 
         # prepare data: IDXPersonalInfo
@@ -1910,6 +1930,7 @@ class TestListSpecificBondTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _to_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_to_personal_info)
 
         # prepare data: IDXTransferApproval
@@ -2095,6 +2116,7 @@ class TestListSpecificBondTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _from_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_from_personal_info)
 
         # prepare data: IDXPersonalInfo
@@ -2110,6 +2132,7 @@ class TestListSpecificBondTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _to_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_to_personal_info)
 
         # prepare data: IDXTransferApproval
@@ -2335,6 +2358,7 @@ class TestListSpecificBondTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _from_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_from_personal_info)
 
         # prepare data: IDXPersonalInfo
@@ -2350,6 +2374,7 @@ class TestListSpecificBondTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _to_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_to_personal_info)
 
         # prepare data: IDXTransferApproval
@@ -2575,6 +2600,7 @@ class TestListSpecificBondTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _from_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_from_personal_info)
 
         # prepare data: IDXPersonalInfo
@@ -2590,6 +2616,7 @@ class TestListSpecificBondTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _to_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_to_personal_info)
 
         # prepare data: IDXTransferApproval
@@ -2780,6 +2807,7 @@ class TestListSpecificBondTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _from_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_from_personal_info)
 
         # prepare data: IDXPersonalInfo
@@ -2795,6 +2823,7 @@ class TestListSpecificBondTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _to_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_to_personal_info)
 
         # prepare data: IDXTransferApproval
@@ -2983,6 +3012,7 @@ class TestListSpecificBondTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _from_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_from_personal_info)
 
         # prepare data: IDXPersonalInfo
@@ -2998,6 +3028,7 @@ class TestListSpecificBondTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _to_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_to_personal_info)
 
         # prepare data: IDXTransferApproval
@@ -3222,6 +3253,7 @@ class TestListSpecificBondTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _from_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_from_personal_info)
 
         # prepare data: IDXPersonalInfo
@@ -3237,6 +3269,7 @@ class TestListSpecificBondTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _to_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_to_personal_info)
 
         # prepare data: IDXTransferApproval
@@ -3468,6 +3501,7 @@ class TestListSpecificBondTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _from_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_from_personal_info)
 
         # prepare data: IDXPersonalInfo
@@ -3483,6 +3517,7 @@ class TestListSpecificBondTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _to_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_to_personal_info)
 
         # prepare data: IDXTransferApproval
@@ -3710,6 +3745,7 @@ class TestListSpecificBondTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _from_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_from_personal_info)
 
         # prepare data: IDXPersonalInfo
@@ -3725,6 +3761,7 @@ class TestListSpecificBondTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _to_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_to_personal_info)
 
         # prepare data: IDXTransferApproval

--- a/tests/app/test_bond_transfer_approvals_RetrieveBondTokenTransferApprovalStatus.py
+++ b/tests/app/test_bond_transfer_approvals_RetrieveBondTokenTransferApprovalStatus.py
@@ -25,6 +25,7 @@ import config
 from app.model.db import (
     IDXPersonalInfo,
     IDXTransferApproval,
+    PersonalInfoDataSource,
     Token,
     TokenType,
     TokenVersion,
@@ -113,6 +114,7 @@ class TestRetrieveBondTokenTransferApprovalStatus:
             "is_corporate": False,
             "tax_category": 10,
         }  # latest data
+        _personal_info_from.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_from)
 
         _personal_info_to = IDXPersonalInfo()
@@ -128,6 +130,7 @@ class TestRetrieveBondTokenTransferApprovalStatus:
             "is_corporate": False,
             "tax_category": 10,
         }  # latest data
+        _personal_info_to.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_to)
 
         # prepare data: IDXTransferApproval
@@ -513,6 +516,7 @@ class TestRetrieveBondTokenTransferApprovalStatus:
             "is_corporate": False,
             "tax_category": 10,
         }  # latest data
+        _personal_info_from.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_from)
 
         _personal_info_to = IDXPersonalInfo()
@@ -528,6 +532,7 @@ class TestRetrieveBondTokenTransferApprovalStatus:
             "is_corporate": False,
             "tax_category": 10,
         }  # latest data
+        _personal_info_to.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_to)
 
         # prepare data: IDXTransferApproval
@@ -852,6 +857,7 @@ class TestRetrieveBondTokenTransferApprovalStatus:
             "is_corporate": False,
             "tax_category": 10,
         }  # latest data
+        _personal_info_from.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_from)
 
         _personal_info_to = IDXPersonalInfo()
@@ -867,6 +873,7 @@ class TestRetrieveBondTokenTransferApprovalStatus:
             "is_corporate": False,
             "tax_category": 10,
         }  # latest data
+        _personal_info_to.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_to)
 
         # prepare data: IDXTransferApproval

--- a/tests/app/test_bond_transfer_approvals_UpdateBondTokenTransferApprovalStatus.py
+++ b/tests/app/test_bond_transfer_approvals_UpdateBondTokenTransferApprovalStatus.py
@@ -39,6 +39,7 @@ from app.model.db import (
     AuthToken,
     IDXPersonalInfo,
     IDXTransferApproval,
+    PersonalInfoDataSource,
     Token,
     TokenType,
     TokenVersion,
@@ -125,6 +126,7 @@ class TestUpdateBondTokenTransferApprovalStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        _personal_info_from.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_from)
 
         _personal_info_to = IDXPersonalInfo()
@@ -140,6 +142,7 @@ class TestUpdateBondTokenTransferApprovalStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        _personal_info_to.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_to)
 
         db.commit()
@@ -263,6 +266,7 @@ class TestUpdateBondTokenTransferApprovalStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        _personal_info_from.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_from)
 
         _personal_info_to = IDXPersonalInfo()
@@ -278,6 +282,7 @@ class TestUpdateBondTokenTransferApprovalStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        _personal_info_to.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_to)
 
         # mock
@@ -400,6 +405,7 @@ class TestUpdateBondTokenTransferApprovalStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        _personal_info_from.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_from)
 
         _personal_info_to = IDXPersonalInfo()
@@ -415,6 +421,7 @@ class TestUpdateBondTokenTransferApprovalStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        _personal_info_to.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_to)
 
         db.commit()
@@ -542,6 +549,7 @@ class TestUpdateBondTokenTransferApprovalStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        _personal_info_from.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_from)
 
         _personal_info_to = IDXPersonalInfo()
@@ -557,6 +565,7 @@ class TestUpdateBondTokenTransferApprovalStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        _personal_info_to.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_to)
 
         db.commit()
@@ -1297,6 +1306,7 @@ class TestUpdateBondTokenTransferApprovalStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        _personal_info_from.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_from)
 
         _personal_info_to = IDXPersonalInfo()
@@ -1312,6 +1322,8 @@ class TestUpdateBondTokenTransferApprovalStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        _personal_info_to.data_source = PersonalInfoDataSource.ON_CHAIN
+        _personal_info_to.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_to)
 
         db.commit()
@@ -1390,6 +1402,7 @@ class TestUpdateBondTokenTransferApprovalStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        _personal_info_from.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_from)
 
         _personal_info_to = IDXPersonalInfo()
@@ -1405,6 +1418,7 @@ class TestUpdateBondTokenTransferApprovalStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        _personal_info_to.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_to)
 
         db.commit()
@@ -1502,6 +1516,7 @@ class TestUpdateBondTokenTransferApprovalStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        _personal_info_from.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_from)
 
         _personal_info_to = IDXPersonalInfo()
@@ -1517,6 +1532,7 @@ class TestUpdateBondTokenTransferApprovalStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        _personal_info_to.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_to)
 
         db.commit()
@@ -1596,6 +1612,7 @@ class TestUpdateBondTokenTransferApprovalStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        _personal_info_from.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_from)
 
         _personal_info_to = IDXPersonalInfo()
@@ -1611,6 +1628,7 @@ class TestUpdateBondTokenTransferApprovalStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        _personal_info_to.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_to)
 
         db.commit()
@@ -1700,6 +1718,7 @@ class TestUpdateBondTokenTransferApprovalStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        _personal_info_from.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_from)
 
         _personal_info_to = IDXPersonalInfo()
@@ -1715,6 +1734,7 @@ class TestUpdateBondTokenTransferApprovalStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        _personal_info_to.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_to)
 
         db.commit()
@@ -1793,6 +1813,7 @@ class TestUpdateBondTokenTransferApprovalStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        _personal_info_from.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_from)
 
         _personal_info_to = IDXPersonalInfo()
@@ -1808,6 +1829,7 @@ class TestUpdateBondTokenTransferApprovalStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        _personal_info_to.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_to)
 
         db.commit()
@@ -1959,6 +1981,7 @@ class TestUpdateBondTokenTransferApprovalStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        _personal_info_from.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_from)
 
         db.commit()

--- a/tests/app/test_bond_transfers_ListBondTokenTransferHistory.py
+++ b/tests/app/test_bond_transfers_ListBondTokenTransferHistory.py
@@ -26,6 +26,7 @@ from app.model.db import (
     IDXPersonalInfo,
     IDXTransfer,
     IDXTransferSourceEventType,
+    PersonalInfoDataSource,
     Token,
     TokenType,
     TokenVersion,
@@ -165,6 +166,7 @@ class TestAppRoutersBondTransfersGET:
             "is_corporate": False,
             "tax_category": 10,
         }  # latest data
+        _personal_info_from.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_from)
 
         _personal_info_to = IDXPersonalInfo()
@@ -180,6 +182,7 @@ class TestAppRoutersBondTransfersGET:
             "is_corporate": False,
             "tax_category": 10,
         }  # latest data
+        _personal_info_to.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_to)
 
         # prepare data: IDXTransfer
@@ -619,6 +622,7 @@ class TestAppRoutersBondTransfersGET:
             "is_corporate": False,
             "tax_category": 10,
         }  # latest data
+        _personal_info_from.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_from)
 
         _personal_info_to = IDXPersonalInfo()
@@ -634,6 +638,7 @@ class TestAppRoutersBondTransfersGET:
             "is_corporate": False,
             "tax_category": 10,
         }  # latest data
+        _personal_info_to.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_to)
 
         db.commit()
@@ -724,6 +729,7 @@ class TestAppRoutersBondTransfersGET:
             "is_corporate": False,
             "tax_category": 10,
         }  # latest data
+        _personal_info_from.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_from)
 
         _personal_info_to = IDXPersonalInfo()
@@ -739,6 +745,7 @@ class TestAppRoutersBondTransfersGET:
             "is_corporate": False,
             "tax_category": 10,
         }  # latest data
+        _personal_info_to.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_to)
 
         db.commit()
@@ -1520,6 +1527,7 @@ class TestAppRoutersBondTransfersGET:
             "is_corporate": False,
             "tax_category": 10,
         }  # latest data
+        _personal_info_from.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_from)
 
         _personal_info_to = IDXPersonalInfo()
@@ -1535,6 +1543,7 @@ class TestAppRoutersBondTransfersGET:
             "is_corporate": False,
             "tax_category": 10,
         }  # latest data
+        _personal_info_to.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_to)
 
         db.commit()
@@ -1649,6 +1658,7 @@ class TestAppRoutersBondTransfersGET:
             "is_corporate": False,
             "tax_category": 10,
         }  # latest data
+        _personal_info_from.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_from)
 
         _personal_info_to = IDXPersonalInfo()
@@ -1664,6 +1674,7 @@ class TestAppRoutersBondTransfersGET:
             "is_corporate": False,
             "tax_category": 10,
         }  # latest data
+        _personal_info_to.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_to)
 
         db.commit()

--- a/tests/app/test_ledger_RetrieveLedgerHistory.py
+++ b/tests/app/test_ledger_RetrieveLedgerHistory.py
@@ -27,6 +27,7 @@ from app.model.db import (
     Ledger,
     LedgerDetailsDataType,
     LedgerDetailsTemplate,
+    PersonalInfoDataSource,
     Token,
     TokenType,
     TokenVersion,
@@ -957,6 +958,7 @@ class TestRetrieveLedgerHistory:
             "name": "name_db_1",
             "address": "address_db_1",
         }
+        _idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_idx_personal_info_1)
 
         _details_1 = LedgerDetailsTemplate()
@@ -1269,6 +1271,7 @@ class TestRetrieveLedgerHistory:
         _idx_personal_info_1.account_address = account_address_1
         _idx_personal_info_1.issuer_address = issuer_address
         _idx_personal_info_1.personal_info = {"name": "name_test_1", "address": None}
+        _idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_idx_personal_info_1)
 
         _details_1 = LedgerDetailsTemplate()
@@ -1958,6 +1961,7 @@ class TestRetrieveLedgerHistory:
             "name": None,
             "address": None,
         }
+        _idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_idx_personal_info_1)
 
         _idx_personal_info_2 = (
@@ -1969,7 +1973,8 @@ class TestRetrieveLedgerHistory:
             "name": "name_db_2",
             "address": "address_db_2",
         }
-        db.add(_idx_personal_info_1)
+        _idx_personal_info_2.data_source = PersonalInfoDataSource.ON_CHAIN
+        db.add(_idx_personal_info_2)
 
         _details_1 = LedgerDetailsTemplate()
         _details_1.token_address = token_address
@@ -2779,6 +2784,7 @@ class TestRetrieveLedgerHistory:
             "name": "name_db_1",
             "address": "address_db_1",
         }
+        _idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_idx_personal_info_1)
 
         db.commit()

--- a/tests/app/test_settlement_issuer_ListAllDVPDeliveries.py
+++ b/tests/app/test_settlement_issuer_ListAllDVPDeliveries.py
@@ -24,6 +24,7 @@ from app.model.db import (
     DeliveryStatus,
     IDXDelivery,
     IDXPersonalInfo,
+    PersonalInfoDataSource,
     Token,
     TokenType,
     TokenVersion,
@@ -529,6 +530,7 @@ class TestListAllDVPDeliveries:
             "is_corporate": False,
             "tax_category": 10,
         }
+        _personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info)
 
         _personal_info = IDXPersonalInfo()
@@ -544,6 +546,7 @@ class TestListAllDVPDeliveries:
             "is_corporate": False,
             "tax_category": 10,
         }
+        _personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info)
 
         _personal_info = IDXPersonalInfo()
@@ -559,6 +562,7 @@ class TestListAllDVPDeliveries:
             "is_corporate": False,
             "tax_category": 10,
         }
+        _personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info)
 
         # prepare data: IDXDelivery(Created)

--- a/tests/app/test_settlement_issuer_RetrieveDVPDelivery.py
+++ b/tests/app/test_settlement_issuer_RetrieveDVPDelivery.py
@@ -24,6 +24,7 @@ from app.model.db import (
     DeliveryStatus,
     IDXDelivery,
     IDXPersonalInfo,
+    PersonalInfoDataSource,
     Token,
     TokenType,
     TokenVersion,
@@ -81,6 +82,7 @@ class TestRetrieveDVPDelivery:
             "is_corporate": False,
             "tax_category": 10,
         }
+        _personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info)
 
         _personal_info = IDXPersonalInfo()
@@ -96,6 +98,7 @@ class TestRetrieveDVPDelivery:
             "is_corporate": False,
             "tax_category": 10,
         }
+        _personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info)
 
         # prepare data: IDXDelivery(Created)
@@ -224,6 +227,7 @@ class TestRetrieveDVPDelivery:
             "is_corporate": False,
             "tax_category": 10,
         }
+        _personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info)
 
         _personal_info = IDXPersonalInfo()
@@ -239,6 +243,7 @@ class TestRetrieveDVPDelivery:
             "is_corporate": False,
             "tax_category": 10,
         }
+        _personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info)
 
         # prepare data: IDXDelivery(Created)

--- a/tests/app/test_share_additional_issue_RetrieveBatchAdditionalShareIssueStatus.py
+++ b/tests/app/test_share_additional_issue_RetrieveBatchAdditionalShareIssueStatus.py
@@ -23,6 +23,7 @@ from app.model.db import (
     BatchIssueRedeemProcessingCategory,
     BatchIssueRedeemUpload,
     IDXPersonalInfo,
+    PersonalInfoDataSource,
     Token,
     TokenType,
     TokenVersion,
@@ -103,6 +104,7 @@ class TestRetrieveBatchAdditionalShareIssueStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         db.commit()
@@ -190,6 +192,7 @@ class TestRetrieveBatchAdditionalShareIssueStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         db.commit()
@@ -284,6 +287,7 @@ class TestRetrieveBatchAdditionalShareIssueStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         db.commit()

--- a/tests/app/test_share_holders_ListAllShareTokenHolders.py
+++ b/tests/app/test_share_holders_ListAllShareTokenHolders.py
@@ -24,6 +24,7 @@ from app.model.db import (
     IDXLockedPosition,
     IDXPersonalInfo,
     IDXPosition,
+    PersonalInfoDataSource,
     Token,
     TokenType,
     TokenVersion,
@@ -155,6 +156,7 @@ class TestListAllShareTokenHolders:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         db.commit()
@@ -259,6 +261,7 @@ class TestListAllShareTokenHolders:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -346,6 +349,7 @@ class TestListAllShareTokenHolders:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         db.commit()
@@ -512,6 +516,7 @@ class TestListAllShareTokenHolders:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         db.commit()
@@ -616,6 +621,7 @@ class TestListAllShareTokenHolders:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         idx_position_2 = IDXPosition()
@@ -650,6 +656,7 @@ class TestListAllShareTokenHolders:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         db.commit()
@@ -794,6 +801,7 @@ class TestListAllShareTokenHolders:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -881,6 +889,7 @@ class TestListAllShareTokenHolders:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         db.commit()
@@ -986,6 +995,7 @@ class TestListAllShareTokenHolders:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -1073,6 +1083,7 @@ class TestListAllShareTokenHolders:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         db.commit()
@@ -1197,6 +1208,7 @@ class TestListAllShareTokenHolders:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -1284,6 +1296,7 @@ class TestListAllShareTokenHolders:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         db.commit()
@@ -1408,6 +1421,7 @@ class TestListAllShareTokenHolders:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -1495,6 +1509,7 @@ class TestListAllShareTokenHolders:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         db.commit()
@@ -1600,6 +1615,7 @@ class TestListAllShareTokenHolders:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -1687,6 +1703,7 @@ class TestListAllShareTokenHolders:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         db.commit()
@@ -1811,6 +1828,7 @@ class TestListAllShareTokenHolders:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -1898,6 +1916,7 @@ class TestListAllShareTokenHolders:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         db.commit()
@@ -2022,6 +2041,7 @@ class TestListAllShareTokenHolders:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -2109,6 +2129,7 @@ class TestListAllShareTokenHolders:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         db.commit()
@@ -2214,6 +2235,7 @@ class TestListAllShareTokenHolders:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -2301,6 +2323,7 @@ class TestListAllShareTokenHolders:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         db.commit()
@@ -2426,6 +2449,7 @@ class TestListAllShareTokenHolders:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -2513,6 +2537,7 @@ class TestListAllShareTokenHolders:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         # prepare data: account_address_4
@@ -2667,6 +2692,7 @@ class TestListAllShareTokenHolders:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -2754,6 +2780,7 @@ class TestListAllShareTokenHolders:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         db.commit()
@@ -2862,6 +2889,7 @@ class TestListAllShareTokenHolders:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -2949,6 +2977,7 @@ class TestListAllShareTokenHolders:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         db.commit()
@@ -3076,6 +3105,7 @@ class TestListAllShareTokenHolders:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -3163,6 +3193,7 @@ class TestListAllShareTokenHolders:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         db.commit()
@@ -3290,6 +3321,7 @@ class TestListAllShareTokenHolders:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -3377,6 +3409,7 @@ class TestListAllShareTokenHolders:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         db.commit()
@@ -3482,6 +3515,7 @@ class TestListAllShareTokenHolders:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -3569,6 +3603,7 @@ class TestListAllShareTokenHolders:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         db.commit()
@@ -3693,6 +3728,7 @@ class TestListAllShareTokenHolders:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -3780,6 +3816,7 @@ class TestListAllShareTokenHolders:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         db.commit()
@@ -3886,6 +3923,7 @@ class TestListAllShareTokenHolders:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -3975,6 +4013,7 @@ class TestListAllShareTokenHolders:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         db.commit()
@@ -4119,6 +4158,7 @@ class TestListAllShareTokenHolders:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -4208,6 +4248,7 @@ class TestListAllShareTokenHolders:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         db.commit()
@@ -4352,6 +4393,7 @@ class TestListAllShareTokenHolders:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -4441,6 +4483,7 @@ class TestListAllShareTokenHolders:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         db.commit()
@@ -4585,6 +4628,7 @@ class TestListAllShareTokenHolders:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -4674,6 +4718,7 @@ class TestListAllShareTokenHolders:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         db.commit()
@@ -4818,6 +4863,7 @@ class TestListAllShareTokenHolders:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -4907,6 +4953,7 @@ class TestListAllShareTokenHolders:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         db.commit()
@@ -5051,6 +5098,7 @@ class TestListAllShareTokenHolders:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -5140,6 +5188,7 @@ class TestListAllShareTokenHolders:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         db.commit()
@@ -5285,6 +5334,7 @@ class TestListAllShareTokenHolders:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -5374,6 +5424,7 @@ class TestListAllShareTokenHolders:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         # prepare data: account_address_4
@@ -5550,6 +5601,7 @@ class TestListAllShareTokenHolders:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -5639,6 +5691,7 @@ class TestListAllShareTokenHolders:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         # prepare data: account_address_4
@@ -5813,6 +5866,7 @@ class TestListAllShareTokenHolders:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -5900,6 +5954,7 @@ class TestListAllShareTokenHolders:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         db.commit()
@@ -6024,6 +6079,7 @@ class TestListAllShareTokenHolders:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         # prepare data: account_address_2
@@ -6111,6 +6167,7 @@ class TestListAllShareTokenHolders:
             "birth": "birth_test3",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_3)
 
         db.commit()

--- a/tests/app/test_share_holders_RetrieveShareTokenHolder.py
+++ b/tests/app/test_share_holders_RetrieveShareTokenHolder.py
@@ -24,6 +24,7 @@ from app.model.db import (
     IDXLockedPosition,
     IDXPersonalInfo,
     IDXPosition,
+    PersonalInfoDataSource,
     Token,
     TokenType,
     TokenVersion,
@@ -77,6 +78,7 @@ class TestRetrieveShareTokenHolder:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         db.commit()
@@ -158,6 +160,7 @@ class TestRetrieveShareTokenHolder:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         db.commit()
@@ -260,6 +263,7 @@ class TestRetrieveShareTokenHolder:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         db.commit()
@@ -398,6 +402,7 @@ class TestRetrieveShareTokenHolder:
             "birth": "birth_test1",
             # PersonalInfo is partially registered.
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         db.commit()

--- a/tests/app/test_share_redeem_RetrieveBatchShareRedemptionStatus.py
+++ b/tests/app/test_share_redeem_RetrieveBatchShareRedemptionStatus.py
@@ -23,6 +23,7 @@ from app.model.db import (
     BatchIssueRedeemProcessingCategory,
     BatchIssueRedeemUpload,
     IDXPersonalInfo,
+    PersonalInfoDataSource,
     Token,
     TokenType,
     TokenVersion,
@@ -103,6 +104,7 @@ class TestRetrieveBatchShareRedemptionStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         db.commit()
@@ -190,6 +192,7 @@ class TestRetrieveBatchShareRedemptionStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         db.commit()
@@ -277,6 +280,7 @@ class TestRetrieveBatchShareRedemptionStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_personal_info_1)
 
         batch_record = BatchIssueRedeem()

--- a/tests/app/test_share_transfer_approvals_ListSpecificShareTokenTransferApprovalHistory.py
+++ b/tests/app/test_share_transfer_approvals_ListSpecificShareTokenTransferApprovalHistory.py
@@ -25,6 +25,7 @@ import config
 from app.model.db import (
     IDXPersonalInfo,
     IDXTransferApproval,
+    PersonalInfoDataSource,
     Token,
     TokenType,
     TokenVersion,
@@ -152,6 +153,7 @@ class TestListSpecificShareTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _from_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_from_personal_info)
 
         # prepare data: IDXPersonalInfo
@@ -167,6 +169,7 @@ class TestListSpecificShareTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _to_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_to_personal_info)
 
         # prepare data: IDXTransferApproval
@@ -346,6 +349,7 @@ class TestListSpecificShareTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _from_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_from_personal_info)
 
         # prepare data: IDXPersonalInfo
@@ -361,6 +365,7 @@ class TestListSpecificShareTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _to_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_to_personal_info)
 
         # prepare data: IDXTransferApproval
@@ -466,6 +471,7 @@ class TestListSpecificShareTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _from_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_from_personal_info)
 
         # prepare data: IDXPersonalInfo
@@ -481,6 +487,7 @@ class TestListSpecificShareTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _to_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_to_personal_info)
 
         # prepare data: IDXTransferApproval
@@ -670,6 +677,7 @@ class TestListSpecificShareTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _from_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_from_personal_info)
 
         # prepare data: IDXPersonalInfo
@@ -685,6 +693,7 @@ class TestListSpecificShareTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _to_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_to_personal_info)
 
         # prepare data: IDXTransferApproval
@@ -783,6 +792,7 @@ class TestListSpecificShareTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _from_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_from_personal_info)
 
         # prepare data: IDXPersonalInfo
@@ -798,6 +808,7 @@ class TestListSpecificShareTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _to_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_to_personal_info)
 
         # prepare data: IDXTransferApproval
@@ -897,6 +908,7 @@ class TestListSpecificShareTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _from_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_from_personal_info)
 
         # prepare data: IDXPersonalInfo
@@ -912,6 +924,7 @@ class TestListSpecificShareTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _to_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_to_personal_info)
 
         # prepare data: IDXTransferApproval
@@ -1043,6 +1056,7 @@ class TestListSpecificShareTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _from_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_from_personal_info)
 
         # prepare data: IDXPersonalInfo
@@ -1058,6 +1072,7 @@ class TestListSpecificShareTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _to_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_to_personal_info)
 
         # prepare data: IDXTransferApproval
@@ -1423,6 +1438,7 @@ class TestListSpecificShareTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _from_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_from_personal_info)
 
         # prepare data: IDXPersonalInfo
@@ -1438,6 +1454,7 @@ class TestListSpecificShareTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _to_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_to_personal_info)
 
         # prepare data: IDXTransferApproval
@@ -1643,6 +1660,7 @@ class TestListSpecificShareTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _from_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_from_personal_info)
 
         # prepare data: IDXPersonalInfo
@@ -1658,6 +1676,7 @@ class TestListSpecificShareTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _to_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_to_personal_info)
 
         # prepare data: IDXTransferApproval
@@ -1895,6 +1914,7 @@ class TestListSpecificShareTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _from_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_from_personal_info)
 
         # prepare data: IDXPersonalInfo
@@ -1910,6 +1930,7 @@ class TestListSpecificShareTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _to_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_to_personal_info)
 
         # prepare data: IDXTransferApproval
@@ -2095,6 +2116,7 @@ class TestListSpecificShareTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _from_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_from_personal_info)
 
         # prepare data: IDXPersonalInfo
@@ -2110,6 +2132,7 @@ class TestListSpecificShareTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _to_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_to_personal_info)
 
         # prepare data: IDXTransferApproval
@@ -2335,6 +2358,7 @@ class TestListSpecificShareTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _from_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_from_personal_info)
 
         # prepare data: IDXPersonalInfo
@@ -2350,6 +2374,7 @@ class TestListSpecificShareTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _to_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_to_personal_info)
 
         # prepare data: IDXTransferApproval
@@ -2575,6 +2600,7 @@ class TestListSpecificShareTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _from_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_from_personal_info)
 
         # prepare data: IDXPersonalInfo
@@ -2590,6 +2616,7 @@ class TestListSpecificShareTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _to_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_to_personal_info)
 
         # prepare data: IDXTransferApproval
@@ -2780,6 +2807,7 @@ class TestListSpecificShareTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _from_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_from_personal_info)
 
         # prepare data: IDXPersonalInfo
@@ -2795,6 +2823,7 @@ class TestListSpecificShareTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _to_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_to_personal_info)
 
         # prepare data: IDXTransferApproval
@@ -2983,6 +3012,7 @@ class TestListSpecificShareTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _from_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_from_personal_info)
 
         # prepare data: IDXPersonalInfo
@@ -2998,6 +3028,7 @@ class TestListSpecificShareTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _to_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_to_personal_info)
 
         # prepare data: IDXTransferApproval
@@ -3222,6 +3253,7 @@ class TestListSpecificShareTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _from_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_from_personal_info)
 
         # prepare data: IDXPersonalInfo
@@ -3237,6 +3269,7 @@ class TestListSpecificShareTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _to_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_to_personal_info)
 
         # prepare data: IDXTransferApproval
@@ -3468,6 +3501,7 @@ class TestListSpecificShareTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _from_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_from_personal_info)
 
         # prepare data: IDXPersonalInfo
@@ -3483,6 +3517,7 @@ class TestListSpecificShareTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _to_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_to_personal_info)
 
         # prepare data: IDXTransferApproval
@@ -3710,6 +3745,7 @@ class TestListSpecificShareTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _from_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_from_personal_info)
 
         # prepare data: IDXPersonalInfo
@@ -3725,6 +3761,7 @@ class TestListSpecificShareTokenTransferApprovalHistory:
             "birth": "birth_test",
             "is_corporate": False,
         }
+        _to_personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_to_personal_info)
 
         # prepare data: IDXTransferApproval

--- a/tests/app/test_share_transfer_approvals_RetrieveShareTokenTransferApprovalStatus.py
+++ b/tests/app/test_share_transfer_approvals_RetrieveShareTokenTransferApprovalStatus.py
@@ -25,6 +25,7 @@ import config
 from app.model.db import (
     IDXPersonalInfo,
     IDXTransferApproval,
+    PersonalInfoDataSource,
     Token,
     TokenType,
     TokenVersion,
@@ -35,7 +36,7 @@ from app.model.db import (
 local_tz = timezone(config.TZ)
 
 
-class TestAppRoutersShareTransferApprovalsTokenAddressIdGET:
+class TestRetrieveShareTokenTransferApprovalStatus:
     # target API endpoint
     base_url = "/share/transfer_approvals/{}/{}"
 
@@ -113,6 +114,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressIdGET:
             "is_corporate": False,
             "tax_category": 10,
         }  # latest data
+        _personal_info_from.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_from)
 
         _personal_info_to = IDXPersonalInfo()
@@ -128,6 +130,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressIdGET:
             "is_corporate": False,
             "tax_category": 10,
         }  # latest data
+        _personal_info_to.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_to)
 
         # prepare data: IDXTransferApproval
@@ -513,6 +516,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressIdGET:
             "is_corporate": False,
             "tax_category": 10,
         }  # latest data
+        _personal_info_from.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_from)
 
         _personal_info_to = IDXPersonalInfo()
@@ -528,6 +532,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressIdGET:
             "is_corporate": False,
             "tax_category": 10,
         }  # latest data
+        _personal_info_to.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_to)
 
         # prepare data: IDXTransferApproval
@@ -852,6 +857,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressIdGET:
             "is_corporate": False,
             "tax_category": 10,
         }  # latest data
+        _personal_info_from.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_from)
 
         _personal_info_to = IDXPersonalInfo()
@@ -867,6 +873,7 @@ class TestAppRoutersShareTransferApprovalsTokenAddressIdGET:
             "is_corporate": False,
             "tax_category": 10,
         }  # latest data
+        _personal_info_to.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_to)
 
         # prepare data: IDXTransferApproval

--- a/tests/app/test_share_transfer_approvals_UpdateShareTokenTransferApprovalStatus.py
+++ b/tests/app/test_share_transfer_approvals_UpdateShareTokenTransferApprovalStatus.py
@@ -39,6 +39,7 @@ from app.model.db import (
     AuthToken,
     IDXPersonalInfo,
     IDXTransferApproval,
+    PersonalInfoDataSource,
     Token,
     TokenType,
     TokenVersion,
@@ -125,6 +126,7 @@ class TestUpdateShareTokenTransferApprovalStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        _personal_info_from.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_from)
 
         _personal_info_to = IDXPersonalInfo()
@@ -140,6 +142,7 @@ class TestUpdateShareTokenTransferApprovalStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        _personal_info_to.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_to)
 
         db.commit()
@@ -263,6 +266,7 @@ class TestUpdateShareTokenTransferApprovalStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        _personal_info_from.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_from)
 
         _personal_info_to = IDXPersonalInfo()
@@ -278,6 +282,7 @@ class TestUpdateShareTokenTransferApprovalStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        _personal_info_to.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_to)
 
         db.commit()
@@ -400,6 +405,7 @@ class TestUpdateShareTokenTransferApprovalStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        _personal_info_from.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_from)
 
         _personal_info_to = IDXPersonalInfo()
@@ -415,6 +421,7 @@ class TestUpdateShareTokenTransferApprovalStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        _personal_info_to.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_to)
 
         db.commit()
@@ -542,6 +549,7 @@ class TestUpdateShareTokenTransferApprovalStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        _personal_info_from.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_from)
 
         _personal_info_to = IDXPersonalInfo()
@@ -557,6 +565,7 @@ class TestUpdateShareTokenTransferApprovalStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        _personal_info_to.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_to)
 
         db.commit()
@@ -1297,6 +1306,7 @@ class TestUpdateShareTokenTransferApprovalStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        _personal_info_from.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_from)
 
         _personal_info_to = IDXPersonalInfo()
@@ -1312,6 +1322,7 @@ class TestUpdateShareTokenTransferApprovalStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        _personal_info_to.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_to)
 
         db.commit()
@@ -1390,6 +1401,7 @@ class TestUpdateShareTokenTransferApprovalStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        _personal_info_from.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_from)
 
         _personal_info_to = IDXPersonalInfo()
@@ -1405,6 +1417,7 @@ class TestUpdateShareTokenTransferApprovalStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        _personal_info_to.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_to)
 
         db.commit()
@@ -1502,6 +1515,7 @@ class TestUpdateShareTokenTransferApprovalStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        _personal_info_from.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_from)
 
         _personal_info_to = IDXPersonalInfo()
@@ -1517,6 +1531,7 @@ class TestUpdateShareTokenTransferApprovalStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        _personal_info_to.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_to)
 
         db.commit()
@@ -1596,6 +1611,7 @@ class TestUpdateShareTokenTransferApprovalStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        _personal_info_from.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_from)
 
         _personal_info_to = IDXPersonalInfo()
@@ -1611,6 +1627,7 @@ class TestUpdateShareTokenTransferApprovalStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        _personal_info_to.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_to)
 
         db.commit()
@@ -1700,6 +1717,7 @@ class TestUpdateShareTokenTransferApprovalStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        _personal_info_from.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_from)
 
         _personal_info_to = IDXPersonalInfo()
@@ -1715,6 +1733,7 @@ class TestUpdateShareTokenTransferApprovalStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        _personal_info_to.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_to)
 
         db.commit()
@@ -1793,6 +1812,7 @@ class TestUpdateShareTokenTransferApprovalStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        _personal_info_from.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_from)
 
         _personal_info_to = IDXPersonalInfo()
@@ -1808,6 +1828,7 @@ class TestUpdateShareTokenTransferApprovalStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        _personal_info_to.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_to)
 
         db.commit()
@@ -1959,6 +1980,7 @@ class TestUpdateShareTokenTransferApprovalStatus:
             "is_corporate": False,
             "tax_category": 10,
         }
+        _personal_info_from.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_from)
 
         db.commit()

--- a/tests/app/test_share_transfers_ListShareTokenTransferHistory.py
+++ b/tests/app/test_share_transfers_ListShareTokenTransferHistory.py
@@ -26,6 +26,7 @@ from app.model.db import (
     IDXPersonalInfo,
     IDXTransfer,
     IDXTransferSourceEventType,
+    PersonalInfoDataSource,
     Token,
     TokenType,
     TokenVersion,
@@ -34,7 +35,7 @@ from app.model.db import (
 local_tz = timezone(config.TZ)
 
 
-class TestAppRoutersShareTransfersGET:
+class TestListShareTokenTransferHistory:
     # target API endpoint
     base_url = "/share/transfers/{}"
 
@@ -165,6 +166,7 @@ class TestAppRoutersShareTransfersGET:
             "is_corporate": False,
             "tax_category": 10,
         }  # latest data
+        _personal_info_from.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_from)
 
         _personal_info_to = IDXPersonalInfo()
@@ -180,6 +182,7 @@ class TestAppRoutersShareTransfersGET:
             "is_corporate": False,
             "tax_category": 10,
         }  # latest data
+        _personal_info_to.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_to)
 
         # prepare data: IDXTransfer
@@ -619,6 +622,7 @@ class TestAppRoutersShareTransfersGET:
             "is_corporate": False,
             "tax_category": 10,
         }  # latest data
+        _personal_info_from.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_from)
 
         _personal_info_to = IDXPersonalInfo()
@@ -634,6 +638,7 @@ class TestAppRoutersShareTransfersGET:
             "is_corporate": False,
             "tax_category": 10,
         }  # latest data
+        _personal_info_to.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_to)
 
         db.commit()
@@ -724,6 +729,7 @@ class TestAppRoutersShareTransfersGET:
             "is_corporate": False,
             "tax_category": 10,
         }  # latest data
+        _personal_info_from.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_from)
 
         _personal_info_to = IDXPersonalInfo()
@@ -739,6 +745,7 @@ class TestAppRoutersShareTransfersGET:
             "is_corporate": False,
             "tax_category": 10,
         }  # latest data
+        _personal_info_to.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_to)
 
         db.commit()
@@ -1520,6 +1527,7 @@ class TestAppRoutersShareTransfersGET:
             "is_corporate": False,
             "tax_category": 10,
         }  # latest data
+        _personal_info_from.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_from)
 
         _personal_info_to = IDXPersonalInfo()
@@ -1535,6 +1543,7 @@ class TestAppRoutersShareTransfersGET:
             "is_corporate": False,
             "tax_category": 10,
         }  # latest data
+        _personal_info_to.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_to)
 
         db.commit()
@@ -1649,6 +1658,7 @@ class TestAppRoutersShareTransfersGET:
             "is_corporate": False,
             "tax_category": 10,
         }  # latest data
+        _personal_info_from.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_from)
 
         _personal_info_to = IDXPersonalInfo()
@@ -1664,6 +1674,7 @@ class TestAppRoutersShareTransfersGET:
             "is_corporate": False,
             "tax_category": 10,
         }  # latest data
+        _personal_info_to.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_personal_info_to)
 
         db.commit()

--- a/tests/app/test_token_holders_ListTokenHoldersPersonalInfo.py
+++ b/tests/app/test_token_holders_ListTokenHoldersPersonalInfo.py
@@ -21,7 +21,7 @@ from unittest import mock
 
 import pytest
 
-from app.model.db import IDXPersonalInfo
+from app.model.db import IDXPersonalInfo, PersonalInfoDataSource
 from tests.account_config import config_eth_account
 
 
@@ -75,6 +75,7 @@ class TestListTokenHoldersPersonalInfo:
             "is_corporate": False,
             "tax_category": 10,
         }
+        personal_info_idx.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(personal_info_idx)
 
         db.commit()
@@ -135,6 +136,7 @@ class TestListTokenHoldersPersonalInfo:
             "is_corporate": False,
             "tax_category": 10,
         }
+        personal_info_idx.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(personal_info_idx)
 
         personal_info_idx = IDXPersonalInfo()
@@ -150,6 +152,7 @@ class TestListTokenHoldersPersonalInfo:
             "is_corporate": False,
             "tax_category": 10,
         }
+        personal_info_idx.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(personal_info_idx)
 
         personal_info_idx = IDXPersonalInfo()
@@ -165,6 +168,7 @@ class TestListTokenHoldersPersonalInfo:
             "is_corporate": False,
             "tax_category": 10,
         }
+        personal_info_idx.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(personal_info_idx)
 
         db.commit()
@@ -258,6 +262,7 @@ class TestListTokenHoldersPersonalInfo:
         }
         personal_info_idx.created = "2024-05-13 09:00:00"
         personal_info_idx.modified = "2024-05-14 09:00:00"
+        personal_info_idx.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(personal_info_idx)
 
         personal_info_idx = IDXPersonalInfo()
@@ -275,6 +280,7 @@ class TestListTokenHoldersPersonalInfo:
         }
         personal_info_idx.created = "2024-05-13 12:00:00"
         personal_info_idx.modified = "2024-05-14 12:00:00"
+        personal_info_idx.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(personal_info_idx)
 
         personal_info_idx = IDXPersonalInfo()
@@ -292,6 +298,7 @@ class TestListTokenHoldersPersonalInfo:
         }
         personal_info_idx.created = "2024-05-13 15:00:00"
         personal_info_idx.modified = "2024-05-14 15:00:00"
+        personal_info_idx.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(personal_info_idx)
 
         db.commit()
@@ -356,6 +363,7 @@ class TestListTokenHoldersPersonalInfo:
         }
         personal_info_idx.created = "2024-05-13 09:00:00"
         personal_info_idx.modified = "2024-05-14 09:00:00"
+        personal_info_idx.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(personal_info_idx)
 
         personal_info_idx = IDXPersonalInfo()
@@ -373,6 +381,7 @@ class TestListTokenHoldersPersonalInfo:
         }
         personal_info_idx.created = "2024-05-13 12:00:00"
         personal_info_idx.modified = "2024-05-14 12:00:00"
+        personal_info_idx.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(personal_info_idx)
 
         personal_info_idx = IDXPersonalInfo()
@@ -390,6 +399,7 @@ class TestListTokenHoldersPersonalInfo:
         }
         personal_info_idx.created = "2024-05-13 15:00:00"
         personal_info_idx.modified = "2024-05-14 15:00:00"
+        personal_info_idx.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(personal_info_idx)
 
         db.commit()
@@ -455,6 +465,7 @@ class TestListTokenHoldersPersonalInfo:
         }
         personal_info_idx.created = "2024-05-13 09:00:00"
         personal_info_idx.modified = "2024-05-14 09:00:00"
+        personal_info_idx.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(personal_info_idx)
 
         personal_info_idx = IDXPersonalInfo()
@@ -472,6 +483,7 @@ class TestListTokenHoldersPersonalInfo:
         }
         personal_info_idx.created = "2024-05-13 12:00:00"
         personal_info_idx.modified = "2024-05-14 12:00:00"
+        personal_info_idx.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(personal_info_idx)
 
         personal_info_idx = IDXPersonalInfo()
@@ -489,6 +501,7 @@ class TestListTokenHoldersPersonalInfo:
         }
         personal_info_idx.created = "2024-05-13 15:00:00"
         personal_info_idx.modified = "2024-05-14 15:00:00"
+        personal_info_idx.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(personal_info_idx)
 
         db.commit()
@@ -555,6 +568,7 @@ class TestListTokenHoldersPersonalInfo:
         }
         personal_info_idx.created = "2023-10-23 00:00:00"
         personal_info_idx.modified = "2023-10-24 00:00:00"
+        personal_info_idx.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(personal_info_idx)
 
         personal_info_idx = IDXPersonalInfo()
@@ -572,6 +586,7 @@ class TestListTokenHoldersPersonalInfo:
         }
         personal_info_idx.created = "2023-10-23 00:00:01"
         personal_info_idx.modified = "2023-10-24 00:00:01"
+        personal_info_idx.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(personal_info_idx)
 
         personal_info_idx = IDXPersonalInfo()
@@ -589,6 +604,7 @@ class TestListTokenHoldersPersonalInfo:
         }
         personal_info_idx.created = "2023-10-23 00:00:02"
         personal_info_idx.modified = "2023-10-24 00:00:02"
+        personal_info_idx.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(personal_info_idx)
 
         db.commit()
@@ -683,6 +699,7 @@ class TestListTokenHoldersPersonalInfo:
             "tax_category": 10,
         }
         personal_info_idx.created = "2023-10-23 00:00:02"
+        personal_info_idx.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(personal_info_idx)
 
         personal_info_idx = IDXPersonalInfo()
@@ -699,6 +716,7 @@ class TestListTokenHoldersPersonalInfo:
             "tax_category": 10,
         }
         personal_info_idx.created = "2023-10-23 00:00:01"
+        personal_info_idx.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(personal_info_idx)
 
         personal_info_idx = IDXPersonalInfo()
@@ -715,6 +733,7 @@ class TestListTokenHoldersPersonalInfo:
             "tax_category": 10,
         }
         personal_info_idx.created = "2023-10-23 00:00:00"
+        personal_info_idx.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(personal_info_idx)
 
         db.commit()
@@ -810,6 +829,7 @@ class TestListTokenHoldersPersonalInfo:
         }
         personal_info_idx.created = "2023-10-23 00:00:00"
         personal_info_idx.modified = "2023-10-24 00:00:02"
+        personal_info_idx.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(personal_info_idx)
 
         personal_info_idx = IDXPersonalInfo()
@@ -827,6 +847,7 @@ class TestListTokenHoldersPersonalInfo:
         }
         personal_info_idx.created = "2023-10-23 00:00:01"
         personal_info_idx.modified = "2023-10-24 00:00:01"
+        personal_info_idx.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(personal_info_idx)
 
         personal_info_idx = IDXPersonalInfo()
@@ -844,6 +865,7 @@ class TestListTokenHoldersPersonalInfo:
         }
         personal_info_idx.created = "2023-10-23 00:00:02"
         personal_info_idx.modified = "2023-10-24 00:00:00"
+        personal_info_idx.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(personal_info_idx)
 
         db.commit()
@@ -936,6 +958,7 @@ class TestListTokenHoldersPersonalInfo:
             "is_corporate": False,
             "tax_category": 10,
         }
+        personal_info_idx.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(personal_info_idx)
 
         personal_info_idx = IDXPersonalInfo()
@@ -951,6 +974,7 @@ class TestListTokenHoldersPersonalInfo:
             "is_corporate": False,
             "tax_category": 10,
         }
+        personal_info_idx.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(personal_info_idx)
 
         personal_info_idx = IDXPersonalInfo()
@@ -966,6 +990,7 @@ class TestListTokenHoldersPersonalInfo:
             "is_corporate": False,
             "tax_category": 10,
         }
+        personal_info_idx.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(personal_info_idx)
 
         db.commit()

--- a/tests/app/test_token_holders_RetrieveTokenHoldersCollection.py
+++ b/tests/app/test_token_holders_RetrieveTokenHoldersCollection.py
@@ -28,6 +28,7 @@ from web3.middleware import ExtraDataToPOAMiddleware
 import config
 from app.model.db import (
     IDXPersonalInfo,
+    PersonalInfoDataSource,
     Token,
     TokenHolder,
     TokenHolderBatchStatus,
@@ -208,6 +209,7 @@ class TestAppRoutersHoldersTokenAddressCollectionIdGET:
                 "is_corporate": True,
                 "tax_category": i + 1,
             }
+            _personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
             db.add(_personal_info)
             holders.append(
                 {
@@ -286,6 +288,7 @@ class TestAppRoutersHoldersTokenAddressCollectionIdGET:
                 "is_corporate": True,
                 "tax_category": i + 1,
             }
+            _personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
             db.add(_personal_info)
             holders.append(
                 {
@@ -364,6 +367,7 @@ class TestAppRoutersHoldersTokenAddressCollectionIdGET:
                 "is_corporate": True,
                 "tax_category": i + 1,
             }
+            _personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
             db.add(_personal_info)
             holders.append(
                 {
@@ -442,6 +446,7 @@ class TestAppRoutersHoldersTokenAddressCollectionIdGET:
                 "is_corporate": True,
                 "tax_category": i + 1,
             }
+            _personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
             db.add(_personal_info)
             holders.append(
                 {
@@ -520,6 +525,7 @@ class TestAppRoutersHoldersTokenAddressCollectionIdGET:
                 "is_corporate": True,
                 "tax_category": i + 1,
             }
+            _personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
             db.add(_personal_info)
             holders.append(
                 {
@@ -598,6 +604,7 @@ class TestAppRoutersHoldersTokenAddressCollectionIdGET:
                 "is_corporate": True,
                 "tax_category": i + 1,
             }
+            _personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
             db.add(_personal_info)
             holders.append(
                 {
@@ -676,6 +683,7 @@ class TestAppRoutersHoldersTokenAddressCollectionIdGET:
                 "is_corporate": True,
                 "tax_category": i + 1,
             }
+            _personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
             db.add(_personal_info)
             holders.append(
                 {
@@ -753,6 +761,7 @@ class TestAppRoutersHoldersTokenAddressCollectionIdGET:
                 "is_corporate": True,
                 "tax_category": i + 1,
             }
+            _personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
             db.add(_personal_info)
             holders.append(
                 {
@@ -828,6 +837,7 @@ class TestAppRoutersHoldersTokenAddressCollectionIdGET:
                 "is_corporate": True,
                 "tax_category": i + 1,
             }
+            _personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
             db.add(_personal_info)
             holders.append(
                 {
@@ -915,6 +925,7 @@ class TestAppRoutersHoldersTokenAddressCollectionIdGET:
                 "is_corporate": True,
                 "tax_category": i + 1,
             }
+            _personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
             db.add(_personal_info)
             holders.append(
                 {

--- a/tests/app/utils/test_ledger_utils.py
+++ b/tests/app/utils/test_ledger_utils.py
@@ -50,6 +50,7 @@ from app.model.db import (
     LedgerTemplate,
     Notification,
     NotificationType,
+    PersonalInfoDataSource,
     Token,
     TokenType,
     TokenVersion,
@@ -219,6 +220,7 @@ class TestCreateLedger:
             "name": "name_test_db_1",
             "address": "address_test_db_1",
         }
+        _idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_idx_personal_info_1)
 
         # Prepare data: Token
@@ -1512,6 +1514,7 @@ class TestCreateLedger:
             "name": "name_test_db_1",
             "address": "address_test_db_1",
         }
+        _idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(_idx_personal_info_1)
 
         # Prepare data: Token

--- a/tests/batch/test_indexer_personal_info.py
+++ b/tests/batch/test_indexer_personal_info.py
@@ -40,6 +40,7 @@ from app.model.db import (
     IDXPersonalInfo,
     IDXPersonalInfoBlockNumber,
     IDXPersonalInfoHistory,
+    PersonalInfoDataSource,
     PersonalInfoEventType,
     Token,
     TokenType,
@@ -342,6 +343,7 @@ class TestProcessor:
         assert _personal_info.account_address == user_address_1
         assert _personal_info.issuer_address == issuer_address
         assert _personal_info.personal_info == personal_info_1
+        assert _personal_info.data_source == PersonalInfoDataSource.ON_CHAIN
 
         _personal_info_history_list = db.scalars(select(IDXPersonalInfoHistory)).all()
         assert len(_personal_info_history_list) == 1
@@ -449,6 +451,7 @@ class TestProcessor:
         assert _personal_info.account_address == user_address_1
         assert _personal_info.issuer_address == issuer_address
         assert _personal_info.personal_info == personal_info_1
+        assert _personal_info.data_source == PersonalInfoDataSource.ON_CHAIN
 
         # Modify
         personal_info_2 = {
@@ -492,6 +495,7 @@ class TestProcessor:
         assert _personal_info.account_address == user_address_1
         assert _personal_info.issuer_address == issuer_address
         assert _personal_info.personal_info == personal_info_2
+        assert _personal_info.data_source == PersonalInfoDataSource.ON_CHAIN
 
         _personal_info_history_list = db.scalars(select(IDXPersonalInfoHistory)).all()
         assert len(_personal_info_history_list) == 2
@@ -605,6 +609,7 @@ class TestProcessor:
         assert _personal_info.account_address == user_address_1
         assert _personal_info.issuer_address == issuer_address
         assert _personal_info.personal_info == personal_info_1
+        assert _personal_info.data_source == PersonalInfoDataSource.ON_CHAIN
 
         # Modify
         personal_info_2 = {
@@ -648,6 +653,7 @@ class TestProcessor:
         assert _personal_info.account_address == user_address_1
         assert _personal_info.issuer_address == issuer_address
         assert _personal_info.personal_info == personal_info_2
+        assert _personal_info.data_source == PersonalInfoDataSource.ON_CHAIN
 
         _personal_info_history_list = db.scalars(
             select(IDXPersonalInfoHistory).order_by(IDXPersonalInfoHistory.id)
@@ -714,6 +720,7 @@ class TestProcessor:
         assert _personal_info.account_address == user_address_1
         assert _personal_info.issuer_address == issuer_address
         assert _personal_info.personal_info == personal_info_3
+        assert _personal_info.data_source == PersonalInfoDataSource.ON_CHAIN
 
         _personal_info_history_list = db.scalars(
             select(IDXPersonalInfoHistory).order_by(IDXPersonalInfoHistory.id)
@@ -908,6 +915,7 @@ class TestProcessor:
                 _personal_info.personal_info
                 == personal_info_dict[stored_address_order[i]]
             )
+            assert _personal_info.data_source == PersonalInfoDataSource.ON_CHAIN
 
         _personal_info_history_list = db.scalars(select(IDXPersonalInfoHistory)).all()
         assert len(_personal_info_history_list) == 2

--- a/tests/batch/test_processor_modify_personal_info.py
+++ b/tests/batch/test_processor_modify_personal_info.py
@@ -42,6 +42,7 @@ from app.model.db import (
     AccountRsaKeyTemporary,
     AccountRsaStatus,
     IDXPersonalInfo,
+    PersonalInfoDataSource,
     Token,
     TokenType,
     TokenVersion,
@@ -271,12 +272,14 @@ class TestProcessor:
         idx_1.issuer_address = user_1["address"]
         idx_1.account_address = personal_user_1["address"]
         idx_1.personal_info = {}
+        idx_1.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_1)
 
         idx_2 = IDXPersonalInfo()
         idx_2.issuer_address = user_1["address"]
         idx_2.account_address = personal_user_2["address"]
         idx_2.personal_info = {}
+        idx_2.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_2)
 
         await set_personal_info_contract(
@@ -304,12 +307,14 @@ class TestProcessor:
         idx_3.issuer_address = user_1["address"]
         idx_3.account_address = personal_user_3["address"]
         idx_3.personal_info = {}
+        idx_3.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_3)
 
         idx_4 = IDXPersonalInfo()
         idx_4.issuer_address = user_1["address"]
         idx_4.account_address = personal_user_4["address"]
         idx_4.personal_info = {}
+        idx_4.data_source = PersonalInfoDataSource.ON_CHAIN
         db.add(idx_4)
 
         await set_personal_info_contract(


### PR DESCRIPTION
close #682 

### Add functionality for managing issuer's child keys with a deterministic wallet (CRUD API)
- The deterministic wallet adopts a method that derives the child public key from the issuer's public key. Since there is no need to access the issuer's private key, the API specification does not require the use of eoa_password as input information.
- When generating a child key, the investor’s personal information is registered.
- The update API does not modify any keys; it is currently an API that only changes personal information. The update API can only update information for addresses managed as child keys.

### Off-chain personal information is managed using the IDXPersonalInfo model
- A field called `data_source` is added to IDXPersonalInfo to distinguish between on-chain and off-chain data. Existing data will be switched to set as on-chain.
- For the personal information fields, the reserved word "SELF" is registered in key_manager, indicating that it is managed by the issuer themselves.

Based on the above policy, no significant changes have been made to the existing functions that use IDXPersonalInfo, but the following points have been exceptionally modified:
- The indexer for personal info has been modified to set the data_source to "on-chain."
- Additionally, filtering for "on-chain" has been added to processes that should only extract personal_info from the contract.