### PR TITLE
Add validation for posted personal info length to child account API

### DIFF
--- a/app/utils/docs_utils.py
+++ b/app/utils/docs_utils.py
@@ -23,6 +23,7 @@ from typing import List, Type, Union
 
 from fastapi.openapi.utils import get_openapi
 from pydantic import BaseModel, Field, create_model
+from typing_extensions import get_type_hints
 
 from app.exceptions import AppError
 
@@ -149,6 +150,10 @@ def create_error_model(app_error: Type[AppError]):
         ),
         title=(str, Field(..., examples=[base_name])),
     )
+    if get_type_hints(app_error).get("detail") is not None:
+        detail = (get_type_hints(app_error).get("detail"), Field(...))
+    else:
+        detail = (str, Field())
     error_model = create_model(
         f"{base_name}Response",
         meta=(
@@ -157,7 +162,7 @@ def create_error_model(app_error: Type[AppError]):
                 ...,
             ),
         ),
-        detail=(str, Field()),
+        detail=detail,
     )
     error_model.__doc__ = app_error.__doc__
     return error_model

--- a/docs/ibet_prime.yaml
+++ b/docs/ibet_prime.yaml
@@ -441,7 +441,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OperationNotPermittedForOlderIssuersResponse'
+                anyOf:
+                  - $ref: '#/components/schemas/OperationNotPermittedForOlderIssuersResponse'
+                  - $ref: '#/components/schemas/PersonalInfoExceedsSizeLimitResponse'
+                title: Response 400 Createchildaccount
         '503':
           description: Service Unavailable Error
           content:
@@ -616,7 +619,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OperationNotPermittedForOlderIssuersResponse'
+                anyOf:
+                  - $ref: '#/components/schemas/BatchPersonalInfoRegistrationValidationErrorResponse'
+                  - $ref: '#/components/schemas/OperationNotPermittedForOlderIssuersResponse'
+                title: Response 400 Createchildaccountinbatch
         '503':
           description: Service Unavailable Error
           content:
@@ -690,6 +696,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error404Model'
+        '400':
+          description: Invalid Parameter Error / Send Transaction Error / Contract
+            Revert Error etc
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PersonalInfoExceedsSizeLimitResponse'
     delete:
       tags:
         - account
@@ -10227,8 +10240,7 @@ components:
         meta:
           $ref: '#/components/schemas/BatchPersonalInfoRegistrationValidationErrorMetainfo'
         detail:
-          type: string
-          title: Detail
+          $ref: '#/components/schemas/InvalidUploadErrorDetail'
       type: object
       required:
         - meta
@@ -13073,6 +13085,17 @@ components:
         - meta
         - detail
       title: InvalidParameterErrorResponse
+    InvalidUploadErrorDetail:
+      properties:
+        record_error_details:
+          items:
+            $ref: '#/components/schemas/RecordErrorDetail'
+          type: array
+          title: Record Error Details
+      type: object
+      required:
+        - record_error_details
+      title: InvalidUploadErrorDetail
     IssueErrorMetaInfo:
       properties:
         token_address:
@@ -14295,6 +14318,20 @@ components:
       $ref: '#/components/schemas/Position'
       title: PositionResponse
       description: Position schema (Response)
+    RecordErrorDetail:
+      properties:
+        row_num:
+          type: integer
+          title: Row Num
+        error_reason:
+          type: string
+          const: PersonalInfoExceedsSizeLimit
+          title: Error Reason
+      type: object
+      required:
+        - row_num
+        - error_reason
+      title: RecordErrorDetail
     RecordNewFreezeLogRequest:
       properties:
         account_address:


### PR DESCRIPTION
- Add validation for posted personal info length to child account API
- Updated the API docs to describe the details of `BatchPersonalInfoRegistrationValidationError`