### PR TITLE
Change the database connection in AsyncContractUtils to use asyncpg

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,13 +85,13 @@ The main environment variables are as follows.
         <td>DATABASE_URL</td>
         <td>False</td>
         <td nowrap>Database URL</td>
-        <td>postgresql+psycopg://issuerapi:issuerapipass@localhost:5432/issuerapidb</td>
+        <td>postgresql://issuerapi:issuerapipass@localhost:5432/issuerapidb</td>
     </tr>
     <tr>
         <td>TEST_DATABASE_URL</td>
         <td>False</td>
         <td nowrap>Test database URL</td>
-        <td>postgresql+psycopg://issuerapi:issuerapipass@localhost:5432/issuerapidb</td>
+        <td>postgresql://issuerapi:issuerapipass@localhost:5432/issuerapidb</td>
     </tr>
     <tr>
         <td>DATABASE_SCHEMA</td>

--- a/README_JA.md
+++ b/README_JA.md
@@ -86,13 +86,13 @@ $ npm install
         <td>DATABASE_URL</td>
         <td>False</td>
         <td nowrap>データベース URL</td>
-        <td>postgresql+psycopg://issuerapi:issuerapipass@localhost:5432/issuerapidb</td>
+        <td>postgresql://issuerapi:issuerapipass@localhost:5432/issuerapidb</td>
     </tr>
     <tr>
         <td>TEST_DATABASE_URL</td>
         <td>False</td>
         <td nowrap>テスト用データベース URL</td>
-        <td>postgresql+psycopg://issuerapi:issuerapipass@localhost:5432/issuerapidb</td>
+        <td>postgresql://issuerapi:issuerapipass@localhost:5432/issuerapidb</td>
     </tr>
     <tr>
         <td>DATABASE_SCHEMA</td>

--- a/batch/indexer_block_tx_data.py
+++ b/batch/indexer_block_tx_data.py
@@ -23,7 +23,7 @@ from typing import Sequence
 
 import uvloop
 from eth_utils import to_checksum_address
-from sqlalchemy import create_engine, select
+from sqlalchemy import select
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 from web3.types import BlockData, TxData
@@ -33,13 +33,12 @@ from app.exceptions import ServiceUnavailableError
 from app.model.db import IDXBlockData, IDXBlockDataBlockNumber, IDXTxData
 from app.utils.web3_utils import AsyncWeb3Wrapper
 from batch.utils import batch_log
-from config import CHAIN_ID, DATABASE_URL, INDEXER_SYNC_INTERVAL
+from config import CHAIN_ID, INDEXER_SYNC_INTERVAL
 
 process_name = "INDEXER-BLOCK_TX_DATA"
 LOG = batch_log.get_logger(process_name=process_name)
 
 web3 = AsyncWeb3Wrapper()
-db_engine = create_engine(DATABASE_URL, echo=False, pool_pre_ping=True)
 
 
 class Processor:

--- a/batch/indexer_token_holders.py
+++ b/batch/indexer_token_holders.py
@@ -22,7 +22,7 @@ import sys
 from typing import Dict, Optional, Sequence
 
 import uvloop
