### PR TITLE
Add SealedTx feature

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -47,7 +47,13 @@ from app.routers.issuer import (
     share,
     token_holders,
 )
-from app.routers.misc import bc_explorer, e2e_messaging, freeze_log, settlement_agent
+from app.routers.misc import (
+    bc_explorer,
+    e2e_messaging,
+    freeze_log,
+    sealed_tx,
+    settlement_agent,
+)
 from app.utils.docs_utils import custom_openapi
 from config import (
     BC_EXPLORER_ENABLED,
@@ -69,6 +75,10 @@ tags_metadata = [
     {
         "name": "[misc] messaging",
         "description": "Messaging functions with external systems",
+    },
+    {
+        "name": "[misc] sealed_tx",
+        "description": "Sealed transaction",
     },
 ]
 
@@ -136,6 +146,7 @@ app.include_router(position.router)
 app.include_router(share.router)
 app.include_router(token_holders.router)
 app.include_router(settlement_issuer.router)
+app.include_router(sealed_tx.router)
 
 if DVP_AGENT_FEATURE_ENABLED:
     app.include_router(settlement_agent.router)

--- a/app/model/schema/__init__.py
+++ b/app/model/schema/__init__.py
@@ -119,6 +119,7 @@ from .scheduled_events import (
     ScheduledEventIdResponse,
     ScheduledEventResponse,
 )
+from .sealed_tx import SealedTxRegisterPersonalInfoRequest
 from .settlement import (
     AbortDVPDeliveryRequest,
     CancelDVPDeliveryRequest,

--- a/app/model/schema/sealed_tx.py
+++ b/app/model/schema/sealed_tx.py
@@ -1,0 +1,42 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+from pydantic import BaseModel
+
+from app.model import EthereumAddress
+from app.model.schema.personal_info import PersonalInfoInput
+
+
+############################
+# REQUEST
+############################
+class SealedTxPersonalInfoInput(PersonalInfoInput):
+    """Personal Information Input schema for sealed tx"""
+
+    key_manager: str
+
+
+############################
+# REQUEST
+############################
+class SealedTxRegisterPersonalInfoRequest(BaseModel):
+    """Schema for personal information registration using sealed tx(REQUEST)"""
+
+    link_address: EthereumAddress
+    personal_information: SealedTxPersonalInfoInput

--- a/app/routers/misc/sealed_tx.py
+++ b/app/routers/misc/sealed_tx.py
@@ -1,0 +1,82 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import json
+
+from fastapi import APIRouter
+from starlette.requests import Request
+
+from app.database import DBAsyncSession
+from app.model.db import (
+    IDXPersonalInfo,
+    IDXPersonalInfoHistory,
+    PersonalInfoDataSource,
+    PersonalInfoEventType,
+)
+from app.model.schema import SealedTxRegisterPersonalInfoRequest
+from app.utils.docs_utils import get_routers_responses
+from app.utils.sealedtx_utils import (
+    RawRequestBody,
+    SealedTxSignatureHeader,
+    VerifySealedTxSignature,
+)
+
+router = APIRouter(prefix="/sealed_tx", tags=["[misc] sealed_tx"])
+
+
+# POST: /personal_info/register
+@router.post(
+    "/personal_info/register",
+    operation_id="SealedTxRegisterPersonalInfo",
+    response_model=None,
+    responses=get_routers_responses(400),
+)
+async def sealed_tx_register_personal_info(
+    db: DBAsyncSession,
+    raw_request_body: RawRequestBody,
+    request: Request,
+    sealed_tx_sig: SealedTxSignatureHeader,
+    register_data: SealedTxRegisterPersonalInfoRequest,
+):
+    # Verify sealed tx signature
+    account_address = VerifySealedTxSignature(
+        req=request, body=json.loads(raw_request_body.decode()), signature=sealed_tx_sig
+    )
+
+    # Insert offchain personal information
+    # NOTE: Overwrite if a record for the same account already exists.
+    personal_info = register_data.personal_information.model_dump()
+    _off_personal_info = IDXPersonalInfo()
+    _off_personal_info.issuer_address = register_data.link_address
+    _off_personal_info.account_address = account_address
+    _off_personal_info.personal_info = personal_info
+    _off_personal_info.data_source = PersonalInfoDataSource.OFF_CHAIN
+    await db.merge(_off_personal_info)
+
+    # Insert personal information history
+    _personal_info_history = IDXPersonalInfoHistory()
+    _personal_info_history.issuer_address = register_data.link_address
+    _personal_info_history.account_address = account_address
+    _personal_info_history.event_type = PersonalInfoEventType.REGISTER
+    _personal_info_history.personal_info = personal_info
+    db.add(_personal_info_history)
+
+    await db.commit()
+
+    return

--- a/app/utils/sealedtx_utils.py
+++ b/app/utils/sealedtx_utils.py
@@ -1,0 +1,94 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import json
+from typing import Annotated
+
+from eth_account.messages import encode_defunct
+from fastapi import Depends, Header, Request
+from web3.auto import w3
+
+from app import log
+from app.exceptions import InvalidParameterError
+
+LOG = log.get_logger()
+
+
+async def get_body(req: Request):
+    return await req.body()
+
+
+RawRequestBody = Annotated[bytes, Depends(get_body)]
+
+SealedTxSignatureHeader = Annotated[str, Header(alias="X-SealedTx-Signature")]
+
+
+def VerifySealedTxSignature(req: Request, body: dict | None, signature: str):
+    """
+    Verify X-SealedTx-Signature
+    - https://github.com/BoostryJP/ibet-Prime/issues/689
+    """
+
+    if signature == "":
+        raise InvalidParameterError("Signature is empty")
+    LOG.debug("X-SealedTx-Signature: " + signature)
+
+    # Calculating the hash value of the request body
+    if body:
+        request_body = json.dumps(body, separators=(",", ":"))
+    else:
+        request_body = json.dumps({})
+    LOG.debug("request_body: " + request_body)
+    request_body_hash = w3.keccak(text=request_body).hex()
+
+    # Normalize the query parameters
+    kvs = []
+    for k, v in sorted(req.query_params.items()):
+        if type(v) == int:
+            v = str(v)
+        kvs.append(k + "=" + v)
+
+    if len(kvs) == 0:
+        query_params = ""
+    else:
+        query_params = "?" + "&".join(kvs)
+
+    # Generate a CanonicalRequest
+    canonical_request = (
+        req.method
+        + "\n"
+        + req.url.path
+        + "\n"
+        + query_params
+        + "\n"
+        + request_body_hash
+    )
+    LOG.debug("Canonical Request: " + canonical_request)
+
+    # Verify the signature
+    try:
+        recovered_address = w3.eth.account.recover_message(
+            encode_defunct(text=canonical_request),
+            signature=signature,
+        )
+        LOG.debug("Recovered EOA: " + recovered_address)
+    except Exception:
+        raise InvalidParameterError("failed to recover hash")
+
+    return recovered_address

--- a/docs/ibet_prime.yaml
+++ b/docs/ibet_prime.yaml
@@ -8523,6 +8523,35 @@ paths:
                   - $ref: '#/components/schemas/InvalidParameterErrorResponse'
                   - $ref: '#/components/schemas/SendTransactionErrorResponse'
                 title: Response 400 Updatedvpdelivery
+  /sealed_tx/personal_info/register:
+    post:
+      tags:
+        - '[misc] sealed_tx'
+      summary: Sealed Tx Register Personal Info
+      operationId: SealedTxRegisterPersonalInfo
+      parameters:
+        - name: X-SealedTx-Signature
+          in: header
+          required: true
+          schema:
+            type: string
+            title: X-Sealedtx-Signature
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SealedTxRegisterPersonalInfoRequest'
+      responses:
+        '200':
+          description: Successful Response
+        '400':
+          description: Invalid Parameter Error / Send Transaction Error / Contract
+            Revert Error etc
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400Model'
   /settlement/dvp/agent/accounts:
     get:
       tags:
@@ -10991,6 +11020,44 @@ components:
         - send_timestamp
       title: E2EMessagingResponse
       description: E2E Messaging schema (Response)
+    Error400MetaModel:
+      properties:
+        code:
+          type: integer
+          title: Code
+          examples:
+            - 0
+            - 1
+            - 2
+            - 100001
+        title:
+          type: string
+          title: Title
+          examples:
+            - InvalidParameterError
+            - SendTransactionError
+            - ContractRevertError
+      type: object
+      required:
+        - code
+        - title
+      title: Error400MetaModel
+    Error400Model:
+      properties:
+        meta:
+          $ref: '#/components/schemas/Error400MetaModel'
+        detail:
+          type: string
+          title: Detail
+          examples:
+            - this token is temporarily unavailable
+            - failed to register token address token list
+            - The address has already been registered.
+      type: object
+      required:
+        - meta
+        - detail
+      title: Error400Model
     Error401MetaModel:
       properties:
         code:
@@ -14273,6 +14340,64 @@ components:
         - Update
       const: Update
       title: ScheduledEventType
+    SealedTxPersonalInfoInput:
+      properties:
+        name:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Name
+        postal_code:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Postal Code
+        address:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Address
+        email:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Email
+        birth:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Birth
+        is_corporate:
+          anyOf:
+            - type: boolean
+            - type: 'null'
+          title: Is Corporate
+        tax_category:
+          anyOf:
+            - type: integer
+            - type: 'null'
+          title: Tax Category
+        key_manager:
+          type: string
+          title: Key Manager
+      type: object
+      required:
+        - key_manager
+      title: SealedTxPersonalInfoInput
+      description: Personal Information Input schema for sealed tx
+    SealedTxRegisterPersonalInfoRequest:
+      properties:
+        link_address:
+          type: string
+          title: Link Address
+        personal_information:
+          $ref: '#/components/schemas/SealedTxPersonalInfoInput'
+      type: object
+      required:
+        - link_address
+        - personal_information
+      title: SealedTxRegisterPersonalInfoRequest
+      description: Schema for personal information registration using sealed tx(REQUEST)
     SendTransactionErrorCode:
       type: integer
       enum:
@@ -15165,6 +15290,8 @@ tags:
     description: Utility functions
   - name: '[misc] messaging'
     description: Messaging functions with external systems
+  - name: '[misc] sealed_tx'
+    description: Sealed transaction
   - name: '[misc] settlement_agent'
     description: Settlement related features for paying agent
   - name: '[misc] blockchain_explorer'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ quote-style = "double"
 indent-style = "space"
 line-ending = "auto"
 skip-magic-trailing-comma = false
+exclude = ["tests/app/utils/test_sealed_tx_utils.py"]
 
 [tool.ruff.lint]
 preview = true

--- a/tests/app/test_sealed_tx_SealedTxRegisterPersonalInfo.py
+++ b/tests/app/test_sealed_tx_SealedTxRegisterPersonalInfo.py
@@ -1,0 +1,345 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import datetime
+
+import pytest
+from sqlalchemy import select
+
+from app.model.db import (
+    IDXPersonalInfo,
+    IDXPersonalInfoHistory,
+    PersonalInfoDataSource,
+    PersonalInfoEventType,
+)
+from tests.app.utils.generate_signature import generate_sealed_tx_signature
+
+
+class TestSealedTxRegisterPersonalInfo:
+    test_issuer_address = "0x56f63dc2351BeC560a429f0C646d64Ca718e11D6"
+
+    test_account_address = "0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf"
+    test_account_pk = "0000000000000000000000000000000000000000000000000000000000000001"
+
+    # Target API endpoint
+    url = "/sealed_tx/personal_info/register"
+
+    ###########################################################################
+    # Normal Case
+    ###########################################################################
+
+    # <Normal_1_1>
+    # Register personal information
+    @pytest.mark.freeze_time("2024-09-30 12:34:56")
+    def test_normal_1_1(self, client, db):
+        # Derive a signature
+        _params = {
+            "link_address": self.test_issuer_address,
+            "personal_information": {
+                "key_manager": "test_key_manager",
+                "name": "test_name",
+                "postal_code": "test_postal_code",
+                "address": "test_address",
+                "email": "test_email",
+                "birth": "test_birth",
+                "is_corporate": False,
+                "tax_category": 10,
+            },
+        }
+        _sealed_tx_sig = generate_sealed_tx_signature(
+            "POST",
+            self.url,
+            private_key=self.test_account_pk,
+            json=_params,
+        )
+
+        # Call API
+        resp = client.post(
+            self.url,
+            json=_params,
+            headers={
+                "Content-Type": "application/json",
+                "X-SealedTx-Signature": _sealed_tx_sig,
+            },
+        )
+
+        # Assertion
+        assert resp.status_code == 200
+        assert resp.json() is None
+
+        _personal_info = db.scalars(select(IDXPersonalInfo).limit(1)).first()
+        assert _personal_info.issuer_address == self.test_issuer_address
+        assert _personal_info.account_address == self.test_account_address
+        assert _personal_info.personal_info == {
+            "key_manager": "test_key_manager",
+            "name": "test_name",
+            "postal_code": "test_postal_code",
+            "address": "test_address",
+            "email": "test_email",
+            "birth": "test_birth",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        assert _personal_info.data_source == PersonalInfoDataSource.OFF_CHAIN
+
+        _history = db.scalars(select(IDXPersonalInfoHistory).limit(1)).first()
+        assert _history.issuer_address == self.test_issuer_address
+        assert _history.account_address == self.test_account_address
+        assert _history.event_type == PersonalInfoEventType.REGISTER
+        assert _history.personal_info == {
+            "key_manager": "test_key_manager",
+            "name": "test_name",
+            "postal_code": "test_postal_code",
+            "address": "test_address",
+            "email": "test_email",
+            "birth": "test_birth",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        assert _history.block_timestamp == datetime.datetime(2024, 9, 30, 12, 34, 56)
+
+    # <Normal_1_2>
+    # Blank personal information
+    @pytest.mark.freeze_time("2024-09-30 12:34:56")
+    def test_normal_1_2(self, client, db):
+        # Derive a signature
+        _params = {
+            "link_address": self.test_issuer_address,
+            "personal_information": {"key_manager": "test_key_manager"},
+        }
+        _sealed_tx_sig = generate_sealed_tx_signature(
+            "POST",
+            self.url,
+            private_key=self.test_account_pk,
+            json=_params,
+        )
+
+        # Call API
+        resp = client.post(
+            self.url,
+            json=_params,
+            headers={
+                "Content-Type": "application/json",
+                "X-SealedTx-Signature": _sealed_tx_sig,
+            },
+        )
+
+        # Assertion
+        assert resp.status_code == 200
+        assert resp.json() is None
+
+        _personal_info = db.scalars(select(IDXPersonalInfo).limit(1)).first()
+        assert _personal_info.issuer_address == self.test_issuer_address
+        assert _personal_info.account_address == self.test_account_address
+        assert _personal_info.personal_info == {
+            "key_manager": "test_key_manager",
+            "name": None,
+            "postal_code": None,
+            "address": None,
+            "email": None,
+            "birth": None,
+            "is_corporate": None,
+            "tax_category": None,
+        }
+        assert _personal_info.data_source == PersonalInfoDataSource.OFF_CHAIN
+
+        _history = db.scalars(select(IDXPersonalInfoHistory).limit(1)).first()
+        assert _history.issuer_address == self.test_issuer_address
+        assert _history.account_address == self.test_account_address
+        assert _history.event_type == PersonalInfoEventType.REGISTER
+        assert _history.personal_info == {
+            "key_manager": "test_key_manager",
+            "name": None,
+            "postal_code": None,
+            "address": None,
+            "email": None,
+            "birth": None,
+            "is_corporate": None,
+            "tax_category": None,
+        }
+        assert _history.block_timestamp == datetime.datetime(2024, 9, 30, 12, 34, 56)
+
+    # <Normal_2>
+    # Overwrite the already registered personal information
+    @pytest.mark.freeze_time("2024-09-30 12:34:56")
+    def test_normal_2(self, client, db):
+        _personal_info = IDXPersonalInfo()
+        _personal_info.issuer_address = self.test_issuer_address
+        _personal_info.account_address = self.test_account_address
+        _personal_info.personal_info = {
+            "key_manager": "test_key_manager_1",
+            "name": "name_test_1",
+            "postal_code": "postal_code_test_1",
+            "address": "address_test_1",
+            "email": "email_test_1",
+            "birth": "birth_test_1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        _personal_info.data_source = PersonalInfoDataSource.ON_CHAIN
+
+        # Derive a signature
+        _params = {
+            "link_address": self.test_issuer_address,
+            "personal_information": {
+                "key_manager": "test_key_manager_2",
+                "name": "test_name_2",
+                "postal_code": "test_postal_code_2",
+                "address": "test_address_2",
+                "email": "test_email_2",
+                "birth": "test_birth_2",
+                "is_corporate": True,
+                "tax_category": 20,
+            },
+        }
+        _sealed_tx_sig = generate_sealed_tx_signature(
+            "POST",
+            self.url,
+            private_key=self.test_account_pk,
+            json=_params,
+        )
+
+        # Call API
+        resp = client.post(
+            self.url,
+            json=_params,
+            headers={
+                "Content-Type": "application/json",
+                "X-SealedTx-Signature": _sealed_tx_sig,
+            },
+        )
+
+        # Assertion
+        assert resp.status_code == 200
+        assert resp.json() is None
+
+        _personal_info_af = db.scalars(select(IDXPersonalInfo).limit(1)).first()
+        assert _personal_info_af.issuer_address == self.test_issuer_address
+        assert _personal_info_af.account_address == self.test_account_address
+        assert _personal_info_af.personal_info == {
+            "key_manager": "test_key_manager_2",
+            "name": "test_name_2",
+            "postal_code": "test_postal_code_2",
+            "address": "test_address_2",
+            "email": "test_email_2",
+            "birth": "test_birth_2",
+            "is_corporate": True,
+            "tax_category": 20,
+        }
+        assert _personal_info_af.data_source == PersonalInfoDataSource.OFF_CHAIN
+
+        _history = db.scalars(select(IDXPersonalInfoHistory).limit(1)).first()
+        assert _history.issuer_address == self.test_issuer_address
+        assert _history.account_address == self.test_account_address
+        assert _history.event_type == PersonalInfoEventType.REGISTER
+        assert _history.personal_info == {
+            "key_manager": "test_key_manager_2",
+            "name": "test_name_2",
+            "postal_code": "test_postal_code_2",
+            "address": "test_address_2",
+            "email": "test_email_2",
+            "birth": "test_birth_2",
+            "is_corporate": True,
+            "tax_category": 20,
+        }
+        assert _history.block_timestamp == datetime.datetime(2024, 9, 30, 12, 34, 56)
+
+    ###########################################################################
+    # Error Case
+    ###########################################################################
+
+    # <Error_1>
+    # RequestValidationError
+    # Missing X-SealedTx-Signature header
+    def test_error_1(self, client, db):
+        _params = {
+            "link_address": self.test_issuer_address,
+            "personal_information": {
+                "key_manager": "test_key_manager",
+                "name": "test_name",
+                "postal_code": "test_postal_code",
+                "address": "test_address",
+                "email": "test_email",
+                "birth": "test_birth",
+                "is_corporate": False,
+                "tax_category": 10,
+            },
+        }
+
+        # Call API
+        resp = client.post(
+            self.url,
+            json=_params,
+            headers={
+                "Content-Type": "application/json",
+            },
+        )
+
+        # Assertion
+        assert resp.status_code == 422
+        assert resp.json() == {
+            "meta": {"code": 1, "title": "RequestValidationError"},
+            "detail": [
+                {
+                    "type": "missing",
+                    "loc": ["header", "X-SealedTx-Signature"],
+                    "msg": "Field required",
+                    "input": None,
+                }
+            ],
+        }
+
+    # <Error_2>
+    # Missing required field: key_manager
+    def test_error_2(self, client, db):
+        # Derive a signature
+        _params = {
+            "link_address": self.test_issuer_address,
+            "personal_information": {},
+        }
+        _sealed_tx_sig = generate_sealed_tx_signature(
+            "POST",
+            self.url,
+            private_key=self.test_account_pk,
+            json=_params,
+        )
+
+        # Call API
+        resp = client.post(
+            self.url,
+            json=_params,
+            headers={
+                "Content-Type": "application/json",
+                "X-SealedTx-Signature": _sealed_tx_sig,
+            },
+        )
+
+        # Assertion
+        assert resp.status_code == 422
+        assert resp.json() == {
+            "meta": {"code": 1, "title": "RequestValidationError"},
+            "detail": [
+                {
+                    "type": "missing",
+                    "loc": ["body", "personal_information", "key_manager"],
+                    "msg": "Field required",
+                    "input": {},
+                }
+            ],
+        }

--- a/tests/app/utils/generate_signature.py
+++ b/tests/app/utils/generate_signature.py
@@ -1,0 +1,84 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import json as j
+
+from eth_account.datastructures import SignedMessage
+from eth_account.messages import encode_defunct
+from web3.auto import w3
+
+
+def _params_to_query_string(params):
+    kvs = []
+    for k, v in sorted(params.items()):
+        if type(v) == int:
+            v = str(v)
+        kvs.append(k + "=" + v)
+
+    if len(kvs) == 0:
+        return ""
+    return "&".join(kvs)
+
+
+def _canonical_request(method, path, request_body, query_string):
+    if request_body is None:
+        request_body = "{}"
+
+    if query_string != "":
+        query_string = "?" + query_string
+
+    request_body_hash = w3.keccak(text=request_body).hex()
+    canonical_request = (
+        method + "\n" + path + "\n" + query_string + "\n" + request_body_hash
+    )
+
+    return canonical_request
+
+
+def _generate_signature(private_key, **kwargs):
+    canonical_request = _canonical_request(**kwargs)
+    signable_message = encode_defunct(text=canonical_request)
+    signed_message: SignedMessage = w3.eth.account.sign_message(
+        signable_message, private_key=private_key
+    )
+    return signed_message.signature.hex()
+
+
+def generate_sealed_tx_signature(
+    method: str,
+    path: str,
+    private_key: str,
+    params: dict | None = None,
+    json: dict | None = None,
+):
+    query_string = ""
+    request_body = None
+    if params is not None:
+        query_string = _params_to_query_string(params)
+    if json is not None:
+        request_body = j.dumps(json, separators=(",", ":"))
+
+    signature = _generate_signature(
+        private_key=private_key,
+        method=method,
+        path=path,
+        request_body=request_body,
+        query_string=query_string,
+    )
+    return signature

--- a/tests/app/utils/test_sealed_tx_utils.py
+++ b/tests/app/utils/test_sealed_tx_utils.py
@@ -1,0 +1,282 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import json
+
+from fastapi import Request
+from fastapi.responses import PlainTextResponse
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.utils.sealedtx_utils import (
+    RawRequestBody,
+    SealedTxSignatureHeader,
+    VerifySealedTxSignature,
+)
+from tests.app.utils.generate_signature import generate_sealed_tx_signature
+
+
+class TestVerifySealedTxSignature:
+    private_key = "0000000000000000000000000000000000000000000000000000000000000001"
+    address = "0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf"
+
+    apiurl = "/test/TestVerifySignature"
+
+    def setup_class(self):
+        # Test API (POST）
+        @app.post("/test/TestVerifySignature", tags=["Test"])
+        def test_post(
+            request: Request,
+            raw_body: RawRequestBody,
+            x_sealed_tx_signature: SealedTxSignatureHeader,
+        ):
+            recovered_address = VerifySealedTxSignature(
+                req=request,
+                body=json.loads(raw_body.decode()) if len(raw_body) > 0 else {},
+                signature=x_sealed_tx_signature,
+            )
+            return PlainTextResponse(recovered_address)
+
+        # Test API（GET）
+        @app.get("/test/TestVerifySignature", tags=["Test"])
+        def test_get(
+            request: Request,
+            x_ibet_signature: SealedTxSignatureHeader,
+        ):
+            recovered_address = VerifySealedTxSignature(
+                req=request, body=None, signature=x_ibet_signature
+            )
+            return PlainTextResponse(recovered_address)
+
+        self.cli = TestClient(app)
+
+    ###########################################################################
+    # Normal
+    ###########################################################################
+
+    # Normal_1
+    # With query string and request body
+    # POST
+    def test_normal_1(self):
+        signature = generate_sealed_tx_signature(
+            "POST",
+            self.apiurl,
+            private_key=self.private_key,
+            params={"password": "123", "name": "abcd"},
+            json={"address":"Tokyo, Japan"},  # NOTE: JSON format without whitespace
+        )
+
+        resp = self.cli.post(
+            self.apiurl,
+            params={
+                "password": 123,
+                "name": "abcd",
+            },
+            content=json.dumps(
+                {"address":"Tokyo, Japan"},  # NOTE: JSON format without whitespace
+                separators=(",", ":")
+            ),
+            headers={
+                "Content-Type": "application/json",
+                "X-SealedTx-Signature": signature,
+            },
+        )
+
+        assert resp.status_code == 200
+        assert resp.text == self.address
+
+    # Normal_2_1
+    # With query string and no request body
+    # POST
+    def test_normal_2_1(self, client):
+        signature = generate_sealed_tx_signature(
+            "POST",
+            self.apiurl,
+            private_key=self.private_key,
+            params={"password": "123", "name": "abcd"},
+        )
+
+        resp = self.cli.post(
+            self.apiurl,
+            params={
+                "password": 123,
+                "name": "abcd",
+            },
+            headers={
+                "X-SealedTx-Signature": signature,
+            },
+        )
+
+        assert resp.status_code == 200
+        assert resp.text == self.address
+
+    # Normal_2_2
+    # With query string and no request body
+    # GET
+    def test_normal_2_2(self, client):
+        signature = generate_sealed_tx_signature(
+            "GET",
+            self.apiurl,
+            private_key=self.private_key,
+            params={"password": "123", "name": "abcd"},
+        )
+
+        resp = self.cli.get(
+            self.apiurl,
+            params={
+                "password": 123,
+                "name": "abcd",
+            },
+            headers={
+                "X-SealedTx-Signature": signature,
+            },
+        )
+
+        assert resp.status_code == 200
+        assert resp.text == self.address
+
+    # Normal_3_1
+    # Without query string and with request body
+    # Standard JSON format
+    # POST
+    def test_normal_3_1(self, client):
+        signature = generate_sealed_tx_signature(
+            "POST",
+            self.apiurl,
+            private_key=self.private_key,
+            json={"address": "Tokyo, Japan"},
+        )
+
+        res = self.cli.post(
+            self.apiurl,
+            json={"address": "Tokyo, Japan"},
+            headers={
+                "Content-Type": "application/json",
+                "X-SealedTx-Signature": signature,
+            },
+        )
+
+        assert res.status_code == 200
+        assert res.text == self.address
+
+    # Normal_3_2
+    # Without query string and with request body
+    # JSON format without whitespace
+    # POST
+    def test_normal_3_2(self, client):
+        signature = generate_sealed_tx_signature(
+            "POST",
+            self.apiurl,
+            private_key=self.private_key,
+            json={"address":"Tokyo, Japan"},  # NOTE: JSON format without whitespace
+        )
+
+        res = self.cli.post(
+            self.apiurl,
+            content=json.dumps(
+                {"address":"Tokyo, Japan"},  # NOTE: JSON format without whitespace
+                separators=(",", ":")
+            ),
+            headers={
+                "Content-Type": "application/json",
+                "X-SealedTx-Signature": signature,
+            },
+        )
+
+        assert res.status_code == 200
+        assert res.text == self.address
+
+    ###########################################################################
+    # Error
+    ###########################################################################
+
+    # Error_1
+    # Invalid signature
+    def test_error_1(self):
+        resp = self.cli.post(
+            self.apiurl,
+            params={
+                "password": 123,
+                "name": "abcd",
+            },
+            json={"address": "Tokyo, Japan"},
+            headers={
+                "Content-Type": "application/json",
+                "X-SealedTx-Signature": "0xaf7117049ab338ea7fa432439172a0e2f5cd02cec8d673dac6b7abc10b6c969c53d3f8846c452581ccdb8712607d9fe3da9fe7b64ee778d2233d29ea102b9d0a1b",
+            },
+        )
+
+        assert resp.status_code == 200
+        assert resp.text != self.address
+
+    # Error_2
+    # Missing signature
+    def test_error_2(self):
+        resp = self.cli.post(
+            self.apiurl,
+            params={
+                "password": 123,
+                "name": "abcd",
+            },
+            json={"address": "Tokyo, Japan"},
+            headers={
+                "Content-Type": "application/json",
+            },
+        )
+
+        assert resp.status_code == 422
+        assert resp.json() == {
+            "meta": {
+                "code": 1,
+                "title": "RequestValidationError"
+            },
+            "detail": [
+                {
+                    "type": "missing",
+                    "loc": ["header", "X-SealedTx-Signature"],
+                    "msg": "Field required",
+                    "input": None
+                }
+            ]
+        }
+
+    # Error_3
+    # Signature format is invalid
+    def test_error_3(self):
+        resp = self.cli.post(
+            self.apiurl,
+            params={
+                "password": 123,
+                "name": "abcd",
+            },
+            json={"address": "Tokyo, Japan"},
+            headers={
+                "Content-Type": "application/json",
+                "X-SealedTx-Signature": "0xaf7117049ab338ea7f",
+            },
+        )
+
+        assert resp.status_code == 400
+        assert resp.json() == {
+            "meta": {
+                "code": 1,
+                "title": "InvalidParameterError"
+            },
+            "detail": "failed to recover hash"
+        }


### PR DESCRIPTION
close #689 

Add SealedTx feature 🚀 

- As a simple implementation, I decided to overwrite the data of PersonalInfo if it already exists. 
- Therefore, if there is a delay in reflecting on-chain information, it is possible that it may be overwritten again by the on-chain information. However, since it seems there are no use cases that utilize both on-chain and off-chain transactions, I have decided not to consider this for now.