### PR TITLE
Add token_address attribute to notification metainfo

### DIFF
--- a/app/model/db/batch_register_personal_info.py
+++ b/app/model/db/batch_register_personal_info.py
@@ -35,6 +35,8 @@ class BatchRegisterPersonalInfoUpload(Base):
     upload_id: Mapped[str] = mapped_column(String(36), primary_key=True)
     # issuer address
     issuer_address: Mapped[str] = mapped_column(String(42), nullable=False, index=True)
+    # token address
+    token_address: Mapped[str | None] = mapped_column(String(42))
     # processing status (BatchRegisterPersonalInfoUploadStatus)
     status: Mapped[str] = mapped_column(String, nullable=False, index=True)
 

--- a/app/model/schema/notification.py
+++ b/app/model/schema/notification.py
@@ -59,6 +59,7 @@ class CreateLedgerInfoMetaInfo(BaseModel):
 
 class BatchRegisterPersonalInfoErrorMetaInfo(BaseModel):
     upload_id: str
+    token_address: Optional[str] = None
     error_registration_id: list[int]
 
 

--- a/app/routers/issuer/bond.py
+++ b/app/routers/issuer/bond.py
@@ -2772,7 +2772,8 @@ async def initiate_bond_token_batch_personal_info_registration(
     batch = BatchRegisterPersonalInfoUpload()
     batch.upload_id = batch_id
     batch.issuer_address = issuer_address
-    batch.status = BatchRegisterPersonalInfoUploadStatus.PENDING.value
+    batch.token_address = token_address
+    batch.status = BatchRegisterPersonalInfoUploadStatus.PENDING
     db.add(batch)
 
     errs = []

--- a/app/routers/issuer/share.py
+++ b/app/routers/issuer/share.py
@@ -2700,7 +2700,8 @@ async def initiate_share_token_batch_personal_info_registration(
     batch = BatchRegisterPersonalInfoUpload()
     batch.upload_id = batch_id
     batch.issuer_address = issuer_address
-    batch.status = BatchRegisterPersonalInfoUploadStatus.PENDING.value
+    batch.token_address = token_address
+    batch.status = BatchRegisterPersonalInfoUploadStatus.PENDING
     db.add(batch)
 
     errs = []

--- a/batch/processor_batch_register_personal_info.py
+++ b/batch/processor_batch_register_personal_info.py
@@ -118,11 +118,12 @@ class Processor:
                     await self.__sink_on_finish_upload_process(
                         db_session=db_session,
                         upload_id=_upload.upload_id,
-                        status=BatchRegisterPersonalInfoUploadStatus.FAILED.value,
+                        status=BatchRegisterPersonalInfoUploadStatus.FAILED,
                     )
                     await self.__sink_on_error_notification(
                         db_session=db_session,
                         issuer_address=_upload.issuer_address,
+                        token_address=_upload.token_address,
                         code=0,
                         upload_id=_upload.upload_id,
                         error_registration_id=[],
@@ -197,14 +198,14 @@ class Processor:
                     await self.__sink_on_finish_upload_process(
                         db_session=db_session,
                         upload_id=_upload.upload_id,
-                        status=BatchRegisterPersonalInfoUploadStatus.DONE.value,
+                        status=BatchRegisterPersonalInfoUploadStatus.DONE,
                     )
                 else:
                     # failed
                     await self.__sink_on_finish_upload_process(
                         db_session=db_session,
                         upload_id=_upload.upload_id,
-                        status=BatchRegisterPersonalInfoUploadStatus.FAILED.value,
+                        status=BatchRegisterPersonalInfoUploadStatus.FAILED,
                     )
                     error_registration_id = [
                         _error_registration.id
@@ -213,6 +214,7 @@ class Processor:
                     await self.__sink_on_error_notification(
                         db_session=db_session,
                         issuer_address=_upload.issuer_address,
+                        token_address=_upload.token_address,
                         code=1,
                         upload_id=_upload.upload_id,
                         error_registration_id=error_registration_id,
@@ -407,18 +409,20 @@ class Processor:
     async def __sink_on_error_notification(
         db_session: AsyncSession,
         issuer_address: str,
+        token_address: str | None,
         code: int,
         upload_id: str,
         error_registration_id: list[int],
     ):
         notification = Notification()
-        notification.notice_id = uuid.uuid4()
+        notification.notice_id = str(uuid.uuid4())
         notification.issuer_address = issuer_address
         notification.priority = 1  # Medium
         notification.type = NotificationType.BATCH_REGISTER_PERSONAL_INFO_ERROR
         notification.code = code
         notification.metainfo = {
             "upload_id": upload_id,
+            "token_address": token_address,
             "error_registration_id": error_registration_id,
         }
         db_session.add(notification)

--- a/docs/ibet_prime.yaml
+++ b/docs/ibet_prime.yaml
@@ -10344,6 +10344,11 @@ components:
         upload_id:
           type: string
           title: Upload Id
+        token_address:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Token Address
         error_registration_id:
           items:
             type: integer

--- a/migrations/versions/02791d34c2ad_v25_3_0_feature_736.py
+++ b/migrations/versions/02791d34c2ad_v25_3_0_feature_736.py
@@ -1,0 +1,33 @@
+"""v25_3_0_feature_736
+
+Revision ID: 02791d34c2ad
+Revises: 3b7e17706e3e
+Create Date: 2025-01-06 18:41:14.077404
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+from app.database import get_db_schema
+
+# revision identifiers, used by Alembic.
+revision = "02791d34c2ad"
+down_revision = "3b7e17706e3e"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "batch_register_personal_info_upload",
+        sa.Column("token_address", sa.String(length=42), nullable=True),
+        schema=get_db_schema(),
+    )
+
+
+def downgrade():
+    op.drop_column(
+        "batch_register_personal_info_upload", "token_address", schema=get_db_schema()
+    )

--- a/tests/app/test_bond_personal_info_InitiateBondTokenBatchPersonalInfoRegistration.py
+++ b/tests/app/test_bond_personal_info_InitiateBondTokenBatchPersonalInfoRegistration.py
@@ -65,11 +65,11 @@ class TestInitiateBondTokenBatchPersonalInfoRegistration:
         db.add(account)
 
         token = Token()
-        token.type = TokenType.IBET_STRAIGHT_BOND.value
+        token.type = TokenType.IBET_STRAIGHT_BOND
         token.tx_hash = ""
         token.issuer_address = _issuer_address
         token.token_address = _token_address
-        token.abi = ""
+        token.abi = {}
         token.version = TokenVersion.V_24_09
         db.add(token)
 
@@ -110,6 +110,7 @@ class TestInitiateBondTokenBatchPersonalInfoRegistration:
         ).first()
         assert _upload.status == BatchRegisterPersonalInfoUploadStatus.PENDING.value
         assert _upload.issuer_address == _issuer_address
+        assert _upload.token_address == _token_address
 
         _register_list: list[BatchRegisterPersonalInfo] = db.scalars(
             select(BatchRegisterPersonalInfo)
@@ -142,11 +143,11 @@ class TestInitiateBondTokenBatchPersonalInfoRegistration:
         db.add(auth_token)
 
         token = Token()
-        token.type = TokenType.IBET_STRAIGHT_BOND.value
+        token.type = TokenType.IBET_STRAIGHT_BOND
         token.tx_hash = ""
         token.issuer_address = _issuer_address
         token.token_address = _token_address
-        token.abi = ""
+        token.abi = {}
         token.version = TokenVersion.V_24_09
         db.add(token)
 
@@ -187,6 +188,7 @@ class TestInitiateBondTokenBatchPersonalInfoRegistration:
         ).first()
         assert _upload.status == BatchRegisterPersonalInfoUploadStatus.PENDING.value
         assert _upload.issuer_address == _issuer_address
+        assert _upload.token_address == _token_address
 
         _register_list: list[BatchRegisterPersonalInfo] = db.scalars(
             select(BatchRegisterPersonalInfo)
@@ -729,11 +731,11 @@ class TestInitiateBondTokenBatchPersonalInfoRegistration:
         db.add(account)
 
         token = Token()
-        token.type = TokenType.IBET_STRAIGHT_BOND.value
+        token.type = TokenType.IBET_STRAIGHT_BOND
         token.tx_hash = ""
         token.issuer_address = _issuer_address
         token.token_address = _token_address
-        token.abi = ""
+        token.abi = {}
         token.token_status = 0
         token.version = TokenVersion.V_24_09
         db.add(token)
@@ -791,11 +793,11 @@ class TestInitiateBondTokenBatchPersonalInfoRegistration:
         db.add(account)
 
         token = Token()
-        token.type = TokenType.IBET_STRAIGHT_BOND.value
+        token.type = TokenType.IBET_STRAIGHT_BOND
         token.tx_hash = ""
         token.issuer_address = _issuer_address
         token.token_address = _token_address
-        token.abi = ""
+        token.abi = {}
         token.token_status = 1
         token.version = TokenVersion.V_24_09
         db.add(token)
@@ -843,11 +845,11 @@ class TestInitiateBondTokenBatchPersonalInfoRegistration:
         db.add(account)
 
         token = Token()
-        token.type = TokenType.IBET_STRAIGHT_BOND.value
+        token.type = TokenType.IBET_STRAIGHT_BOND
         token.tx_hash = ""
         token.issuer_address = _issuer_address
         token.token_address = _token_address
-        token.abi = ""
+        token.abi = {}
         token.version = TokenVersion.V_24_09
         db.add(token)
 

--- a/tests/app/test_notifications_ListAllNotifications.py
+++ b/tests/app/test_notifications_ListAllNotifications.py
@@ -138,6 +138,7 @@ class TestListAllNotifications:
         _notification_6.code = 1
         _notification_6.metainfo = {
             "upload_id": str(uuid.uuid4()),
+            "token_address": test_token_address,
             "error_registration_id": [1, 2, 3],
         }
         _notification_6.created = datetime.strptime(
@@ -307,7 +308,11 @@ class TestListAllNotifications:
                     "priority": 0,
                     "notice_type": NotificationType.BATCH_REGISTER_PERSONAL_INFO_ERROR,
                     "notice_code": 1,
-                    "metainfo": {"upload_id": ANY, "error_registration_id": [1, 2, 3]},
+                    "metainfo": {
+                        "upload_id": ANY,
+                        "token_address": test_token_address,
+                        "error_registration_id": [1, 2, 3],
+                    },
                     "created": "2022-01-06T09:20:30+09:00",
                 },
                 {
@@ -460,7 +465,7 @@ class TestListAllNotifications:
         resp = client.get(
             self.base_url,
             params={
-                "notice_type": NotificationType.SCHEDULE_EVENT_ERROR.value,
+                "notice_type": NotificationType.SCHEDULE_EVENT_ERROR,
             },
             headers={
                 "issuer-address": issuer_address_1,

--- a/tests/app/test_share_personal_info_InitiateShareTokenBatchPersonalInfoRegistration.py
+++ b/tests/app/test_share_personal_info_InitiateShareTokenBatchPersonalInfoRegistration.py
@@ -65,11 +65,11 @@ class TestInitiateShareTokenBatchPersonalInfoRegistration:
         db.add(account)
 
         token = Token()
-        token.type = TokenType.IBET_SHARE.value
+        token.type = TokenType.IBET_SHARE
         token.tx_hash = ""
         token.issuer_address = _issuer_address
         token.token_address = _token_address
-        token.abi = ""
+        token.abi = {}
         token.version = TokenVersion.V_24_09
         db.add(token)
 
@@ -110,6 +110,7 @@ class TestInitiateShareTokenBatchPersonalInfoRegistration:
         ).first()
         assert _upload.status == BatchRegisterPersonalInfoUploadStatus.PENDING.value
         assert _upload.issuer_address == _issuer_address
+        assert _upload.token_address == _token_address
 
         _register_list: list[BatchRegisterPersonalInfo] = db.scalars(
             select(BatchRegisterPersonalInfo)
@@ -142,11 +143,11 @@ class TestInitiateShareTokenBatchPersonalInfoRegistration:
         db.add(auth_token)
 
         token = Token()
-        token.type = TokenType.IBET_SHARE.value
+        token.type = TokenType.IBET_SHARE
         token.tx_hash = ""
         token.issuer_address = _issuer_address
         token.token_address = _token_address
-        token.abi = ""
+        token.abi = {}
         token.version = TokenVersion.V_24_09
         db.add(token)
 
@@ -187,6 +188,7 @@ class TestInitiateShareTokenBatchPersonalInfoRegistration:
         ).first()
         assert _upload.status == BatchRegisterPersonalInfoUploadStatus.PENDING.value
         assert _upload.issuer_address == _issuer_address
+        assert _upload.token_address == _token_address
 
         _register_list: list[BatchRegisterPersonalInfo] = db.scalars(
             select(BatchRegisterPersonalInfo)
@@ -662,11 +664,11 @@ class TestInitiateShareTokenBatchPersonalInfoRegistration:
         db.add(account)
 
         token = Token()
-        token.type = TokenType.IBET_SHARE.value
+        token.type = TokenType.IBET_SHARE
         token.tx_hash = ""
         token.issuer_address = _issuer_address
         token.token_address = _token_address
-        token.abi = ""
+        token.abi = {}
         token.token_status = 0
         token.version = TokenVersion.V_24_09
         db.add(token)
@@ -724,11 +726,11 @@ class TestInitiateShareTokenBatchPersonalInfoRegistration:
         db.add(account)
 
         token = Token()
-        token.type = TokenType.IBET_SHARE.value
+        token.type = TokenType.IBET_SHARE
         token.tx_hash = ""
         token.issuer_address = _issuer_address
         token.token_address = _token_address
-        token.abi = ""
+        token.abi = {}
         token.token_status = 1
         token.version = TokenVersion.V_24_09
         db.add(token)
@@ -776,11 +778,11 @@ class TestInitiateShareTokenBatchPersonalInfoRegistration:
         db.add(account)
 
         token = Token()
-        token.type = TokenType.IBET_SHARE.value
+        token.type = TokenType.IBET_SHARE
         token.tx_hash = ""
         token.issuer_address = _issuer_address
         token.token_address = _token_address
-        token.abi = ""
+        token.abi = {}
         token.version = TokenVersion.V_24_09
         db.add(token)
 

--- a/tests/batch/test_processor_register_personal_info.py
+++ b/tests/batch/test_processor_register_personal_info.py
@@ -166,7 +166,7 @@ class TestProcessor:
         )
         token_address_1 = token_contract_1.address
         token_1 = Token()
-        token_1.type = TokenType.IBET_SHARE.value
+        token_1.type = TokenType.IBET_SHARE
         token_1.token_address = token_address_1
         token_1.issuer_address = _account["address"]
         token_1.abi = token_contract_1.abi
@@ -211,7 +211,7 @@ class TestProcessor:
         )
         token_address_1 = token_contract_1.address
         token_1 = Token()
-        token_1.type = TokenType.IBET_SHARE.value
+        token_1.type = TokenType.IBET_SHARE
         token_1.token_address = token_address_1
         token_1.issuer_address = _account["address"]
         token_1.abi = token_contract_1.abi
@@ -314,7 +314,7 @@ class TestProcessor:
         )
         token_address_1 = token_contract_1.address
         token_1 = Token()
-        token_1.type = TokenType.IBET_SHARE.value
+        token_1.type = TokenType.IBET_SHARE
         token_1.token_address = token_address_1
         token_1.issuer_address = _account["address"]
         token_1.abi = token_contract_1.abi
@@ -330,9 +330,7 @@ class TestProcessor:
                 _account["address"] if i % 3 == 0 else _other_issuer["address"]
             )
             batch_register_upload.upload_id = self.upload_id_list[i]
-            batch_register_upload.status = (
-                BatchRegisterPersonalInfoUploadStatus.PENDING.value
-            )
+            batch_register_upload.status = BatchRegisterPersonalInfoUploadStatus.PENDING
             db.add(batch_register_upload)
 
         # Prepare data : BatchRegisterPersonalInfo
@@ -473,7 +471,7 @@ class TestProcessor:
         )
         token_address_1 = token_contract_1.address
         token_1 = Token()
-        token_1.type = TokenType.IBET_SHARE.value
+        token_1.type = TokenType.IBET_SHARE
         token_1.token_address = token_address_1
         token_1.issuer_address = _account["address"]
         token_1.abi = token_contract_1.abi
@@ -487,9 +485,7 @@ class TestProcessor:
             batch_register_upload = BatchRegisterPersonalInfoUpload()
             batch_register_upload.issuer_address = _account["address"]
             batch_register_upload.upload_id = self.upload_id_list[i]
-            batch_register_upload.status = (
-                BatchRegisterPersonalInfoUploadStatus.PENDING.value
-            )
+            batch_register_upload.status = BatchRegisterPersonalInfoUploadStatus.PENDING
             db.add(batch_register_upload)
 
         # Prepare data : BatchRegisterPersonalInfo
@@ -613,7 +609,7 @@ class TestProcessor:
         )
         token_address_1 = token_contract_1.address
         token_1 = Token()
-        token_1.type = TokenType.IBET_SHARE.value
+        token_1.type = TokenType.IBET_SHARE
         token_1.token_address = token_address_1
         token_1.issuer_address = _account["address"]
         token_1.abi = token_contract_1.abi
@@ -625,9 +621,8 @@ class TestProcessor:
         batch_register_upload = BatchRegisterPersonalInfoUpload()
         batch_register_upload.issuer_address = _account["address"]
         batch_register_upload.upload_id = self.upload_id_list[0]
-        batch_register_upload.status = (
-            BatchRegisterPersonalInfoUploadStatus.PENDING.value
-        )
+        batch_register_upload.token_address = token_address_1
+        batch_register_upload.status = BatchRegisterPersonalInfoUploadStatus.PENDING
         db.add(batch_register_upload)
 
         # Prepare data : BatchRegisterPersonalInfo
@@ -697,6 +692,7 @@ class TestProcessor:
                 assert _notification.code == 0
                 assert _notification.metainfo == {
                     "upload_id": batch_register_upload.upload_id,
+                    "token_address": batch_register_upload.token_address,
                     "error_registration_id": [],
                 }
 
@@ -728,7 +724,7 @@ class TestProcessor:
         )
         token_address_1 = token_contract_1.address
         token_1 = Token()
-        token_1.type = TokenType.IBET_SHARE.value
+        token_1.type = TokenType.IBET_SHARE
         token_1.token_address = token_address_1
         token_1.issuer_address = _account["address"]
         token_1.abi = token_contract_1.abi
@@ -740,9 +736,8 @@ class TestProcessor:
         batch_register_upload = BatchRegisterPersonalInfoUpload()
         batch_register_upload.issuer_address = _account["address"]
         batch_register_upload.upload_id = self.upload_id_list[0]
-        batch_register_upload.status = (
-            BatchRegisterPersonalInfoUploadStatus.PENDING.value
-        )
+        batch_register_upload.token_address = token_address_1
+        batch_register_upload.status = BatchRegisterPersonalInfoUploadStatus.PENDING
         db.add(batch_register_upload)
 
         # Prepare data : BatchRegisterPersonalInfo
@@ -828,6 +823,7 @@ class TestProcessor:
                 assert _notification.code == 1
                 assert _notification.metainfo == {
                     "upload_id": batch_register_upload.upload_id,
+                    "token_address": batch_register_upload.token_address,
                     "error_registration_id": [
                         batch_register.id for batch_register in batch_register_list
                     ],
@@ -861,7 +857,7 @@ class TestProcessor:
         )
         token_address_1 = token_contract_1.address
         token_1 = Token()
-        token_1.type = TokenType.IBET_SHARE.value
+        token_1.type = TokenType.IBET_SHARE
         token_1.token_address = token_address_1
         token_1.issuer_address = _account["address"]
         token_1.abi = token_contract_1.abi
@@ -873,9 +869,8 @@ class TestProcessor:
         batch_register_upload = BatchRegisterPersonalInfoUpload()
         batch_register_upload.issuer_address = _account["address"]
         batch_register_upload.upload_id = self.upload_id_list[0]
-        batch_register_upload.status = (
-            BatchRegisterPersonalInfoUploadStatus.PENDING.value
-        )
+        batch_register_upload.token_address = token_address_1
+        batch_register_upload.status = BatchRegisterPersonalInfoUploadStatus.PENDING
         db.add(batch_register_upload)
 
         # Prepare data : BatchRegisterPersonalInfo
@@ -961,6 +956,7 @@ class TestProcessor:
                 assert _notification.code == 1
                 assert _notification.metainfo == {
                     "upload_id": batch_register_upload.upload_id,
+                    "token_address": batch_register_upload.token_address,
                     "error_registration_id": [
                         batch_register.id for batch_register in batch_register_list
                     ],
@@ -1009,7 +1005,7 @@ EK7Y4zFFnfKP3WIA3atUbbcCAwEAAQ==
         )
         token_address_1 = token_contract_1.address
         token_1 = Token()
-        token_1.type = TokenType.IBET_SHARE.value
+        token_1.type = TokenType.IBET_SHARE
         token_1.token_address = token_address_1
         token_1.issuer_address = _account["address"]
         token_1.abi = token_contract_1.abi
@@ -1021,9 +1017,8 @@ EK7Y4zFFnfKP3WIA3atUbbcCAwEAAQ==
         batch_register_upload = BatchRegisterPersonalInfoUpload()
         batch_register_upload.issuer_address = _account["address"]
         batch_register_upload.upload_id = self.upload_id_list[0]
-        batch_register_upload.status = (
-            BatchRegisterPersonalInfoUploadStatus.PENDING.value
-        )
+        batch_register_upload.token_address = token_address_1
+        batch_register_upload.status = BatchRegisterPersonalInfoUploadStatus.PENDING
         db.add(batch_register_upload)
 
         # Prepare data : BatchRegisterPersonalInfo
@@ -1099,6 +1094,7 @@ EK7Y4zFFnfKP3WIA3atUbbcCAwEAAQ==
             assert _notification.code == 1
             assert _notification.metainfo == {
                 "upload_id": batch_register_upload.upload_id,
+                "token_address": batch_register_upload.token_address,
                 "error_registration_id": [
                     batch_register.id for batch_register in batch_register_list
                 ],


### PR DESCRIPTION
close #736 

Add `token_address` to the metainfo of the `BatchRegisterPersonalInfoError `
- Do not set it for past records.  
- Make it optional in the schema definition as well.  

I chose the approach of adding a field to the upload TBL.