### PR TITLE
Add SQL INDEX to optimize token holders API performance

### DIFF
--- a/app/model/db/idx_personal_info.py
+++ b/app/model/db/idx_personal_info.py
@@ -21,7 +21,7 @@ from datetime import datetime
 from enum import StrEnum
 
 import pytz
-from sqlalchemy import JSON, BigInteger, DateTime, String
+from sqlalchemy import JSON, BigInteger, DateTime, Index, String
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -62,6 +62,15 @@ class IDXPersonalInfo(Base):
     # data source
     data_source: Mapped[PersonalInfoDataSource] = mapped_column(
         String(10), nullable=False
+    )
+
+    __table_args__ = (
+        Index(
+            "idx_personal_info_issuer_account",
+            issuer_address,
+            account_address,
+            postgresql_include=["personal_info", "data_source", "created", "modified"],
+        ),
     )
 
     @hybrid_property

--- a/app/model/db/idx_position.py
+++ b/app/model/db/idx_position.py
@@ -17,7 +17,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-from sqlalchemy import BigInteger, String
+from sqlalchemy import BigInteger, Index, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from .base import Base
@@ -40,6 +40,31 @@ class IDXPosition(Base):
     exchange_commitment: Mapped[int | None] = mapped_column(BigInteger)
     # pendingTransfer
     pending_transfer: Mapped[int | None] = mapped_column(BigInteger)
+
+    __table_args__ = (
+        Index(
+            "idx_position_token_account_value",
+            token_address,
+            account_address,
+            balance,
+            exchange_balance,
+            pending_transfer,
+            exchange_commitment,
+        ),
+        Index(
+            "idx_position_token_account",
+            token_address,
+            account_address,
+            postgresql_include=[
+                "balance",
+                "exchange_balance",
+                "exchange_commitment",
+                "pending_transfer",
+                "created",
+                "modified",
+            ],
+        ),
+    )
 
     def json(self):
         return {
@@ -86,6 +111,16 @@ class IDXLockedPosition(Base):
     account_address: Mapped[str] = mapped_column(String(42), primary_key=True)
     # locked amount
     value: Mapped[int] = mapped_column(BigInteger, nullable=False)
+
+    __table_args__ = (
+        Index(
+            "idx_locked_position_token_account_value_modified",
+            token_address,
+            account_address,
+            value,
+            "modified",
+        ),
+    )
 
     def json(self):
         return {

--- a/migrations/versions/40e3e7206fbc_v25_3_0_fix_763_2.py
+++ b/migrations/versions/40e3e7206fbc_v25_3_0_fix_763_2.py
@@ -1,0 +1,98 @@
+"""v25_3_0_fix_763_2
+
+Revision ID: 40e3e7206fbc
+Revises: 18506373ccd3
+Create Date: 2025-02-26 12:33:20.263287
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+from app.database import get_db_schema
+
+# revision identifiers, used by Alembic.
+revision = "40e3e7206fbc"
+down_revision = "18506373ccd3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index(
+        "idx_locked_position_token_account_value_modified",
+        "idx_locked_position",
+        ["token_address", "account_address", "value", "modified"],
+        unique=False,
+        schema=get_db_schema(),
+    )
+    op.create_index(
+        "idx_personal_info_issuer_account",
+        "idx_personal_info",
+        ["issuer_address", "account_address"],
+        unique=False,
+        postgresql_include=["personal_info", "data_source", "created", "modified"],
+        schema=get_db_schema(),
+    )
+    op.create_index(
+        "idx_position_token_account",
+        "idx_position",
+        ["token_address", "account_address"],
+        unique=False,
+        postgresql_include=[
+            "balance",
+            "exchange_balance",
+            "exchange_commitment",
+            "pending_transfer",
+            "created",
+            "modified",
+        ],
+        schema=get_db_schema(),
+    )
+    op.create_index(
+        "idx_position_token_account_value",
+        "idx_position",
+        [
+            "token_address",
+            "account_address",
+            "balance",
+            "exchange_balance",
+            "pending_transfer",
+            "exchange_commitment",
+        ],
+        unique=False,
+        schema=get_db_schema(),
+    )
+
+
+def downgrade():
+    op.drop_index(
+        "idx_position_token_account_value",
+        table_name="idx_position",
+        schema=get_db_schema(),
+    )
+    op.drop_index(
+        "idx_position_token_account",
+        table_name="idx_position",
+        postgresql_include=[
+            "balance",
+            "exchange_balance",
+            "exchange_commitment",
+            "pending_transfer",
+            "created",
+            "modified",
+        ],
+        schema=get_db_schema(),
+    )
+    op.drop_index(
+        "idx_personal_info_issuer_account",
+        table_name="idx_personal_info",
+        postgresql_include=["personal_info", "data_source", "created", "modified"],
+        schema=get_db_schema(),
+    )
+    op.drop_index(
+        "idx_locked_position_token_account_value_modified",
+        table_name="idx_locked_position",
+        schema=get_db_schema(),
+    )


### PR DESCRIPTION
- Additional fix related to 
  - #763 
  - #764 
- Added SQL INDEX to optimize follow APIs
  - GET: `/bond/tokens/{token_address}/holders`
  - GET: `/share/tokens/{token_address}/holders`