### PR TITLE
Refine transfer data schema to classify transfer data derived from Unlock events

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ lint:
 	poetry run ruff check --fix
 
 doc:
-	poetry run python docs/generate_openapi_doc.py
+	DVP_AGENT_FEATURE_ENABLED=1 BC_EXPLORER_ENABLED=1 FREEZE_LOG_FEATURE_ENABLED=1 poetry run python docs/generate_openapi_doc.py
 
 test:
 	pytest tests/

--- a/app/model/db/__init__.py
+++ b/app/model/db/__init__.py
@@ -71,10 +71,10 @@ from .idx_position import (
     IDXPositionShareBlockNumber,
 )
 from .idx_transfer import (
+    DataMessage,
     IDXTransfer,
     IDXTransferBlockNumber,
     IDXTransferSourceEventType,
-    UnlockData,
 )
 from .idx_transfer_approval import (
     IDXTransferApproval,

--- a/app/model/db/__init__.py
+++ b/app/model/db/__init__.py
@@ -74,6 +74,7 @@ from .idx_transfer import (
     IDXTransfer,
     IDXTransferBlockNumber,
     IDXTransferSourceEventType,
+    UnlockData,
 )
 from .idx_transfer_approval import (
     IDXTransferApproval,

--- a/app/model/db/idx_transfer.py
+++ b/app/model/db/idx_transfer.py
@@ -35,7 +35,7 @@ class IDXTransferSourceEventType(StrEnum):
     UNLOCK = "Unlock"
 
 
-class UnlockData(BaseModel):
+class DataMessage(BaseModel):
     message: Literal[
         "garnishment",
         "inheritance",
@@ -65,7 +65,7 @@ class IDXTransfer(Base):
     #   source_event = "Transfer"
     #     => None
     #   source_event = "Unlock"
-    #     =>  UnlockData
+    #     =>  DataMessage
     data: Mapped[dict | None] = mapped_column(JSON)
     # Message
     #   source_event = "Transfer"

--- a/app/model/db/idx_transfer.py
+++ b/app/model/db/idx_transfer.py
@@ -19,7 +19,9 @@ SPDX-License-Identifier: Apache-2.0
 
 from datetime import datetime
 from enum import StrEnum
+from typing import Literal
 
+from pydantic import BaseModel
 from sqlalchemy import JSON, BigInteger, DateTime, String
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -31,6 +33,14 @@ class IDXTransferSourceEventType(StrEnum):
 
     TRANSFER = "Transfer"
     UNLOCK = "Unlock"
+
+
+class UnlockData(BaseModel):
+    message: Literal[
+        "garnishment",
+        "inheritance",
+        "force_unlock",
+    ]
 
 
 class IDXTransfer(Base):
@@ -52,8 +62,16 @@ class IDXTransfer(Base):
     # Source Event (IDXTransferSourceEventType)
     source_event: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
     # Data
+    #   source_event = "Transfer"
+    #     => None
+    #   source_event = "Unlock"
+    #     =>  UnlockData
     data: Mapped[dict | None] = mapped_column(JSON)
     # Message
+    #   source_event = "Transfer"
+    #     => None
+    #   source_event = "Unlock"
+    #     => "force_unlock", "garnishment" or "inheritance"
     message: Mapped[str | None] = mapped_column(String(50), index=True)
     # block timestamp
     block_timestamp: Mapped[datetime | None] = mapped_column(DateTime)

--- a/app/model/db/idx_transfer.py
+++ b/app/model/db/idx_transfer.py
@@ -50,9 +50,11 @@ class IDXTransfer(Base):
     # transfer amount
     amount: Mapped[int | None] = mapped_column(BigInteger)
     # Source Event (IDXTransferSourceEventType)
-    source_event: Mapped[str] = mapped_column(String(50), nullable=False)
+    source_event: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
     # Data
     data: Mapped[dict | None] = mapped_column(JSON)
+    # Message
+    message: Mapped[str | None] = mapped_column(String(50), index=True)
     # block timestamp
     block_timestamp: Mapped[datetime | None] = mapped_column(DateTime)
 

--- a/app/model/schema/__init__.py
+++ b/app/model/schema/__init__.py
@@ -191,7 +191,6 @@ from .transfer import (
     TransferApprovalTokenDetailResponse,
     TransferApprovalTokenResponse,
     TransferHistoryResponse,
-    TransferResponse,
     UpdateTransferApprovalOperationType,
     UpdateTransferApprovalRequest,
 )

--- a/app/model/schema/transfer.py
+++ b/app/model/schema/transfer.py
@@ -69,7 +69,7 @@ class Transfer(TransferBase):
     data: None = Field(description="Event data")
 
 
-class UnlockData(BaseModel):
+class DataMessage(BaseModel):
     message: Literal[
         "garnishment",
         "inheritance",
@@ -81,7 +81,7 @@ class UnlockTransfer(TransferBase):
     source_event: Literal[TransferSourceEventType.Unlock] = Field(
         description="Source Event"
     )
-    data: UnlockData | dict = Field(description="Event data")
+    data: DataMessage | dict = Field(description="Event data")
 
 
 ############################

--- a/app/model/schema/transfer.py
+++ b/app/model/schema/transfer.py
@@ -19,7 +19,7 @@ SPDX-License-Identifier: Apache-2.0
 
 from datetime import datetime
 from enum import IntEnum, StrEnum
-from typing import List, Optional
+from typing import List, Literal, Optional
 
 from pydantic import BaseModel, Field
 
@@ -47,6 +47,41 @@ class TransferApprovalStatus(IntEnum):
     ESCROW_FINISHED = 1
     TRANSFERRED = 2
     CANCELED = 3
+
+
+class TransferBase(BaseModel):
+    """transfer data base"""
+
+    transaction_hash: str
+    token_address: str
+    from_address: str
+    from_address_personal_information: Optional[PersonalInfo] = Field(...)
+    to_address: str
+    to_address_personal_information: Optional[PersonalInfo] = Field(...)
+    amount: int
+    block_timestamp: str
+
+
+class Transfer(TransferBase):
+    source_event: Literal[TransferSourceEventType.Transfer] = Field(
+        description="Source Event"
+    )
+    data: None = Field(description="Event data")
+
+
+class UnlockData(BaseModel):
+    message: Literal[
+        "garnishment",
+        "inheritance",
+        "force_unlock",
+    ]
+
+
+class UnlockTransfer(TransferBase):
+    source_event: Literal[TransferSourceEventType.Unlock] = Field(
+        description="Source Event"
+    )
+    data: UnlockData | dict = Field(description="Event data")
 
 
 ############################
@@ -87,6 +122,9 @@ class ListTransferHistoryQuery(BasePaginationQuery):
         None, description="Source event of transfer"
     )
     data: Optional[str] = Field(None, description="source event data")
+    message: Optional[
+        Literal["garnishment"] | Literal["inheritance"] | Literal["force_unlock"]
+    ] = Field(None, description="message field in source event data")
 
     sort_item: Optional[ListTransferHistorySortItem] = Field(
         ListTransferHistorySortItem.BLOCK_TIMESTAMP, description="Sort item"
@@ -143,26 +181,11 @@ class ListSpecificTokenTransferApprovalHistoryQuery(BasePaginationQuery):
 ############################
 
 
-class TransferResponse(BaseModel):
-    """transfer data"""
-
-    transaction_hash: str
-    token_address: str
-    from_address: str
-    from_address_personal_information: Optional[PersonalInfo] = Field(...)
-    to_address: str
-    to_address_personal_information: Optional[PersonalInfo] = Field(...)
-    amount: int
-    source_event: TransferSourceEventType = Field(description="Source Event")
-    data: dict | None = Field(description="Event data")
-    block_timestamp: str
-
-
 class TransferHistoryResponse(BaseModel):
     """transfer history"""
 
     result_set: ResultSet
-    transfer_history: List[TransferResponse]
+    transfer_history: List[Transfer | UnlockTransfer]
 
 
 class TransferApprovalResponse(BaseModel):

--- a/app/routers/issuer/bond.py
+++ b/app/routers/issuer/bond.py
@@ -3055,6 +3055,8 @@ async def list_bond_token_transfer_history(
         stmt = stmt.where(IDXTransfer.source_event == query.source_event)
     if query.data is not None:
         stmt = stmt.where(cast(IDXTransfer.data, String).like("%" + query.data + "%"))
+    if query.message is not None:
+        stmt = stmt.where(IDXTransfer.message == query.message)
     count = await db.scalar(select(func.count()).select_from(stmt.subquery()))
 
     # Sort

--- a/app/routers/issuer/position.py
+++ b/app/routers/issuer/position.py
@@ -17,6 +17,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
+import json
 from typing import Annotated, Optional, Sequence
 
 from eth_keyfile import decode_keyfile_json
@@ -530,7 +531,7 @@ async def force_unlock(
         "account_address": account_address,
         "recipient_address": data.recipient_address,
         "value": data.value,
-        "data": "",
+        "data": json.dumps({"message": "force_unlock"}),
     }
     try:
         await IbetSecurityTokenInterface(data.token_address).force_unlock(

--- a/app/routers/issuer/settlement_issuer.py
+++ b/app/routers/issuer/settlement_issuer.py
@@ -145,6 +145,8 @@ async def list_all_dvp_deliveries(
         stmt = stmt.order_by(IDXDelivery.create_blocktimestamp)
     else:  # DESC
         stmt = stmt.order_by(desc(IDXDelivery.create_blocktimestamp))
+    # NOTE: Set secondary sort for consistent results
+    stmt = stmt.order_by(IDXDelivery.delivery_id)
 
     # Pagination
     if request_query.limit is not None:

--- a/app/routers/issuer/share.py
+++ b/app/routers/issuer/share.py
@@ -2993,6 +2993,8 @@ async def list_share_token_transfer_history(
         stmt = stmt.where(IDXTransfer.source_event == query.source_event)
     if query.data is not None:
         stmt = stmt.where(cast(IDXTransfer.data, String).like("%" + query.data + "%"))
+    if query.message is not None:
+        stmt = stmt.where(IDXTransfer.message == query.message)
     count = await db.scalar(select(func.count()).select_from(stmt.subquery()))
 
     # Sort

--- a/app/routers/misc/settlement_agent.py
+++ b/app/routers/misc/settlement_agent.py
@@ -300,6 +300,8 @@ async def list_all_dvp_agent_deliveries(
         stmt = stmt.order_by(IDXDelivery.create_blocktimestamp)
     else:  # DESC
         stmt = stmt.order_by(desc(IDXDelivery.create_blocktimestamp))
+    # NOTE: Set secondary sort for consistent results
+    stmt = stmt.order_by(IDXDelivery.delivery_id)
 
     # Pagination
     if request_query.limit is not None:

--- a/batch/indexer_transfer.py
+++ b/batch/indexer_transfer.py
@@ -35,11 +35,11 @@ from app.database import BatchAsyncSessionLocal
 from app.exceptions import ServiceUnavailableError
 from app.model.db import (
     Account,
+    DataMessage,
     IDXTransfer,
     IDXTransferBlockNumber,
     IDXTransferSourceEventType,
     Token,
-    UnlockData,
 )
 from app.utils.contract_utils import AsyncContractUtils
 from app.utils.web3_utils import AsyncWeb3Wrapper
@@ -286,7 +286,7 @@ class Processor:
         if data_str is not None:
             try:
                 data = json.loads(data_str)
-                validated_data = UnlockData(**data)
+                validated_data = DataMessage(**data)
                 message = validated_data.message
             except ValidationError:
                 data = {}

--- a/batch/indexer_transfer.py
+++ b/batch/indexer_transfer.py
@@ -25,6 +25,7 @@ from typing import Sequence
 
 import uvloop
 from eth_utils import to_checksum_address
+from pydantic import ValidationError
 from sqlalchemy import and_, select
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -38,6 +39,7 @@ from app.model.db import (
     IDXTransferBlockNumber,
     IDXTransferSourceEventType,
     Token,
+    UnlockData,
 )
 from app.utils.contract_utils import AsyncContractUtils
 from app.utils.web3_utils import AsyncWeb3Wrapper
@@ -284,7 +286,11 @@ class Processor:
         if data_str is not None:
             try:
                 data = json.loads(data_str)
-                message = data.get("message", "")[0:50]
+                validated_data = UnlockData(**data)
+                message = validated_data.message
+            except ValidationError:
+                data = {}
+                message = None
             except json.JSONDecodeError:
                 data = {}
                 message = None

--- a/batch/indexer_transfer.py
+++ b/batch/indexer_transfer.py
@@ -284,10 +284,13 @@ class Processor:
         if data_str is not None:
             try:
                 data = json.loads(data_str)
+                message = data.get("message", "")[0:50]
             except json.JSONDecodeError:
                 data = {}
+                message = None
         else:
             data = None
+            message = None
         transfer_record = IDXTransfer()
         transfer_record.transaction_hash = transaction_hash
         transfer_record.token_address = token_address
@@ -296,6 +299,7 @@ class Processor:
         transfer_record.amount = amount
         transfer_record.source_event = source_event.value
         transfer_record.data = data
+        transfer_record.message = message
         transfer_record.block_timestamp = block_timestamp
         db_session.add(transfer_record)
         LOG.debug(f"Transfer: transaction_hash={transaction_hash}")

--- a/docs/ibet_prime.yaml
+++ b/docs/ibet_prime.yaml
@@ -11153,6 +11153,19 @@ components:
         - notice_type
         - metainfo
       title: DVPDeliveryInfoNotification
+    DataMessage:
+      properties:
+        message:
+          type: string
+          enum:
+            - garnishment
+            - inheritance
+            - force_unlock
+          title: Message
+      type: object
+      required:
+        - message
+      title: DataMessage
     DeliveryStatus:
       type: integer
       enum:
@@ -15422,19 +15435,6 @@ components:
       allOf:
         - $ref: '#/components/schemas/TxDataDetail'
       title: TxDataResponse
-    UnlockData:
-      properties:
-        message:
-          type: string
-          enum:
-            - garnishment
-            - inheritance
-            - force_unlock
-          title: Message
-      type: object
-      required:
-        - message
-      title: UnlockData
     UnlockInfoMetaInfo:
       properties:
         token_address:
@@ -15542,7 +15542,7 @@ components:
           description: Source Event
         data:
           anyOf:
-            - $ref: '#/components/schemas/UnlockData'
+            - $ref: '#/components/schemas/DataMessage'
             - type: object
           title: Data
           description: Event data

--- a/docs/ibet_prime.yaml
+++ b/docs/ibet_prime.yaml
@@ -2970,6 +2970,27 @@ paths:
             description: source event data
             title: Data
           description: source event data
+        - name: message
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - enum:
+                  - garnishment
+                const: garnishment
+                type: string
+              - enum:
+                  - inheritance
+                const: inheritance
+                type: string
+              - enum:
+                  - force_unlock
+                const: force_unlock
+                type: string
+              - type: 'null'
+            description: message field in source event data
+            title: Message
+          description: message field in source event data
         - name: sort_item
           in: query
           required: false
@@ -7332,6 +7353,27 @@ paths:
             description: source event data
             title: Data
           description: source event data
+        - name: message
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - enum:
+                  - garnishment
+                const: garnishment
+                type: string
+              - enum:
+                  - inheritance
+                const: inheritance
+                type: string
+              - enum:
+                  - force_unlock
+                const: force_unlock
+                type: string
+              - type: 'null'
+            description: message field in source event data
+            title: Message
+          description: message field in source event data
         - name: sort_item
           in: query
           required: false
@@ -8796,809 +8838,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/InvalidParameterErrorResponse'
-  /settlement/dvp/agent/accounts:
-    get:
-      tags:
-        - '[misc] settlement_agent'
-      summary: List All Accounts
-      description: List all DVP-Payment Agent accounts
-      operationId: ListAllDVPAgentAccounts
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ListAllDVPAgentAccountResponse'
-    post:
-      tags:
-        - '[misc] settlement_agent'
-      summary: Create Account
-      description: Create DVP-Payment Agent Account
-      operationId: CreateDVPAgentAccount
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CreateDVPAgentAccountRequest'
-        required: true
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DVPAgentAccountResponse'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error422Model'
-        '400':
-          description: Invalid Parameter Error / Send Transaction Error / Contract
-            Revert Error etc
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InvalidParameterErrorResponse'
-  /settlement/dvp/agent/account/{account_address}:
-    delete:
-      tags:
-        - '[misc] settlement_agent'
-      summary: Delete Account
-      description: Logically delete an DVP-Payment Agent Account
-      operationId: DeleteDVPAgentAccount
-      parameters:
-        - name: account_address
-          in: path
-          required: true
-          schema:
-            type: string
-            title: Account Address
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DVPAgentAccountResponse'
-        '404':
-          description: Not Found Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error404Model'
-  /settlement/dvp/agent/account/{account_address}/eoa_password:
-    post:
-      tags:
-        - '[misc] settlement_agent'
-      summary: Change Eoa Password
-      description: Change Agent's EOA Password
-      operationId: ChangeDVPAgentAccountPassword
-      parameters:
-        - name: account_address
-          in: path
-          required: true
-          schema:
-            type: string
-            title: Account Address
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/DVPAgentAccountChangeEOAPasswordRequest'
-      responses:
-        '200':
-          description: Successful Response
-        '404':
-          description: Not Found Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error404Model'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error422Model'
-        '400':
-          description: Invalid Parameter Error / Send Transaction Error / Contract
-            Revert Error etc
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InvalidParameterErrorResponse'
-  /settlement/dvp/agent/{exchange_address}/deliveries:
-    get:
-      tags:
-        - '[misc] settlement_agent'
-      summary: List All Dvp Agent Deliveries
-      description: List all DVP deliveries for paying agent
-      operationId: ListAllDVPAgentDeliveries
-      parameters:
-        - name: exchange_address
-          in: path
-          required: true
-          schema:
-            type: string
-            title: Exchange Address
-        - name: offset
-          in: query
-          required: false
-          schema:
-            anyOf:
-              - type: integer
-                minimum: 0
-              - type: 'null'
-            description: Offset for pagination
-            title: Offset
-          description: Offset for pagination
-        - name: limit
-          in: query
-          required: false
-          schema:
-            anyOf:
-              - type: integer
-                minimum: 0
-              - type: 'null'
-            description: Limit for pagination
-            title: Limit
-          description: Limit for pagination
-        - name: agent_address
-          in: query
-          required: true
-          schema:
-            type: string
-            description: Agent address
-            title: Agent Address
-          description: Agent address
-        - name: token_address
-          in: query
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: Token address
-            title: Token Address
-          description: Token address
-        - name: seller_address
-          in: query
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: Seller address
-            title: Seller Address
-          description: Seller address
-        - name: buyer_address
-          in: query
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: Buyer address
-            title: Buyer Address
-          description: Buyer address
-        - name: valid
-          in: query
-          required: false
-          schema:
-            anyOf:
-              - type: boolean
-              - type: 'null'
-            description: Valid flag
-            title: Valid
-          description: Valid flag
-        - name: status
-          in: query
-          required: false
-          schema:
-            anyOf:
-              - $ref: '#/components/schemas/DeliveryStatus'
-              - type: 'null'
-            description: Delivery status
-            title: Status
-          description: Delivery status
-        - name: create_blocktimestamp_from
-          in: query
-          required: false
-          schema:
-            anyOf:
-              - type: string
-                format: date-time
-              - type: 'null'
-            description: Create block timestamp filter(From)
-            title: Create Blocktimestamp From
-          description: Create block timestamp filter(From)
-        - name: create_blocktimestamp_to
-          in: query
-          required: false
-          schema:
-            anyOf:
-              - type: string
-                format: date-time
-              - type: 'null'
-            description: Create block timestamp filter(To)
-            title: Create Blocktimestamp To
-          description: Create block timestamp filter(To)
-        - name: sort_order
-          in: query
-          required: false
-          schema:
-            anyOf:
-              - $ref: '#/components/schemas/SortOrder'
-              - type: 'null'
-            description: 'Sort order (0: ASC, 1: DESC)'
-            default: 1
-            title: Sort Order
-          description: 'Sort order (0: ASC, 1: DESC)'
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ListAllDVPAgentDeliveriesResponse'
-        '404':
-          description: Not Found Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error404Model'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error422Model'
-        '400':
-          description: Invalid Parameter Error / Send Transaction Error / Contract
-            Revert Error etc
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InvalidParameterErrorResponse'
-  /settlement/dvp/agent/{exchange_address}/delivery/{delivery_id}:
-    post:
-      tags:
-        - '[misc] settlement_agent'
-      summary: Update Dvp Agent Delivery
-      description: Finish/Abort DVP delivery
-      operationId: UpdateDVPAgentDelivery
-      parameters:
-        - name: exchange_address
-          in: path
-          required: true
-          schema:
-            type: string
-            title: Exchange Address
-        - name: delivery_id
-          in: path
-          required: true
-          schema:
-            type: string
-            title: Delivery Id
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              anyOf:
-                - $ref: '#/components/schemas/FinishDVPDeliveryRequest'
-                - $ref: '#/components/schemas/AbortDVPDeliveryRequest'
-              title: Data
-      responses:
-        '200':
-          description: Successful Response
-        '404':
-          description: Not Found Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error404Model'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error422Model'
-        '400':
-          description: Invalid Parameter Error / Send Transaction Error / Contract
-            Revert Error etc
-          content:
-            application/json:
-              schema:
-                anyOf:
-                  - $ref: '#/components/schemas/InvalidParameterErrorResponse'
-                  - $ref: '#/components/schemas/SendTransactionErrorResponse'
-                title: Response 400 Updatedvpagentdelivery
-  /blockchain_explorer/block_data:
-    get:
-      tags:
-        - '[misc] blockchain_explorer'
-      summary: '[ibet Blockchain Explorer] List block data'
-      description: |-
-        Returns a list of block data within the specified block number range.
-        The maximum number of search results is 1000.
-      operationId: ListBlockData
-      parameters:
-        - name: offset
-          in: query
-          required: false
-          schema:
-            anyOf:
-              - type: integer
-                minimum: 0
-              - type: 'null'
-            description: Offset for pagination
-            title: Offset
-          description: Offset for pagination
-        - name: limit
-          in: query
-          required: false
-          schema:
-            anyOf:
-              - type: integer
-                minimum: 0
-              - type: 'null'
-            description: Limit for pagination
-            title: Limit
-          description: Limit for pagination
-        - name: from_block_number
-          in: query
-          required: false
-          schema:
-            anyOf:
-              - type: integer
-                minimum: 0
-              - type: 'null'
-            title: From Block Number
-        - name: to_block_number
-          in: query
-          required: false
-          schema:
-            anyOf:
-              - type: integer
-                minimum: 0
-              - type: 'null'
-            title: To Block Number
-        - name: sort_order
-          in: query
-          required: false
-          schema:
-            anyOf:
-              - $ref: '#/components/schemas/SortOrder'
-              - type: 'null'
-            description: 'Sort order (0: ASC, 1: DESC)'
-            default: 0
-            title: Sort Order
-          description: 'Sort order (0: ASC, 1: DESC)'
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BlockDataListResponse'
-        '404':
-          description: Not Found Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error404Model'
-        '400':
-          description: Invalid Parameter Error / Send Transaction Error / Contract
-            Revert Error etc
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ResponseLimitExceededErrorResponse'
-  /blockchain_explorer/block_data/{block_number}:
-    get:
-      tags:
-        - '[misc] blockchain_explorer'
-      summary: '[ibet Blockchain Explorer] Retrieve block data'
-      description: Returns block data in the specified block number.
-      operationId: GetBlockData
-      parameters:
-        - name: block_number
-          in: path
-          required: true
-          schema:
-            type: integer
-            minimum: 0
-            description: Block number
-            title: Block Number
-          description: Block number
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BlockDataResponse'
-        '404':
-          description: Not Found Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error404Model'
-  /blockchain_explorer/tx_data:
-    get:
-      tags:
-        - '[misc] blockchain_explorer'
-      summary: '[ibet Blockchain Explorer] List tx data'
-      description: |-
-        Returns a list of transactions by various search parameters.
-        The maximum number of search results is 10000.
-      operationId: ListTxData
-      parameters:
-        - name: offset
-          in: query
-          required: false
-          schema:
-            anyOf:
-              - type: integer
-                minimum: 0
-              - type: 'null'
-            description: Offset for pagination
-            title: Offset
-          description: Offset for pagination
-        - name: limit
-          in: query
-          required: false
-          schema:
-            anyOf:
-              - type: integer
-                minimum: 0
-              - type: 'null'
-            description: Limit for pagination
-            title: Limit
-          description: Limit for pagination
-        - name: block_number
-          in: query
-          required: false
-          schema:
-            anyOf:
-              - type: integer
-                minimum: 0
-              - type: 'null'
-            description: block number
-            title: Block Number
-          description: block number
-        - name: from_address
-          in: query
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: tx from
-            title: From Address
-          description: tx from
-        - name: to_address
-          in: query
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: tx to
-            title: To Address
-          description: tx to
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TxDataListResponse'
-        '404':
-          description: Not Found Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error404Model'
-        '400':
-          description: Invalid Parameter Error / Send Transaction Error / Contract
-            Revert Error etc
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ResponseLimitExceededErrorResponse'
-  /blockchain_explorer/tx_data/{hash}:
-    get:
-      tags:
-        - '[misc] blockchain_explorer'
-      summary: '[ibet Blockchain Explorer] Retrieve transaction data'
-      description: Searching for the transaction by transaction hash
-      operationId: GetTxData
-      parameters:
-        - name: hash
-          in: path
-          required: true
-          schema:
-            type: string
-            description: Transaction hash
-            title: Hash
-          description: Transaction hash
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TxDataResponse'
-        '404':
-          description: Not Found Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error404Model'
-  /freeze_log/accounts:
-    get:
-      tags:
-        - '[misc] freeze_log'
-      summary: List All Accounts
-      description: List all freeze-logging accounts
-      operationId: ListAllFreezeLogAccount
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ListAllFreezeLogAccountResponse'
-    post:
-      tags:
-        - '[misc] freeze_log'
-      summary: Create Account
-      description: Create Freeze-Logging Account
-      operationId: CreateFreezeLogAccount
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CreateFreezeLogAccountRequest'
-        required: true
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/FreezeLogAccountResponse'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error422Model'
-        '400':
-          description: Invalid Parameter Error / Send Transaction Error / Contract
-            Revert Error etc
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InvalidParameterErrorResponse'
-  /freeze_log/accounts/{account_address}:
-    delete:
-      tags:
-        - '[misc] freeze_log'
-      summary: Delete Account
-      description: Logically delete an freeze-logging account
-      operationId: DeleteFreezeLogAccount
-      parameters:
-        - name: account_address
-          in: path
-          required: true
-          schema:
-            type: string
-            title: Account Address
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/FreezeLogAccountResponse'
-        '404':
-          description: Not Found Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error404Model'
-  /freeze_log/accounts/{account_address}/eoa_password:
-    post:
-      tags:
-        - '[misc] freeze_log'
-      summary: Change Eoa Password
-      description: Change Account's EOA Password
-      operationId: ChangeFreezeLogAccountPassword
-      parameters:
-        - name: account_address
-          in: path
-          required: true
-          schema:
-            type: string
-            title: Account Address
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/FreezeLogAccountChangeEOAPasswordRequest'
-      responses:
-        '200':
-          description: Successful Response
-        '404':
-          description: Not Found Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error404Model'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error422Model'
-        '400':
-          description: Invalid Parameter Error / Send Transaction Error / Contract
-            Revert Error etc
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InvalidParameterErrorResponse'
-  /freeze_log/logs:
-    post:
-      tags:
-        - '[misc] freeze_log'
-      summary: Record New Log
-      operationId: RecordNewFreezeLog
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RecordNewFreezeLogRequest'
-        required: true
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RecordNewFreezeLogResponse'
-        '404':
-          description: Not Found Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error404Model'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error422Model'
-        '400':
-          description: Invalid Parameter Error / Send Transaction Error / Contract
-            Revert Error etc
-          content:
-            application/json:
-              schema:
-                anyOf:
-                  - $ref: '#/components/schemas/InvalidParameterErrorResponse'
-                  - $ref: '#/components/schemas/SendTransactionErrorResponse'
-                title: Response 400 Recordnewfreezelog
-  /freeze_log/logs/{log_index}:
-    post:
-      tags:
-        - '[misc] freeze_log'
-      summary: Update Log
-      operationId: UpdateFreezeLog
-      parameters:
-        - name: log_index
-          in: path
-          required: true
-          schema:
-            type: integer
-            description: Log index
-            title: Log Index
-          description: Log index
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/UpdateFreezeLogRequest'
-      responses:
-        '200':
-          description: Successful Response
-        '404':
-          description: Not Found Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error404Model'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error422Model'
-        '400':
-          description: Invalid Parameter Error / Send Transaction Error / Contract
-            Revert Error etc
-          content:
-            application/json:
-              schema:
-                anyOf:
-                  - $ref: '#/components/schemas/InvalidParameterErrorResponse'
-                  - $ref: '#/components/schemas/SendTransactionErrorResponse'
-                title: Response 400 Updatefreezelog
-    get:
-      tags:
-        - '[misc] freeze_log'
-      summary: Retrieve Log
-      operationId: RetrieveFreezeLog
-      parameters:
-        - name: log_index
-          in: path
-          required: true
-          schema:
-            type: integer
-            description: Log index
-            title: Log Index
-          description: Log index
-        - name: account_address
-          in: query
-          required: true
-          schema:
-            type: string
-            description: Logging account address
-            title: Account Address
-          description: Logging account address
-      responses:
-        '200':
-          description: Successful Response
-        '404':
-          description: Not Found Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error404Model'
 components:
   schemas:
-    AbortDVPDeliveryRequest:
-      properties:
-        operation_type:
-          type: string
-          enum:
-            - Abort
-          const: Abort
-          title: Operation Type
-        account_address:
-          type: string
-          title: Account Address
-          description: Agent account address
-        eoa_password:
-          type: string
-          title: Eoa Password
-          description: Agent account key file password
-      type: object
-      required:
-        - operation_type
-        - account_address
-        - eoa_password
-      title: AbortDVPDeliveryRequest
-      description: DVP delivery abort schema (REQUEST)
     Account:
       properties:
         issuer_address:
@@ -10053,148 +9294,6 @@ components:
         - failed
       title: BatchRegisterPersonalInfoUploadStatus
       description: Batch Register PersonalInfo Upload Status
-    BlockData:
-      properties:
-        number:
-          type: integer
-          minimum: 0.0
-          title: Number
-          description: Block number
-        hash:
-          type: string
-          title: Hash
-          description: Block hash
-        transactions:
-          items:
-            type: string
-          type: array
-          title: Transactions
-          description: Transaction list
-        timestamp:
-          type: integer
-          title: Timestamp
-        gas_limit:
-          type: integer
-          title: Gas Limit
-        gas_used:
-          type: integer
-          title: Gas Used
-        size:
-          type: integer
-          minimum: 0.0
-          title: Size
-      type: object
-      required:
-        - number
-        - hash
-        - transactions
-        - timestamp
-        - gas_limit
-        - gas_used
-        - size
-      title: BlockData
-    BlockDataDetail:
-      properties:
-        number:
-          type: integer
-          minimum: 0.0
-          title: Number
-          description: Block number
-        parent_hash:
-          type: string
-          title: Parent Hash
-        sha3_uncles:
-          type: string
-          title: Sha3 Uncles
-        miner:
-          type: string
-          title: Miner
-        state_root:
-          type: string
-          title: State Root
-        transactions_root:
-          type: string
-          title: Transactions Root
-        receipts_root:
-          type: string
-          title: Receipts Root
-        logs_bloom:
-          type: string
-          title: Logs Bloom
-        difficulty:
-          type: integer
-          title: Difficulty
-        gas_limit:
-          type: integer
-          title: Gas Limit
-        gas_used:
-          type: integer
-          title: Gas Used
-        timestamp:
-          type: integer
-          title: Timestamp
-        proof_of_authority_data:
-          type: string
-          title: Proof Of Authority Data
-        mix_hash:
-          type: string
-          title: Mix Hash
-        nonce:
-          type: string
-          title: Nonce
-        hash:
-          type: string
-          title: Hash
-          description: Block hash
-        size:
-          type: integer
-          minimum: 0.0
-          title: Size
-        transactions:
-          items:
-            type: string
-          type: array
-          title: Transactions
-          description: Transaction list
-      type: object
-      required:
-        - number
-        - parent_hash
-        - sha3_uncles
-        - miner
-        - state_root
-        - transactions_root
-        - receipts_root
-        - logs_bloom
-        - difficulty
-        - gas_limit
-        - gas_used
-        - timestamp
-        - proof_of_authority_data
-        - mix_hash
-        - nonce
-        - hash
-        - size
-        - transactions
-      title: BlockDataDetail
-    BlockDataListResponse:
-      properties:
-        result_set:
-          $ref: '#/components/schemas/ResultSet'
-        block_data:
-          items:
-            $ref: '#/components/schemas/BlockData'
-          type: array
-          title: Block Data
-      type: object
-      required:
-        - result_set
-        - block_data
-      title: BlockDataListResponse
-    BlockDataResponse:
-      allOf:
-        - $ref: '#/components/schemas/BlockDataDetail'
-      title: BlockDataResponse
     BlockNumberResponse:
       properties:
         block_number:
@@ -10703,17 +9802,6 @@ components:
         - child_account_index
       title: CreateChildAccountResponse
       description: Create a issuer's child account schema (RESPONSE)
-    CreateDVPAgentAccountRequest:
-      properties:
-        eoa_password:
-          type: string
-          title: Eoa Password
-          description: EOA keyfile password
-      type: object
-      required:
-        - eoa_password
-      title: CreateDVPAgentAccountRequest
-      description: DVP agent account create schema (REQUEST)
     CreateDVPDeliveryRequest:
       properties:
         token_address:
@@ -10746,17 +9834,6 @@ components:
         - settlement_service_type
       title: CreateDVPDeliveryRequest
       description: DVP delivery create schema (REQUEST)
-    CreateFreezeLogAccountRequest:
-      properties:
-        eoa_password:
-          type: string
-          title: Eoa Password
-          description: EOA keyfile password
-      type: object
-      required:
-        - eoa_password
-      title: CreateFreezeLogAccountRequest
-      description: Freeze-Logging account create schema (REQUEST)
     CreateLedgerInfoMetaInfo:
       properties:
         token_address:
@@ -10976,36 +10053,6 @@ components:
         - details
       title: CreateUpdateLedgerTemplateRequest
       description: Create or Update Ledger Template schema (Request)
-    DVPAgentAccountChangeEOAPasswordRequest:
-      properties:
-        old_eoa_password:
-          type: string
-          title: Old Eoa Password
-          description: EOA keyfile password (old)
-        eoa_password:
-          type: string
-          title: Eoa Password
-          description: EOA keyfile password (new)
-      type: object
-      required:
-        - old_eoa_password
-        - eoa_password
-      title: DVPAgentAccountChangeEOAPasswordRequest
-      description: DVP agent account change EOA password schema (REQUEST)
-    DVPAgentAccountResponse:
-      properties:
-        account_address:
-          type: string
-          title: Account Address
-        is_deleted:
-          type: boolean
-          title: Is Deleted
-      type: object
-      required:
-        - account_address
-        - is_deleted
-      title: DVPAgentAccountResponse
-      description: DVP agent account reference schema (RESPONSE)
     DVPDeliveryData:
       properties:
         delivery_type:
@@ -11485,29 +10532,6 @@ components:
         - created
       title: FileResponse
       description: File schema (Response)
-    FinishDVPDeliveryRequest:
-      properties:
-        operation_type:
-          type: string
-          enum:
-            - Finish
-          const: Finish
-          title: Operation Type
-        account_address:
-          type: string
-          title: Account Address
-          description: Agent account address
-        eoa_password:
-          type: string
-          title: Eoa Password
-          description: Agent account key file password
-      type: object
-      required:
-        - operation_type
-        - account_address
-        - eoa_password
-      title: FinishDVPDeliveryRequest
-      description: DVP delivery finish schema (REQUEST)
     ForceUnlockRequest:
       properties:
         token_address:
@@ -11534,36 +10558,6 @@ components:
         - recipient_address
         - value
       title: ForceUnlockRequest
-    FreezeLogAccountChangeEOAPasswordRequest:
-      properties:
-        old_eoa_password:
-          type: string
-          title: Old Eoa Password
-          description: EOA keyfile password (old)
-        eoa_password:
-          type: string
-          title: Eoa Password
-          description: EOA keyfile password (new)
-      type: object
-      required:
-        - old_eoa_password
-        - eoa_password
-      title: FreezeLogAccountChangeEOAPasswordRequest
-      description: Freeze-Logging account change EOA password schema (REQUEST)
-    FreezeLogAccountResponse:
-      properties:
-        account_address:
-          type: string
-          title: Account Address
-        is_deleted:
-          type: boolean
-          title: Is Deleted
-      type: object
-      required:
-        - account_address
-        - is_deleted
-      title: FreezeLogAccountResponse
-      description: Freeze-logging account reference schema (RESPONSE)
     GetBatchIssueRedeemResponse:
       properties:
         processed:
@@ -12986,27 +11980,6 @@ components:
         - created
         - modified
       title: ListAllChildAccountSortItem
-    ListAllDVPAgentAccountResponse:
-      items:
-        $ref: '#/components/schemas/DVPAgentAccountResponse'
-      type: array
-      title: ListAllDVPAgentAccountResponse
-      description: DVP agent account list reference schema (RESPONSE)
-    ListAllDVPAgentDeliveriesResponse:
-      properties:
-        result_set:
-          $ref: '#/components/schemas/ResultSet'
-        deliveries:
-          items:
-            $ref: '#/components/schemas/RetrieveDVPAgentDeliveryResponse'
-          type: array
-          title: Deliveries
-      type: object
-      required:
-        - result_set
-        - deliveries
-      title: ListAllDVPAgentDeliveriesResponse
-      description: List all DVP delivery schema for paying agent (Response)
     ListAllDVPDeliveriesResponse:
       properties:
         result_set:
@@ -13052,12 +12025,6 @@ components:
         - files
       title: ListAllFilesResponse
       description: List All Files schema (Response)
-    ListAllFreezeLogAccountResponse:
-      items:
-        $ref: '#/components/schemas/FreezeLogAccountResponse'
-      type: array
-      title: ListAllFreezeLogAccountResponse
-      description: Freeze-logging account list reference schema (RESPONSE)
     ListAllHoldersSortItem:
       type: string
       enum:
@@ -13912,43 +12879,6 @@ components:
         - $ref: '#/components/schemas/Position'
       title: PositionResponse
       description: Position schema (Response)
-    RecordNewFreezeLogRequest:
-      properties:
-        account_address:
-          type: string
-          title: Account Address
-          description: Logging account address
-        eoa_password:
-          type: string
-          title: Eoa Password
-          description: Logging account key file password
-        log_message:
-          type: string
-          title: Log Message
-          description: Log message
-        freezing_grace_block_count:
-          type: integer
-          exclusiveMinimum: 0.0
-          title: Freezing Grace Block Count
-          description: Freezing grace block count
-      type: object
-      required:
-        - account_address
-        - eoa_password
-        - log_message
-        - freezing_grace_block_count
-      title: RecordNewFreezeLogRequest
-      description: Record new freeze log schema (REQUEST)
-    RecordNewFreezeLogResponse:
-      properties:
-        log_index:
-          type: integer
-          title: Log Index
-      type: object
-      required:
-        - log_index
-      title: RecordNewFreezeLogResponse
-      description: New freeze-log recording schema (RESPONSE)
     RegisterPersonalInfoRequest:
       properties:
         name:
@@ -13998,41 +12928,6 @@ components:
         - key_manager
       title: RegisterPersonalInfoRequest
       description: Register Personal Information schema (REQUEST)
-    ResponseLimitExceededErrorCode:
-      type: integer
-      enum:
-        - 4
-      const: 4
-      title: ResponseLimitExceededErrorCode
-    ResponseLimitExceededErrorMetainfo:
-      properties:
-        code:
-          allOf:
-            - $ref: '#/components/schemas/ResponseLimitExceededErrorCode'
-          examples:
-            - 4
-        title:
-          type: string
-          title: Title
-          examples:
-            - ResponseLimitExceededError
-      type: object
-      required:
-        - code
-        - title
-      title: ResponseLimitExceededErrorMetainfo
-    ResponseLimitExceededErrorResponse:
-      properties:
-        meta:
-          $ref: '#/components/schemas/ResponseLimitExceededErrorMetainfo'
-        detail:
-          type: string
-          title: Detail
-      type: object
-      required:
-        - meta
-        - detail
-      title: ResponseLimitExceededErrorResponse
     ResultSet:
       properties:
         count:
@@ -14063,118 +12958,6 @@ components:
         - total
       title: ResultSet
       description: result set for pagination
-    RetrieveDVPAgentDeliveryResponse:
-      properties:
-        exchange_address:
-          type: string
-          title: Exchange Address
-        delivery_id:
-          type: integer
-          title: Delivery Id
-        token_address:
-          type: string
-          title: Token Address
-        buyer_address:
-          type: string
-          title: Buyer Address
-        seller_address:
-          type: string
-          title: Seller Address
-        amount:
-          type: integer
-          title: Amount
-        agent_address:
-          type: string
-          title: Agent Address
-        data:
-          anyOf:
-            - $ref: '#/components/schemas/DVPDeliveryData'
-            - type: 'null'
-        settlement_service_type:
-          anyOf:
-            - type: string
-            - type: 'null'
-          title: Settlement Service Type
-        create_blocktimestamp:
-          type: string
-          title: Create Blocktimestamp
-        create_transaction_hash:
-          type: string
-          title: Create Transaction Hash
-        cancel_blocktimestamp:
-          anyOf:
-            - type: string
-            - type: 'null'
-          title: Cancel Blocktimestamp
-        cancel_transaction_hash:
-          anyOf:
-            - type: string
-            - type: 'null'
-          title: Cancel Transaction Hash
-        confirm_blocktimestamp:
-          anyOf:
-            - type: string
-            - type: 'null'
-          title: Confirm Blocktimestamp
-        confirm_transaction_hash:
-          anyOf:
-            - type: string
-            - type: 'null'
-          title: Confirm Transaction Hash
-        finish_blocktimestamp:
-          anyOf:
-            - type: string
-            - type: 'null'
-          title: Finish Blocktimestamp
-        finish_transaction_hash:
-          anyOf:
-            - type: string
-            - type: 'null'
-          title: Finish Transaction Hash
-        abort_blocktimestamp:
-          anyOf:
-            - type: string
-            - type: 'null'
-          title: Abort Blocktimestamp
-        abort_transaction_hash:
-          anyOf:
-            - type: string
-            - type: 'null'
-          title: Abort Transaction Hash
-        confirmed:
-          type: boolean
-          title: Confirmed
-        valid:
-          type: boolean
-          title: Valid
-        status:
-          $ref: '#/components/schemas/DeliveryStatus'
-      type: object
-      required:
-        - exchange_address
-        - delivery_id
-        - token_address
-        - buyer_address
-        - seller_address
-        - amount
-        - agent_address
-        - data
-        - settlement_service_type
-        - create_blocktimestamp
-        - create_transaction_hash
-        - cancel_blocktimestamp
-        - cancel_transaction_hash
-        - confirm_blocktimestamp
-        - confirm_transaction_hash
-        - finish_blocktimestamp
-        - finish_transaction_hash
-        - abort_blocktimestamp
-        - abort_transaction_hash
-        - confirmed
-        - valid
-        - status
-      title: RetrieveDVPAgentDeliveryResponse
-      description: Retrieve DVP delivery schema for paying agent (Response)
     RetrieveDVPDeliveryResponse:
       properties:
         exchange_address:
@@ -14870,6 +13653,58 @@ components:
         - Update
       title: TokenUpdateOperationCategory
       description: Operation category of update token
+    Transfer:
+      properties:
+        transaction_hash:
+          type: string
+          title: Transaction Hash
+        token_address:
+          type: string
+          title: Token Address
+        from_address:
+          type: string
+          title: From Address
+        from_address_personal_information:
+          anyOf:
+            - $ref: '#/components/schemas/PersonalInfo'
+            - type: 'null'
+        to_address:
+          type: string
+          title: To Address
+        to_address_personal_information:
+          anyOf:
+            - $ref: '#/components/schemas/PersonalInfo'
+            - type: 'null'
+        amount:
+          type: integer
+          title: Amount
+        block_timestamp:
+          type: string
+          title: Block Timestamp
+        source_event:
+          type: string
+          enum:
+            - Transfer
+          const: Transfer
+          title: Source Event
+          description: Source Event
+        data:
+          type: 'null'
+          title: Data
+          description: Event data
+      type: object
+      required:
+        - transaction_hash
+        - token_address
+        - from_address
+        - from_address_personal_information
+        - to_address
+        - to_address_personal_information
+        - amount
+        - block_timestamp
+        - source_event
+        - data
+      title: Transfer
     TransferApprovalHistoryResponse:
       properties:
         result_set:
@@ -15187,7 +14022,9 @@ components:
           $ref: '#/components/schemas/ResultSet'
         transfer_history:
           items:
-            $ref: '#/components/schemas/TransferResponse'
+            anyOf:
+              - $ref: '#/components/schemas/Transfer'
+              - $ref: '#/components/schemas/UnlockTransfer'
           type: array
           title: Transfer History
       type: object
@@ -15196,188 +14033,25 @@ components:
         - transfer_history
       title: TransferHistoryResponse
       description: transfer history
-    TransferResponse:
-      properties:
-        transaction_hash:
-          type: string
-          title: Transaction Hash
-        token_address:
-          type: string
-          title: Token Address
-        from_address:
-          type: string
-          title: From Address
-        from_address_personal_information:
-          anyOf:
-            - $ref: '#/components/schemas/PersonalInfo'
-            - type: 'null'
-        to_address:
-          type: string
-          title: To Address
-        to_address_personal_information:
-          anyOf:
-            - $ref: '#/components/schemas/PersonalInfo'
-            - type: 'null'
-        amount:
-          type: integer
-          title: Amount
-        source_event:
-          allOf:
-            - $ref: '#/components/schemas/TransferSourceEventType'
-          description: Source Event
-        data:
-          anyOf:
-            - type: object
-            - type: 'null'
-          title: Data
-          description: Event data
-        block_timestamp:
-          type: string
-          title: Block Timestamp
-      type: object
-      required:
-        - transaction_hash
-        - token_address
-        - from_address
-        - from_address_personal_information
-        - to_address
-        - to_address_personal_information
-        - amount
-        - source_event
-        - data
-        - block_timestamp
-      title: TransferResponse
-      description: transfer data
     TransferSourceEventType:
       type: string
       enum:
         - Transfer
         - Unlock
       title: TransferSourceEventType
-    TxData:
+    UnlockData:
       properties:
-        hash:
+        message:
           type: string
-          title: Hash
-          description: Transaction hash
-        block_hash:
-          type: string
-          title: Block Hash
-        block_number:
-          type: integer
-          minimum: 0.0
-          title: Block Number
-        transaction_index:
-          type: integer
-          minimum: 0.0
-          title: Transaction Index
-        from_address:
-          type: string
-          title: From Address
-        to_address:
-          anyOf:
-            - type: string
-            - type: 'null'
-          title: To Address
+          enum:
+            - garnishment
+            - inheritance
+            - force_unlock
+          title: Message
       type: object
       required:
-        - hash
-        - block_hash
-        - block_number
-        - transaction_index
-        - from_address
-        - to_address
-      title: TxData
-    TxDataDetail:
-      properties:
-        hash:
-          type: string
-          title: Hash
-          description: Transaction hash
-        block_hash:
-          type: string
-          title: Block Hash
-        block_number:
-          type: integer
-          minimum: 0.0
-          title: Block Number
-        transaction_index:
-          type: integer
-          minimum: 0.0
-          title: Transaction Index
-        from_address:
-          type: string
-          title: From Address
-        to_address:
-          anyOf:
-            - type: string
-            - type: 'null'
-          title: To Address
-        contract_name:
-          anyOf:
-            - type: string
-            - type: 'null'
-          title: Contract Name
-        contract_function:
-          anyOf:
-            - type: string
-            - type: 'null'
-          title: Contract Function
-        contract_parameters:
-          anyOf:
-            - type: object
-            - type: 'null'
-          title: Contract Parameters
-        gas:
-          type: integer
-          minimum: 0.0
-          title: Gas
-        gas_price:
-          type: integer
-          minimum: 0.0
-          title: Gas Price
-        value:
-          type: integer
-          minimum: 0.0
-          title: Value
-        nonce:
-          type: integer
-          minimum: 0.0
-          title: Nonce
-      type: object
-      required:
-        - hash
-        - block_hash
-        - block_number
-        - transaction_index
-        - from_address
-        - to_address
-        - contract_name
-        - contract_function
-        - contract_parameters
-        - gas
-        - gas_price
-        - value
-        - nonce
-      title: TxDataDetail
-    TxDataListResponse:
-      properties:
-        result_set:
-          $ref: '#/components/schemas/ResultSet'
-        tx_data:
-          items:
-            $ref: '#/components/schemas/TxData'
-          type: array
-          title: Tx Data
-      type: object
-      required:
-        - result_set
-        - tx_data
-      title: TxDataListResponse
-    TxDataResponse:
-      allOf:
-        - $ref: '#/components/schemas/TxDataDetail'
-      title: TxDataResponse
+        - message
+      title: UnlockData
     UnlockInfoMetaInfo:
       properties:
         token_address:
@@ -15448,27 +14122,60 @@ components:
         - notice_type
         - metainfo
       title: UnlockInfoNotification
-    UpdateFreezeLogRequest:
+    UnlockTransfer:
       properties:
-        account_address:
+        transaction_hash:
           type: string
-          title: Account Address
-          description: Logging account address
-        eoa_password:
+          title: Transaction Hash
+        token_address:
           type: string
-          title: Eoa Password
-          description: Logging account key file password
-        log_message:
+          title: Token Address
+        from_address:
           type: string
-          title: Log Message
-          description: Log message
+          title: From Address
+        from_address_personal_information:
+          anyOf:
+            - $ref: '#/components/schemas/PersonalInfo'
+            - type: 'null'
+        to_address:
+          type: string
+          title: To Address
+        to_address_personal_information:
+          anyOf:
+            - $ref: '#/components/schemas/PersonalInfo'
+            - type: 'null'
+        amount:
+          type: integer
+          title: Amount
+        block_timestamp:
+          type: string
+          title: Block Timestamp
+        source_event:
+          type: string
+          enum:
+            - Unlock
+          const: Unlock
+          title: Source Event
+          description: Source Event
+        data:
+          anyOf:
+            - $ref: '#/components/schemas/UnlockData'
+            - type: object
+          title: Data
+          description: Event data
       type: object
       required:
-        - account_address
-        - eoa_password
-        - log_message
-      title: UpdateFreezeLogRequest
-      description: Update freeze log schema (REQUEST)
+        - transaction_hash
+        - token_address
+        - from_address
+        - from_address_personal_information
+        - to_address
+        - to_address_personal_information
+        - amount
+        - block_timestamp
+        - source_event
+        - data
+      title: UnlockTransfer
     UpdateTransferApprovalOperationType:
       type: string
       enum:
@@ -15571,9 +14278,3 @@ tags:
     description: Messaging functions with external systems
   - name: '[misc] sealed_tx'
     description: Sealed transaction
-  - name: '[misc] settlement_agent'
-    description: Settlement related features for paying agent
-  - name: '[misc] blockchain_explorer'
-    description: Blockchain explorer
-  - name: '[misc] freeze_log'
-    description: Freeze log contract

--- a/docs/ibet_prime.yaml
+++ b/docs/ibet_prime.yaml
@@ -8838,8 +8838,809 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/InvalidParameterErrorResponse'
+  /settlement/dvp/agent/accounts:
+    get:
+      tags:
+        - '[misc] settlement_agent'
+      summary: List All Accounts
+      description: List all DVP-Payment Agent accounts
+      operationId: ListAllDVPAgentAccounts
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListAllDVPAgentAccountResponse'
+    post:
+      tags:
+        - '[misc] settlement_agent'
+      summary: Create Account
+      description: Create DVP-Payment Agent Account
+      operationId: CreateDVPAgentAccount
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateDVPAgentAccountRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DVPAgentAccountResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error422Model'
+        '400':
+          description: Invalid Parameter Error / Send Transaction Error / Contract
+            Revert Error etc
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvalidParameterErrorResponse'
+  /settlement/dvp/agent/account/{account_address}:
+    delete:
+      tags:
+        - '[misc] settlement_agent'
+      summary: Delete Account
+      description: Logically delete an DVP-Payment Agent Account
+      operationId: DeleteDVPAgentAccount
+      parameters:
+        - name: account_address
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Account Address
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DVPAgentAccountResponse'
+        '404':
+          description: Not Found Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404Model'
+  /settlement/dvp/agent/account/{account_address}/eoa_password:
+    post:
+      tags:
+        - '[misc] settlement_agent'
+      summary: Change Eoa Password
+      description: Change Agent's EOA Password
+      operationId: ChangeDVPAgentAccountPassword
+      parameters:
+        - name: account_address
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Account Address
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DVPAgentAccountChangeEOAPasswordRequest'
+      responses:
+        '200':
+          description: Successful Response
+        '404':
+          description: Not Found Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404Model'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error422Model'
+        '400':
+          description: Invalid Parameter Error / Send Transaction Error / Contract
+            Revert Error etc
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvalidParameterErrorResponse'
+  /settlement/dvp/agent/{exchange_address}/deliveries:
+    get:
+      tags:
+        - '[misc] settlement_agent'
+      summary: List All Dvp Agent Deliveries
+      description: List all DVP deliveries for paying agent
+      operationId: ListAllDVPAgentDeliveries
+      parameters:
+        - name: exchange_address
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Exchange Address
+        - name: offset
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: integer
+                minimum: 0
+              - type: 'null'
+            description: Offset for pagination
+            title: Offset
+          description: Offset for pagination
+        - name: limit
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: integer
+                minimum: 0
+              - type: 'null'
+            description: Limit for pagination
+            title: Limit
+          description: Limit for pagination
+        - name: agent_address
+          in: query
+          required: true
+          schema:
+            type: string
+            description: Agent address
+            title: Agent Address
+          description: Agent address
+        - name: token_address
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: 'null'
+            description: Token address
+            title: Token Address
+          description: Token address
+        - name: seller_address
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: 'null'
+            description: Seller address
+            title: Seller Address
+          description: Seller address
+        - name: buyer_address
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: 'null'
+            description: Buyer address
+            title: Buyer Address
+          description: Buyer address
+        - name: valid
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: boolean
+              - type: 'null'
+            description: Valid flag
+            title: Valid
+          description: Valid flag
+        - name: status
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - $ref: '#/components/schemas/DeliveryStatus'
+              - type: 'null'
+            description: Delivery status
+            title: Status
+          description: Delivery status
+        - name: create_blocktimestamp_from
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: string
+                format: date-time
+              - type: 'null'
+            description: Create block timestamp filter(From)
+            title: Create Blocktimestamp From
+          description: Create block timestamp filter(From)
+        - name: create_blocktimestamp_to
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: string
+                format: date-time
+              - type: 'null'
+            description: Create block timestamp filter(To)
+            title: Create Blocktimestamp To
+          description: Create block timestamp filter(To)
+        - name: sort_order
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - $ref: '#/components/schemas/SortOrder'
+              - type: 'null'
+            description: 'Sort order (0: ASC, 1: DESC)'
+            default: 1
+            title: Sort Order
+          description: 'Sort order (0: ASC, 1: DESC)'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListAllDVPAgentDeliveriesResponse'
+        '404':
+          description: Not Found Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404Model'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error422Model'
+        '400':
+          description: Invalid Parameter Error / Send Transaction Error / Contract
+            Revert Error etc
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvalidParameterErrorResponse'
+  /settlement/dvp/agent/{exchange_address}/delivery/{delivery_id}:
+    post:
+      tags:
+        - '[misc] settlement_agent'
+      summary: Update Dvp Agent Delivery
+      description: Finish/Abort DVP delivery
+      operationId: UpdateDVPAgentDelivery
+      parameters:
+        - name: exchange_address
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Exchange Address
+        - name: delivery_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Delivery Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              anyOf:
+                - $ref: '#/components/schemas/FinishDVPDeliveryRequest'
+                - $ref: '#/components/schemas/AbortDVPDeliveryRequest'
+              title: Data
+      responses:
+        '200':
+          description: Successful Response
+        '404':
+          description: Not Found Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404Model'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error422Model'
+        '400':
+          description: Invalid Parameter Error / Send Transaction Error / Contract
+            Revert Error etc
+          content:
+            application/json:
+              schema:
+                anyOf:
+                  - $ref: '#/components/schemas/InvalidParameterErrorResponse'
+                  - $ref: '#/components/schemas/SendTransactionErrorResponse'
+                title: Response 400 Updatedvpagentdelivery
+  /blockchain_explorer/block_data:
+    get:
+      tags:
+        - '[misc] blockchain_explorer'
+      summary: '[ibet Blockchain Explorer] List block data'
+      description: |-
+        Returns a list of block data within the specified block number range.
+        The maximum number of search results is 1000.
+      operationId: ListBlockData
+      parameters:
+        - name: offset
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: integer
+                minimum: 0
+              - type: 'null'
+            description: Offset for pagination
+            title: Offset
+          description: Offset for pagination
+        - name: limit
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: integer
+                minimum: 0
+              - type: 'null'
+            description: Limit for pagination
+            title: Limit
+          description: Limit for pagination
+        - name: from_block_number
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: integer
+                minimum: 0
+              - type: 'null'
+            title: From Block Number
+        - name: to_block_number
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: integer
+                minimum: 0
+              - type: 'null'
+            title: To Block Number
+        - name: sort_order
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - $ref: '#/components/schemas/SortOrder'
+              - type: 'null'
+            description: 'Sort order (0: ASC, 1: DESC)'
+            default: 0
+            title: Sort Order
+          description: 'Sort order (0: ASC, 1: DESC)'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BlockDataListResponse'
+        '404':
+          description: Not Found Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404Model'
+        '400':
+          description: Invalid Parameter Error / Send Transaction Error / Contract
+            Revert Error etc
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseLimitExceededErrorResponse'
+  /blockchain_explorer/block_data/{block_number}:
+    get:
+      tags:
+        - '[misc] blockchain_explorer'
+      summary: '[ibet Blockchain Explorer] Retrieve block data'
+      description: Returns block data in the specified block number.
+      operationId: GetBlockData
+      parameters:
+        - name: block_number
+          in: path
+          required: true
+          schema:
+            type: integer
+            minimum: 0
+            description: Block number
+            title: Block Number
+          description: Block number
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BlockDataResponse'
+        '404':
+          description: Not Found Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404Model'
+  /blockchain_explorer/tx_data:
+    get:
+      tags:
+        - '[misc] blockchain_explorer'
+      summary: '[ibet Blockchain Explorer] List tx data'
+      description: |-
+        Returns a list of transactions by various search parameters.
+        The maximum number of search results is 10000.
+      operationId: ListTxData
+      parameters:
+        - name: offset
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: integer
+                minimum: 0
+              - type: 'null'
+            description: Offset for pagination
+            title: Offset
+          description: Offset for pagination
+        - name: limit
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: integer
+                minimum: 0
+              - type: 'null'
+            description: Limit for pagination
+            title: Limit
+          description: Limit for pagination
+        - name: block_number
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: integer
+                minimum: 0
+              - type: 'null'
+            description: block number
+            title: Block Number
+          description: block number
+        - name: from_address
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: 'null'
+            description: tx from
+            title: From Address
+          description: tx from
+        - name: to_address
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: 'null'
+            description: tx to
+            title: To Address
+          description: tx to
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TxDataListResponse'
+        '404':
+          description: Not Found Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404Model'
+        '400':
+          description: Invalid Parameter Error / Send Transaction Error / Contract
+            Revert Error etc
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseLimitExceededErrorResponse'
+  /blockchain_explorer/tx_data/{hash}:
+    get:
+      tags:
+        - '[misc] blockchain_explorer'
+      summary: '[ibet Blockchain Explorer] Retrieve transaction data'
+      description: Searching for the transaction by transaction hash
+      operationId: GetTxData
+      parameters:
+        - name: hash
+          in: path
+          required: true
+          schema:
+            type: string
+            description: Transaction hash
+            title: Hash
+          description: Transaction hash
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TxDataResponse'
+        '404':
+          description: Not Found Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404Model'
+  /freeze_log/accounts:
+    get:
+      tags:
+        - '[misc] freeze_log'
+      summary: List All Accounts
+      description: List all freeze-logging accounts
+      operationId: ListAllFreezeLogAccount
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListAllFreezeLogAccountResponse'
+    post:
+      tags:
+        - '[misc] freeze_log'
+      summary: Create Account
+      description: Create Freeze-Logging Account
+      operationId: CreateFreezeLogAccount
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateFreezeLogAccountRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FreezeLogAccountResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error422Model'
+        '400':
+          description: Invalid Parameter Error / Send Transaction Error / Contract
+            Revert Error etc
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvalidParameterErrorResponse'
+  /freeze_log/accounts/{account_address}:
+    delete:
+      tags:
+        - '[misc] freeze_log'
+      summary: Delete Account
+      description: Logically delete an freeze-logging account
+      operationId: DeleteFreezeLogAccount
+      parameters:
+        - name: account_address
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Account Address
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FreezeLogAccountResponse'
+        '404':
+          description: Not Found Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404Model'
+  /freeze_log/accounts/{account_address}/eoa_password:
+    post:
+      tags:
+        - '[misc] freeze_log'
+      summary: Change Eoa Password
+      description: Change Account's EOA Password
+      operationId: ChangeFreezeLogAccountPassword
+      parameters:
+        - name: account_address
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Account Address
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FreezeLogAccountChangeEOAPasswordRequest'
+      responses:
+        '200':
+          description: Successful Response
+        '404':
+          description: Not Found Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404Model'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error422Model'
+        '400':
+          description: Invalid Parameter Error / Send Transaction Error / Contract
+            Revert Error etc
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvalidParameterErrorResponse'
+  /freeze_log/logs:
+    post:
+      tags:
+        - '[misc] freeze_log'
+      summary: Record New Log
+      operationId: RecordNewFreezeLog
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RecordNewFreezeLogRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecordNewFreezeLogResponse'
+        '404':
+          description: Not Found Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404Model'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error422Model'
+        '400':
+          description: Invalid Parameter Error / Send Transaction Error / Contract
+            Revert Error etc
+          content:
+            application/json:
+              schema:
+                anyOf:
+                  - $ref: '#/components/schemas/InvalidParameterErrorResponse'
+                  - $ref: '#/components/schemas/SendTransactionErrorResponse'
+                title: Response 400 Recordnewfreezelog
+  /freeze_log/logs/{log_index}:
+    post:
+      tags:
+        - '[misc] freeze_log'
+      summary: Update Log
+      operationId: UpdateFreezeLog
+      parameters:
+        - name: log_index
+          in: path
+          required: true
+          schema:
+            type: integer
+            description: Log index
+            title: Log Index
+          description: Log index
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateFreezeLogRequest'
+      responses:
+        '200':
+          description: Successful Response
+        '404':
+          description: Not Found Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404Model'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error422Model'
+        '400':
+          description: Invalid Parameter Error / Send Transaction Error / Contract
+            Revert Error etc
+          content:
+            application/json:
+              schema:
+                anyOf:
+                  - $ref: '#/components/schemas/InvalidParameterErrorResponse'
+                  - $ref: '#/components/schemas/SendTransactionErrorResponse'
+                title: Response 400 Updatefreezelog
+    get:
+      tags:
+        - '[misc] freeze_log'
+      summary: Retrieve Log
+      operationId: RetrieveFreezeLog
+      parameters:
+        - name: log_index
+          in: path
+          required: true
+          schema:
+            type: integer
+            description: Log index
+            title: Log Index
+          description: Log index
+        - name: account_address
+          in: query
+          required: true
+          schema:
+            type: string
+            description: Logging account address
+            title: Account Address
+          description: Logging account address
+      responses:
+        '200':
+          description: Successful Response
+        '404':
+          description: Not Found Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404Model'
 components:
   schemas:
+    AbortDVPDeliveryRequest:
+      properties:
+        operation_type:
+          type: string
+          enum:
+            - Abort
+          const: Abort
+          title: Operation Type
+        account_address:
+          type: string
+          title: Account Address
+          description: Agent account address
+        eoa_password:
+          type: string
+          title: Eoa Password
+          description: Agent account key file password
+      type: object
+      required:
+        - operation_type
+        - account_address
+        - eoa_password
+      title: AbortDVPDeliveryRequest
+      description: DVP delivery abort schema (REQUEST)
     Account:
       properties:
         issuer_address:
@@ -9294,6 +10095,148 @@ components:
         - failed
       title: BatchRegisterPersonalInfoUploadStatus
       description: Batch Register PersonalInfo Upload Status
+    BlockData:
+      properties:
+        number:
+          type: integer
+          minimum: 0.0
+          title: Number
+          description: Block number
+        hash:
+          type: string
+          title: Hash
+          description: Block hash
+        transactions:
+          items:
+            type: string
+          type: array
+          title: Transactions
+          description: Transaction list
+        timestamp:
+          type: integer
+          title: Timestamp
+        gas_limit:
+          type: integer
+          title: Gas Limit
+        gas_used:
+          type: integer
+          title: Gas Used
+        size:
+          type: integer
+          minimum: 0.0
+          title: Size
+      type: object
+      required:
+        - number
+        - hash
+        - transactions
+        - timestamp
+        - gas_limit
+        - gas_used
+        - size
+      title: BlockData
+    BlockDataDetail:
+      properties:
+        number:
+          type: integer
+          minimum: 0.0
+          title: Number
+          description: Block number
+        parent_hash:
+          type: string
+          title: Parent Hash
+        sha3_uncles:
+          type: string
+          title: Sha3 Uncles
+        miner:
+          type: string
+          title: Miner
+        state_root:
+          type: string
+          title: State Root
+        transactions_root:
+          type: string
+          title: Transactions Root
+        receipts_root:
+          type: string
+          title: Receipts Root
+        logs_bloom:
+          type: string
+          title: Logs Bloom
+        difficulty:
+          type: integer
+          title: Difficulty
+        gas_limit:
+          type: integer
+          title: Gas Limit
+        gas_used:
+          type: integer
+          title: Gas Used
+        timestamp:
+          type: integer
+          title: Timestamp
+        proof_of_authority_data:
+          type: string
+          title: Proof Of Authority Data
+        mix_hash:
+          type: string
+          title: Mix Hash
+        nonce:
+          type: string
+          title: Nonce
+        hash:
+          type: string
+          title: Hash
+          description: Block hash
+        size:
+          type: integer
+          minimum: 0.0
+          title: Size
+        transactions:
+          items:
+            type: string
+          type: array
+          title: Transactions
+          description: Transaction list
+      type: object
+      required:
+        - number
+        - parent_hash
+        - sha3_uncles
+        - miner
+        - state_root
+        - transactions_root
+        - receipts_root
+        - logs_bloom
+        - difficulty
+        - gas_limit
+        - gas_used
+        - timestamp
+        - proof_of_authority_data
+        - mix_hash
+        - nonce
+        - hash
+        - size
+        - transactions
+      title: BlockDataDetail
+    BlockDataListResponse:
+      properties:
+        result_set:
+          $ref: '#/components/schemas/ResultSet'
+        block_data:
+          items:
+            $ref: '#/components/schemas/BlockData'
+          type: array
+          title: Block Data
+      type: object
+      required:
+        - result_set
+        - block_data
+      title: BlockDataListResponse
+    BlockDataResponse:
+      allOf:
+        - $ref: '#/components/schemas/BlockDataDetail'
+      title: BlockDataResponse
     BlockNumberResponse:
       properties:
         block_number:
@@ -9802,6 +10745,17 @@ components:
         - child_account_index
       title: CreateChildAccountResponse
       description: Create a issuer's child account schema (RESPONSE)
+    CreateDVPAgentAccountRequest:
+      properties:
+        eoa_password:
+          type: string
+          title: Eoa Password
+          description: EOA keyfile password
+      type: object
+      required:
+        - eoa_password
+      title: CreateDVPAgentAccountRequest
+      description: DVP agent account create schema (REQUEST)
     CreateDVPDeliveryRequest:
       properties:
         token_address:
@@ -9834,6 +10788,17 @@ components:
         - settlement_service_type
       title: CreateDVPDeliveryRequest
       description: DVP delivery create schema (REQUEST)
+    CreateFreezeLogAccountRequest:
+      properties:
+        eoa_password:
+          type: string
+          title: Eoa Password
+          description: EOA keyfile password
+      type: object
+      required:
+        - eoa_password
+      title: CreateFreezeLogAccountRequest
+      description: Freeze-Logging account create schema (REQUEST)
     CreateLedgerInfoMetaInfo:
       properties:
         token_address:
@@ -10053,6 +11018,36 @@ components:
         - details
       title: CreateUpdateLedgerTemplateRequest
       description: Create or Update Ledger Template schema (Request)
+    DVPAgentAccountChangeEOAPasswordRequest:
+      properties:
+        old_eoa_password:
+          type: string
+          title: Old Eoa Password
+          description: EOA keyfile password (old)
+        eoa_password:
+          type: string
+          title: Eoa Password
+          description: EOA keyfile password (new)
+      type: object
+      required:
+        - old_eoa_password
+        - eoa_password
+      title: DVPAgentAccountChangeEOAPasswordRequest
+      description: DVP agent account change EOA password schema (REQUEST)
+    DVPAgentAccountResponse:
+      properties:
+        account_address:
+          type: string
+          title: Account Address
+        is_deleted:
+          type: boolean
+          title: Is Deleted
+      type: object
+      required:
+        - account_address
+        - is_deleted
+      title: DVPAgentAccountResponse
+      description: DVP agent account reference schema (RESPONSE)
     DVPDeliveryData:
       properties:
         delivery_type:
@@ -10532,6 +11527,29 @@ components:
         - created
       title: FileResponse
       description: File schema (Response)
+    FinishDVPDeliveryRequest:
+      properties:
+        operation_type:
+          type: string
+          enum:
+            - Finish
+          const: Finish
+          title: Operation Type
+        account_address:
+          type: string
+          title: Account Address
+          description: Agent account address
+        eoa_password:
+          type: string
+          title: Eoa Password
+          description: Agent account key file password
+      type: object
+      required:
+        - operation_type
+        - account_address
+        - eoa_password
+      title: FinishDVPDeliveryRequest
+      description: DVP delivery finish schema (REQUEST)
     ForceUnlockRequest:
       properties:
         token_address:
@@ -10558,6 +11576,36 @@ components:
         - recipient_address
         - value
       title: ForceUnlockRequest
+    FreezeLogAccountChangeEOAPasswordRequest:
+      properties:
+        old_eoa_password:
+          type: string
+          title: Old Eoa Password
+          description: EOA keyfile password (old)
+        eoa_password:
+          type: string
+          title: Eoa Password
+          description: EOA keyfile password (new)
+      type: object
+      required:
+        - old_eoa_password
+        - eoa_password
+      title: FreezeLogAccountChangeEOAPasswordRequest
+      description: Freeze-Logging account change EOA password schema (REQUEST)
+    FreezeLogAccountResponse:
+      properties:
+        account_address:
+          type: string
+          title: Account Address
+        is_deleted:
+          type: boolean
+          title: Is Deleted
+      type: object
+      required:
+        - account_address
+        - is_deleted
+      title: FreezeLogAccountResponse
+      description: Freeze-logging account reference schema (RESPONSE)
     GetBatchIssueRedeemResponse:
       properties:
         processed:
@@ -11980,6 +13028,27 @@ components:
         - created
         - modified
       title: ListAllChildAccountSortItem
+    ListAllDVPAgentAccountResponse:
+      items:
+        $ref: '#/components/schemas/DVPAgentAccountResponse'
+      type: array
+      title: ListAllDVPAgentAccountResponse
+      description: DVP agent account list reference schema (RESPONSE)
+    ListAllDVPAgentDeliveriesResponse:
+      properties:
+        result_set:
+          $ref: '#/components/schemas/ResultSet'
+        deliveries:
+          items:
+            $ref: '#/components/schemas/RetrieveDVPAgentDeliveryResponse'
+          type: array
+          title: Deliveries
+      type: object
+      required:
+        - result_set
+        - deliveries
+      title: ListAllDVPAgentDeliveriesResponse
+      description: List all DVP delivery schema for paying agent (Response)
     ListAllDVPDeliveriesResponse:
       properties:
         result_set:
@@ -12025,6 +13094,12 @@ components:
         - files
       title: ListAllFilesResponse
       description: List All Files schema (Response)
+    ListAllFreezeLogAccountResponse:
+      items:
+        $ref: '#/components/schemas/FreezeLogAccountResponse'
+      type: array
+      title: ListAllFreezeLogAccountResponse
+      description: Freeze-logging account list reference schema (RESPONSE)
     ListAllHoldersSortItem:
       type: string
       enum:
@@ -12879,6 +13954,43 @@ components:
         - $ref: '#/components/schemas/Position'
       title: PositionResponse
       description: Position schema (Response)
+    RecordNewFreezeLogRequest:
+      properties:
+        account_address:
+          type: string
+          title: Account Address
+          description: Logging account address
+        eoa_password:
+          type: string
+          title: Eoa Password
+          description: Logging account key file password
+        log_message:
+          type: string
+          title: Log Message
+          description: Log message
+        freezing_grace_block_count:
+          type: integer
+          exclusiveMinimum: 0.0
+          title: Freezing Grace Block Count
+          description: Freezing grace block count
+      type: object
+      required:
+        - account_address
+        - eoa_password
+        - log_message
+        - freezing_grace_block_count
+      title: RecordNewFreezeLogRequest
+      description: Record new freeze log schema (REQUEST)
+    RecordNewFreezeLogResponse:
+      properties:
+        log_index:
+          type: integer
+          title: Log Index
+      type: object
+      required:
+        - log_index
+      title: RecordNewFreezeLogResponse
+      description: New freeze-log recording schema (RESPONSE)
     RegisterPersonalInfoRequest:
       properties:
         name:
@@ -12928,6 +14040,41 @@ components:
         - key_manager
       title: RegisterPersonalInfoRequest
       description: Register Personal Information schema (REQUEST)
+    ResponseLimitExceededErrorCode:
+      type: integer
+      enum:
+        - 4
+      const: 4
+      title: ResponseLimitExceededErrorCode
+    ResponseLimitExceededErrorMetainfo:
+      properties:
+        code:
+          allOf:
+            - $ref: '#/components/schemas/ResponseLimitExceededErrorCode'
+          examples:
+            - 4
+        title:
+          type: string
+          title: Title
+          examples:
+            - ResponseLimitExceededError
+      type: object
+      required:
+        - code
+        - title
+      title: ResponseLimitExceededErrorMetainfo
+    ResponseLimitExceededErrorResponse:
+      properties:
+        meta:
+          $ref: '#/components/schemas/ResponseLimitExceededErrorMetainfo'
+        detail:
+          type: string
+          title: Detail
+      type: object
+      required:
+        - meta
+        - detail
+      title: ResponseLimitExceededErrorResponse
     ResultSet:
       properties:
         count:
@@ -12958,6 +14105,118 @@ components:
         - total
       title: ResultSet
       description: result set for pagination
+    RetrieveDVPAgentDeliveryResponse:
+      properties:
+        exchange_address:
+          type: string
+          title: Exchange Address
+        delivery_id:
+          type: integer
+          title: Delivery Id
+        token_address:
+          type: string
+          title: Token Address
+        buyer_address:
+          type: string
+          title: Buyer Address
+        seller_address:
+          type: string
+          title: Seller Address
+        amount:
+          type: integer
+          title: Amount
+        agent_address:
+          type: string
+          title: Agent Address
+        data:
+          anyOf:
+            - $ref: '#/components/schemas/DVPDeliveryData'
+            - type: 'null'
+        settlement_service_type:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Settlement Service Type
+        create_blocktimestamp:
+          type: string
+          title: Create Blocktimestamp
+        create_transaction_hash:
+          type: string
+          title: Create Transaction Hash
+        cancel_blocktimestamp:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Cancel Blocktimestamp
+        cancel_transaction_hash:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Cancel Transaction Hash
+        confirm_blocktimestamp:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Confirm Blocktimestamp
+        confirm_transaction_hash:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Confirm Transaction Hash
+        finish_blocktimestamp:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Finish Blocktimestamp
+        finish_transaction_hash:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Finish Transaction Hash
+        abort_blocktimestamp:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Abort Blocktimestamp
+        abort_transaction_hash:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Abort Transaction Hash
+        confirmed:
+          type: boolean
+          title: Confirmed
+        valid:
+          type: boolean
+          title: Valid
+        status:
+          $ref: '#/components/schemas/DeliveryStatus'
+      type: object
+      required:
+        - exchange_address
+        - delivery_id
+        - token_address
+        - buyer_address
+        - seller_address
+        - amount
+        - agent_address
+        - data
+        - settlement_service_type
+        - create_blocktimestamp
+        - create_transaction_hash
+        - cancel_blocktimestamp
+        - cancel_transaction_hash
+        - confirm_blocktimestamp
+        - confirm_transaction_hash
+        - finish_blocktimestamp
+        - finish_transaction_hash
+        - abort_blocktimestamp
+        - abort_transaction_hash
+        - confirmed
+        - valid
+        - status
+      title: RetrieveDVPAgentDeliveryResponse
+      description: Retrieve DVP delivery schema for paying agent (Response)
     RetrieveDVPDeliveryResponse:
       properties:
         exchange_address:
@@ -14039,6 +15298,130 @@ components:
         - Transfer
         - Unlock
       title: TransferSourceEventType
+    TxData:
+      properties:
+        hash:
+          type: string
+          title: Hash
+          description: Transaction hash
+        block_hash:
+          type: string
+          title: Block Hash
+        block_number:
+          type: integer
+          minimum: 0.0
+          title: Block Number
+        transaction_index:
+          type: integer
+          minimum: 0.0
+          title: Transaction Index
+        from_address:
+          type: string
+          title: From Address
+        to_address:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: To Address
+      type: object
+      required:
+        - hash
+        - block_hash
+        - block_number
+        - transaction_index
+        - from_address
+        - to_address
+      title: TxData
+    TxDataDetail:
+      properties:
+        hash:
+          type: string
+          title: Hash
+          description: Transaction hash
+        block_hash:
+          type: string
+          title: Block Hash
+        block_number:
+          type: integer
+          minimum: 0.0
+          title: Block Number
+        transaction_index:
+          type: integer
+          minimum: 0.0
+          title: Transaction Index
+        from_address:
+          type: string
+          title: From Address
+        to_address:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: To Address
+        contract_name:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Contract Name
+        contract_function:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Contract Function
+        contract_parameters:
+          anyOf:
+            - type: object
+            - type: 'null'
+          title: Contract Parameters
+        gas:
+          type: integer
+          minimum: 0.0
+          title: Gas
+        gas_price:
+          type: integer
+          minimum: 0.0
+          title: Gas Price
+        value:
+          type: integer
+          minimum: 0.0
+          title: Value
+        nonce:
+          type: integer
+          minimum: 0.0
+          title: Nonce
+      type: object
+      required:
+        - hash
+        - block_hash
+        - block_number
+        - transaction_index
+        - from_address
+        - to_address
+        - contract_name
+        - contract_function
+        - contract_parameters
+        - gas
+        - gas_price
+        - value
+        - nonce
+      title: TxDataDetail
+    TxDataListResponse:
+      properties:
+        result_set:
+          $ref: '#/components/schemas/ResultSet'
+        tx_data:
+          items:
+            $ref: '#/components/schemas/TxData'
+          type: array
+          title: Tx Data
+      type: object
+      required:
+        - result_set
+        - tx_data
+      title: TxDataListResponse
+    TxDataResponse:
+      allOf:
+        - $ref: '#/components/schemas/TxDataDetail'
+      title: TxDataResponse
     UnlockData:
       properties:
         message:
@@ -14176,6 +15559,27 @@ components:
         - source_event
         - data
       title: UnlockTransfer
+    UpdateFreezeLogRequest:
+      properties:
+        account_address:
+          type: string
+          title: Account Address
+          description: Logging account address
+        eoa_password:
+          type: string
+          title: Eoa Password
+          description: Logging account key file password
+        log_message:
+          type: string
+          title: Log Message
+          description: Log message
+      type: object
+      required:
+        - account_address
+        - eoa_password
+        - log_message
+      title: UpdateFreezeLogRequest
+      description: Update freeze log schema (REQUEST)
     UpdateTransferApprovalOperationType:
       type: string
       enum:
@@ -14278,3 +15682,9 @@ tags:
     description: Messaging functions with external systems
   - name: '[misc] sealed_tx'
     description: Sealed transaction
+  - name: '[misc] settlement_agent'
+    description: Settlement related features for paying agent
+  - name: '[misc] blockchain_explorer'
+    description: Blockchain explorer
+  - name: '[misc] freeze_log'
+    description: Freeze log contract

--- a/migrations/versions/68f088d446c4_v24_12_0_feature_700.py
+++ b/migrations/versions/68f088d446c4_v24_12_0_feature_700.py
@@ -1,0 +1,55 @@
+"""v24_12_0_feature_700
+
+Revision ID: 68f088d446c4
+Revises: 3977b822f983
+Create Date: 2024-10-30 10:39:56.378764
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+from app.database import get_db_schema
+
+# revision identifiers, used by Alembic.
+revision = "68f088d446c4"
+down_revision = "3977b822f983"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "idx_transfer",
+        sa.Column("message", sa.String(length=50), nullable=True),
+        schema=get_db_schema(),
+    )
+    op.create_index(
+        op.f("ix_idx_transfer_message"),
+        "idx_transfer",
+        ["message"],
+        unique=False,
+        schema=get_db_schema(),
+    )
+    op.create_index(
+        op.f("ix_idx_transfer_source_event"),
+        "idx_transfer",
+        ["source_event"],
+        unique=False,
+        schema=get_db_schema(),
+    )
+
+
+def downgrade():
+    op.drop_index(
+        op.f("ix_idx_transfer_source_event"),
+        table_name="idx_transfer",
+        schema=get_db_schema(),
+    )
+    op.drop_index(
+        op.f("ix_idx_transfer_message"),
+        table_name="idx_transfer",
+        schema=get_db_schema(),
+    )
+    op.drop_column("idx_transfer", "message", schema=get_db_schema())

--- a/tests/app/model/blockchain/test_token_IbetStraightBond.py
+++ b/tests/app/model/blockchain/test_token_IbetStraightBond.py
@@ -17,6 +17,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
+import json
 import time
 from binascii import Error
 from datetime import UTC, datetime, timedelta
@@ -27,6 +28,7 @@ import pytest
 from eth_keyfile import decode_keyfile_json
 from pydantic import ValidationError
 from sqlalchemy import select
+from web3 import Web3
 from web3.exceptions import (
     ContractLogicError,
     InvalidAddress,
@@ -34,6 +36,7 @@ from web3.exceptions import (
     TimeExhausted,
     TransactionNotFound,
 )
+from web3.middleware import ExtraDataToPOAMiddleware
 
 from app.exceptions import ContractRevertError, SendTransactionError
 from app.model.blockchain import IbetStraightBondContract
@@ -49,13 +52,16 @@ from app.model.blockchain.tx_params.ibet_straight_bond import (
     UpdateParams,
 )
 from app.model.db import TokenAttrUpdate, TokenCache
-from app.utils.contract_utils import ContractUtils
-from config import DEFAULT_CURRENCY, TOKEN_CACHE_TTL, ZERO_ADDRESS
+from app.utils.contract_utils import AsyncContractUtils, ContractUtils
+from config import DEFAULT_CURRENCY, TOKEN_CACHE_TTL, WEB3_HTTP_PROVIDER, ZERO_ADDRESS
 from tests.account_config import config_eth_account
 from tests.contract_utils import (
     IbetSecurityTokenContractTestUtils,
     PersonalInfoContractTestUtils,
 )
+
+web3 = Web3(Web3.HTTPProvider(WEB3_HTTP_PROVIDER))
+web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 class TestCreate:
@@ -4665,23 +4671,35 @@ class TestForceUnlock:
             "account_address": issuer_address,
             "recipient_address": issuer_address,
             "value": 5,
-            "data": "",
+            "data": json.dumps({"message": "force_unlock"}),
         }
+        block_from = web3.eth.block_number
         tx_hash, tx_receipt = await bond_contract.force_unlock(
             data=ForceUnlockPrams(**lock_data),
             tx_from=issuer_address,
             private_key=issuer_pk,
         )
+        block_to = web3.eth.block_number
 
         # assertion
         assert isinstance(tx_hash, str) and int(tx_hash, 16) > 0
         assert tx_receipt["status"] == 1
 
-        bond_token = ContractUtils.get_contract(
+        bond_token = AsyncContractUtils.get_contract(
             contract_name="IbetStraightBond", contract_address=token_address
         )
-        lock_amount = bond_token.functions.lockedOf(lock_address, issuer_address).call()
+        lock_amount = await bond_token.functions.lockedOf(
+            lock_address, issuer_address
+        ).call()
         assert lock_amount == 5
+
+        logs = await AsyncContractUtils.get_event_logs(
+            contract=bond_token,
+            event="Unlock",
+            block_from=block_from,
+            block_to=block_to,
+        )
+        assert json.loads(logs[0].args["data"]) == {"message": "force_unlock"}
 
     ###########################################################################
     # Error Case

--- a/tests/app/test_bond_transfers_ListBondTokenTransferHistory.py
+++ b/tests/app/test_bond_transfers_ListBondTokenTransferHistory.py
@@ -1090,7 +1090,7 @@ class TestAppRoutersBondTransfersGET:
         # request target API
         resp = client.get(
             self.base_url.format(self.test_token_address),
-            params={"source_event": IDXTransferSourceEventType.UNLOCK.value},
+            params={"source_event": IDXTransferSourceEventType.UNLOCK},
         )
 
         # assertion
@@ -1183,6 +1183,83 @@ class TestAppRoutersBondTransfersGET:
                     "amount": 2,
                     "source_event": IDXTransferSourceEventType.UNLOCK.value,
                     "data": {"message": "unlock"},
+                    "block_timestamp": self.test_block_timestamp_str[2],
+                }
+            ],
+        }
+        assert resp.json() == assumed_response
+
+    # <Normal_3_10>
+    # filter: message
+    def test_normal_3_10(self, client, db):
+        # prepare data: Token
+        _token = Token()
+        _token.type = TokenType.IBET_STRAIGHT_BOND.value
+        _token.tx_hash = self.test_transaction_hash
+        _token.issuer_address = self.test_issuer_address
+        _token.token_address = self.test_token_address
+        _token.abi = {}
+        _token.version = TokenVersion.V_24_09
+        db.add(_token)
+
+        # prepare data: IDXTransfer
+        _idx_transfer = IDXTransfer()
+        _idx_transfer.transaction_hash = self.test_transaction_hash
+        _idx_transfer.token_address = self.test_token_address
+        _idx_transfer.from_address = self.test_from_address_2
+        _idx_transfer.to_address = self.test_to_address_1
+        _idx_transfer.amount = 0
+        _idx_transfer.source_event = IDXTransferSourceEventType.TRANSFER.value
+        _idx_transfer.data = None
+        _idx_transfer.block_timestamp = self.test_block_timestamp[0]
+        db.add(_idx_transfer)
+
+        _idx_transfer = IDXTransfer()
+        _idx_transfer.transaction_hash = self.test_transaction_hash
+        _idx_transfer.token_address = self.test_token_address
+        _idx_transfer.from_address = self.test_from_address_2
+        _idx_transfer.to_address = self.test_to_address_1
+        _idx_transfer.amount = 1
+        _idx_transfer.source_event = IDXTransferSourceEventType.TRANSFER.value
+        _idx_transfer.data = None
+        _idx_transfer.block_timestamp = self.test_block_timestamp[1]
+        db.add(_idx_transfer)
+
+        _idx_transfer = IDXTransfer()
+        _idx_transfer.transaction_hash = self.test_transaction_hash
+        _idx_transfer.token_address = self.test_token_address
+        _idx_transfer.from_address = self.test_from_address_1
+        _idx_transfer.to_address = self.test_to_address_1
+        _idx_transfer.amount = 2
+        _idx_transfer.source_event = IDXTransferSourceEventType.UNLOCK.value
+        _idx_transfer.data = {"message": "force_unlock"}
+        _idx_transfer.message = "force_unlock"
+        _idx_transfer.block_timestamp = self.test_block_timestamp[2]
+        db.add(_idx_transfer)
+
+        db.commit()
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(self.test_token_address),
+            params={"message": "force_unlock"},
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assumed_response = {
+            "result_set": {"count": 1, "offset": None, "limit": None, "total": 3},
+            "transfer_history": [
+                {
+                    "transaction_hash": self.test_transaction_hash,
+                    "token_address": self.test_token_address,
+                    "from_address": self.test_from_address_1,
+                    "from_address_personal_information": None,
+                    "to_address": self.test_to_address_1,
+                    "to_address_personal_information": None,
+                    "amount": 2,
+                    "source_event": IDXTransferSourceEventType.UNLOCK.value,
+                    "data": {"message": "force_unlock"},
                     "block_timestamp": self.test_block_timestamp_str[2],
                 }
             ],

--- a/tests/app/test_positions_ForceUnlock.py
+++ b/tests/app/test_positions_ForceUnlock.py
@@ -97,7 +97,7 @@ class TestForceUnlock:
                     "account_address": account_address,
                     "recipient_address": _recipient_address,
                     "value": 10,
-                    "data": "",
+                    "data": json.dumps({"message": "force_unlock"}),
                 }
             ),
             tx_from=_admin_address,

--- a/tests/app/test_positions_ForceUnlock.py
+++ b/tests/app/test_positions_ForceUnlock.py
@@ -18,6 +18,7 @@ SPDX-License-Identifier: Apache-2.0
 """
 
 import hashlib
+import json
 from unittest import mock
 from unittest.mock import ANY, MagicMock
 
@@ -169,7 +170,7 @@ class TestForceUnlock:
                     "account_address": account_address,
                     "recipient_address": _recipient_address,
                     "value": 10,
-                    "data": "",
+                    "data": json.dumps({"message": "force_unlock"}),
                 }
             ),
             tx_from=_admin_address,

--- a/tests/app/test_share_transfers_ListShareTokenTransferHistory.py
+++ b/tests/app/test_share_transfers_ListShareTokenTransferHistory.py
@@ -1090,7 +1090,7 @@ class TestListShareTokenTransferHistory:
         # request target API
         resp = client.get(
             self.base_url.format(self.test_token_address),
-            params={"source_event": IDXTransferSourceEventType.UNLOCK.value},
+            params={"source_event": IDXTransferSourceEventType.UNLOCK},
         )
 
         # assertion
@@ -1183,6 +1183,83 @@ class TestListShareTokenTransferHistory:
                     "amount": 2,
                     "source_event": IDXTransferSourceEventType.UNLOCK.value,
                     "data": {"message": "unlock"},
+                    "block_timestamp": self.test_block_timestamp_str[2],
+                }
+            ],
+        }
+        assert resp.json() == assumed_response
+
+    # <Normal_3_10>
+    # filter: message
+    def test_normal_3_10(self, client, db):
+        # prepare data: Token
+        _token = Token()
+        _token.type = TokenType.IBET_SHARE.value
+        _token.tx_hash = self.test_transaction_hash
+        _token.issuer_address = self.test_issuer_address
+        _token.token_address = self.test_token_address
+        _token.abi = {}
+        _token.version = TokenVersion.V_24_09
+        db.add(_token)
+
+        # prepare data: IDXTransfer
+        _idx_transfer = IDXTransfer()
+        _idx_transfer.transaction_hash = self.test_transaction_hash
+        _idx_transfer.token_address = self.test_token_address
+        _idx_transfer.from_address = self.test_from_address_2
+        _idx_transfer.to_address = self.test_to_address_1
+        _idx_transfer.amount = 0
+        _idx_transfer.source_event = IDXTransferSourceEventType.TRANSFER.value
+        _idx_transfer.data = None
+        _idx_transfer.block_timestamp = self.test_block_timestamp[0]
+        db.add(_idx_transfer)
+
+        _idx_transfer = IDXTransfer()
+        _idx_transfer.transaction_hash = self.test_transaction_hash
+        _idx_transfer.token_address = self.test_token_address
+        _idx_transfer.from_address = self.test_from_address_2
+        _idx_transfer.to_address = self.test_to_address_1
+        _idx_transfer.amount = 1
+        _idx_transfer.source_event = IDXTransferSourceEventType.TRANSFER.value
+        _idx_transfer.data = None
+        _idx_transfer.block_timestamp = self.test_block_timestamp[1]
+        db.add(_idx_transfer)
+
+        _idx_transfer = IDXTransfer()
+        _idx_transfer.transaction_hash = self.test_transaction_hash
+        _idx_transfer.token_address = self.test_token_address
+        _idx_transfer.from_address = self.test_from_address_1
+        _idx_transfer.to_address = self.test_to_address_1
+        _idx_transfer.amount = 2
+        _idx_transfer.source_event = IDXTransferSourceEventType.UNLOCK.value
+        _idx_transfer.data = {"message": "force_unlock"}
+        _idx_transfer.message = "force_unlock"
+        _idx_transfer.block_timestamp = self.test_block_timestamp[2]
+        db.add(_idx_transfer)
+
+        db.commit()
+
+        # request target API
+        resp = client.get(
+            self.base_url.format(self.test_token_address),
+            params={"message": "force_unlock"},
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assumed_response = {
+            "result_set": {"count": 1, "offset": None, "limit": None, "total": 3},
+            "transfer_history": [
+                {
+                    "transaction_hash": self.test_transaction_hash,
+                    "token_address": self.test_token_address,
+                    "from_address": self.test_from_address_1,
+                    "from_address_personal_information": None,
+                    "to_address": self.test_to_address_1,
+                    "to_address_personal_information": None,
+                    "amount": 2,
+                    "source_event": IDXTransferSourceEventType.UNLOCK.value,
+                    "data": {"message": "force_unlock"},
                     "block_timestamp": self.test_block_timestamp_str[2],
                 }
             ],

--- a/tests/batch/test_indexer_transfer.py
+++ b/tests/batch/test_indexer_transfer.py
@@ -321,7 +321,9 @@ class TestProcessor:
 
         # Unlock (lock -> unlock)
         tx_2_1 = token_contract_1.functions.lock(
-            lock_account["address"], 10, ""
+            lock_account["address"],
+            10,
+            json.dumps({"message": "garnishment"}),
         ).build_transaction(
             {
                 "chainId": CHAIN_ID,
@@ -333,7 +335,7 @@ class TestProcessor:
         _, _ = ContractUtils.send_transaction(tx_2_1, issuer_private_key)
 
         tx_2_2 = token_contract_1.functions.unlock(
-            issuer_address, user_address_1, 10, json.dumps({"message": "unlock"})
+            issuer_address, user_address_1, 10, json.dumps({"message": "force_unlock"})
         ).build_transaction(
             {
                 "chainId": CHAIN_ID,
@@ -376,7 +378,8 @@ class TestProcessor:
         assert _transfer.to_address == user_address_1
         assert _transfer.amount == 10
         assert _transfer.source_event == IDXTransferSourceEventType.UNLOCK.value
-        assert _transfer.data == {"message": "unlock"}
+        assert _transfer.data == {"message": "force_unlock"}
+        assert _transfer.message == "force_unlock"
         block = web3.eth.get_block(tx_receipt_2["blockNumber"])
         assert _transfer.block_timestamp == datetime.fromtimestamp(
             block["timestamp"], UTC
@@ -442,7 +445,7 @@ class TestProcessor:
 
         # Unlock (lock -> unlock)
         tx_1_1 = token_contract_1.functions.lock(
-            lock_account["address"], 10, ""
+            lock_account["address"], 10, json.dumps({"message": "garnishment"})
         ).build_transaction(
             {
                 "chainId": CHAIN_ID,
@@ -454,7 +457,7 @@ class TestProcessor:
         _, _ = ContractUtils.send_transaction(tx_1_1, issuer_private_key)
 
         tx_1_2 = token_contract_1.functions.unlock(
-            issuer_address, issuer_address, 10, json.dumps({"message": "unlock"})
+            issuer_address, issuer_address, 10, json.dumps({"message": "force_unlock"})
         ).build_transaction(
             {
                 "chainId": CHAIN_ID,
@@ -569,7 +572,7 @@ class TestProcessor:
 
         # Unlock (lock -> unlock)
         tx_3_1 = token_contract_1.functions.lock(
-            lock_account["address"], 10, ""
+            lock_account["address"], 10, json.dumps({"message": "garnishment"})
         ).build_transaction(
             {
                 "chainId": CHAIN_ID,
@@ -581,7 +584,7 @@ class TestProcessor:
         _, _ = ContractUtils.send_transaction(tx_3_1, issuer_private_key)
 
         tx_3_2 = token_contract_1.functions.unlock(
-            issuer_address, user_address_1, 10, json.dumps({"message": "unlock"})
+            issuer_address, user_address_1, 10, json.dumps({"message": "garnishment"})
         ).build_transaction(
             {
                 "chainId": CHAIN_ID,
@@ -595,7 +598,7 @@ class TestProcessor:
         )
 
         tx_4_1 = token_contract_1.functions.lock(
-            lock_account["address"], 10, ""
+            lock_account["address"], 10, json.dumps({"message": "inheritance"})
         ).build_transaction(
             {
                 "chainId": CHAIN_ID,
@@ -607,7 +610,7 @@ class TestProcessor:
         _, _ = ContractUtils.send_transaction(tx_4_1, issuer_private_key)
 
         tx_4_2 = token_contract_1.functions.unlock(
-            issuer_address, user_address_1, 10, json.dumps({"message": "unlock"})
+            issuer_address, user_address_1, 10, json.dumps({"message": "inheritance"})
         ).build_transaction(
             {
                 "chainId": CHAIN_ID,
@@ -664,7 +667,8 @@ class TestProcessor:
         assert _transfer.to_address == user_address_1
         assert _transfer.amount == 10
         assert _transfer.source_event == IDXTransferSourceEventType.UNLOCK.value
-        assert _transfer.data == {"message": "unlock"}
+        assert _transfer.data == {"message": "garnishment"}
+        assert _transfer.message == "garnishment"
         block = web3.eth.get_block(tx_receipt_3["blockNumber"])
         assert _transfer.block_timestamp == datetime.fromtimestamp(
             block["timestamp"], UTC
@@ -678,7 +682,8 @@ class TestProcessor:
         assert _transfer.to_address == user_address_1
         assert _transfer.amount == 10
         assert _transfer.source_event == IDXTransferSourceEventType.UNLOCK.value
-        assert _transfer.data == {"message": "unlock"}
+        assert _transfer.data == {"message": "inheritance"}
+        assert _transfer.message == "inheritance"
         block = web3.eth.get_block(tx_receipt_4["blockNumber"])
         assert _transfer.block_timestamp == datetime.fromtimestamp(
             block["timestamp"], UTC


### PR DESCRIPTION
Close #700 

**DB**

- Added new message column with index to idx_transfer table, separate from existing JSON data field

**API**

- Detailed transfer data schema on Transfer List API to classify transfer data derived from Unlock events

```Python
class TransferBase(BaseModel):
    transaction_hash: str
    token_address: str
    from_address: str
    from_address_personal_information: Optional[PersonalInfo] = Field(...)
    to_address: str
    to_address_personal_information: Optional[PersonalInfo] = Field(...)
    amount: int
    block_timestamp: str

class Transfer(TransferBase):
    source_event: Literal[TransferSourceEventType.Transfer] = Field(
        description="Source Event"
    )
    data: None = Field(description="Event data")

class UnlockData(BaseModel):
    message: Literal[
        "garnishment",
        "inheritance",
        "force_unlock",
    ]

class UnlockTransfer(TransferBase):
    source_event: Literal[TransferSourceEventType.Unlock] = Field(
        description="Source Event"
    )
    data: UnlockData | dict = Field(description="Event data")
```

- Added GET query to `/{bond or share}/transfers/{token_address}` for searching by message field.

**Batch**

- Fixed to store message column when saving Transfer records.