### PR TITLE
Optimize row count query performance of multiple joined statement

### DIFF
--- a/app/routers/issuer/bond.py
+++ b/app/routers/issuer/bond.py
@@ -2035,7 +2035,7 @@ async def list_all_bond_token_holders(
     )
 
     total = await db.scalar(
-        select(func.count()).select_from(stmt.with_only_columns(1).order_by(None))
+        select(func.count()).select_from(IDXPosition).where(IDXPosition.token_address == token_address)
     )
 
     if not get_query.include_former_holder:

--- a/app/routers/issuer/share.py
+++ b/app/routers/issuer/share.py
@@ -1963,7 +1963,7 @@ async def list_all_share_token_holders(
     )
 
     total = await db.scalar(
-        select(func.count()).select_from(stmt.with_only_columns(1).order_by(None))
+        select(func.count()).select_from(IDXPosition).where(IDXPosition.token_address == token_address)
     )
 
     if not get_query.include_former_holder:


### PR DESCRIPTION
- Related to #763 
- Optimized row count query performance of multiple joined statement
- Target APIs are as follows:
  - GET: `/bond/tokens/{token_address}/holders`
  - GET: `/share/tokens/{token_address}/holders`