-from sqlalchemy import and_, create_engine, delete, select
+from sqlalchemy import and_, delete, select
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 from web3.contract import AsyncContract
@@ -42,7 +42,6 @@ from app.utils.contract_utils import AsyncContractUtils
 from app.utils.web3_utils import AsyncWeb3Wrapper
 from batch.utils import batch_log
 from config import (
-    DATABASE_URL,
     INDEXER_BLOCK_LOT_MAX_SIZE,
     INDEXER_SYNC_INTERVAL,
     ZERO_ADDRESS,
@@ -50,8 +49,6 @@ from config import (
 
 process_name = "INDEXER-Token-Holders"
 LOG = batch_log.get_logger(process_name=process_name)
-
-db_engine = create_engine(DATABASE_URL, echo=False, pool_pre_ping=True)
 
 web3 = AsyncWeb3Wrapper()
 

--- a/batch/processor_batch_issue_redeem.py
+++ b/batch/processor_batch_issue_redeem.py
@@ -25,7 +25,7 @@ from typing import Sequence
 
 import uvloop
 from eth_keyfile import decode_keyfile_json
-from sqlalchemy import and_, create_engine, select
+from sqlalchemy import and_, select
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -54,7 +54,7 @@ from app.model.db import (
 from app.utils.e2ee_utils import E2EEUtils
 from batch.utils import batch_log
 from batch.utils.signal_handler import setup_signal_handler
-from config import BULK_TX_LOT_SIZE, DATABASE_URL
+from config import BULK_TX_LOT_SIZE
 
 """
 [PROCESSOR-Batch-Issue-Redeem]
@@ -64,8 +64,6 @@ Batch processing for additional issuance and redemption
 
 process_name = "PROCESSOR-Batch-Issue-Redeem"
 LOG = batch_log.get_logger(process_name=process_name)
-
-db_engine = create_engine(DATABASE_URL, echo=False, pool_pre_ping=True)
 
 
 class Processor:

--- a/batch/processor_create_utxo.py
+++ b/batch/processor_create_utxo.py
@@ -24,7 +24,7 @@ from datetime import UTC, datetime
 from typing import Sequence
 
 import uvloop
-from sqlalchemy import and_, create_engine, select
+from sqlalchemy import and_, select
 from sqlalchemy.exc import DBAPIError, SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -39,7 +39,6 @@ from batch.utils import batch_log
 from config import (
     CREATE_UTXO_BLOCK_LOT_MAX_SIZE,
     CREATE_UTXO_INTERVAL,
-    DATABASE_URL,
     ZERO_ADDRESS,
 )
 
@@ -51,8 +50,6 @@ Batch processing for creation of ledger data
 
 process_name = "PROCESSOR-Create-UTXO"
 LOG = batch_log.get_logger(process_name=process_name)
-
-db_engine = create_engine(DATABASE_URL, echo=False, pool_pre_ping=True)
 
 web3 = AsyncWeb3Wrapper()
 

--- a/batch/processor_dvp_async_tx.py
+++ b/batch/processor_dvp_async_tx.py
@@ -24,7 +24,7 @@ from typing import Sequence
 
 import uvloop
 from eth_keyfile import decode_keyfile_json
-from sqlalchemy import and_, asc, create_engine, select
+from sqlalchemy import and_, asc, select
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 from web3.exceptions import TimeExhausted
@@ -48,7 +48,6 @@ from app.utils.contract_utils import AsyncContractUtils
 from app.utils.e2ee_utils import E2EEUtils
 from batch.utils import batch_log
 from batch.utils.signal_handler import setup_signal_handler
-from config import DATABASE_URL
 
 """
 [PROCESSOR-DVP-ASYNC-TX]
@@ -58,8 +57,6 @@ A processor for asynchronous transaction execution of DVP
 
 process_name = "PROCESSOR-DVP-Async-Tx"
 LOG = batch_log.get_logger(process_name=process_name)
-
-db_engine = create_engine(DATABASE_URL, echo=False, pool_pre_ping=True)
 
 
 class Processor:

--- a/batch/processor_generate_rsa_key.py
+++ b/batch/processor_generate_rsa_key.py
@@ -24,7 +24,7 @@ from typing import Sequence
 import uvloop
 from Crypto import Random
 from Crypto.PublicKey import RSA
-from sqlalchemy import and_, create_engine, or_, select
+from sqlalchemy import and_, or_, select
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -32,7 +32,6 @@ from app.database import BatchAsyncSessionLocal
 from app.model.db import Account, AccountRsaKeyTemporary, AccountRsaStatus
 from app.utils.e2ee_utils import E2EEUtils
 from batch.utils import batch_log
-from config import DATABASE_URL
 
 """
 [PROCESSOR-Generate-RSA-Key]
@@ -42,8 +41,6 @@ Process for generating and updating issuer RSA keys
 
 process_name = "PROCESSOR-Generate-RSA-Key"
 LOG = batch_log.get_logger(process_name=process_name)
-
-db_engine = create_engine(DATABASE_URL, echo=False, pool_pre_ping=True)
 
 
 class Processor:


### PR DESCRIPTION
In `send_transaction` of `AsyncContractUtils`, `psycopg` was still being used during table locks. This has now been replaced with `asyncpg`, making it consistent with other online processes.  
- **Note:** The non-async version of `ContractUtils` will continue to use `psycopg`.  

Various other improvements were also made.