### PR TITLE
Release free memory back to the OS with malloc_trim

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -17,6 +17,8 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
+import ctypes
+from ctypes.util import find_library
 from datetime import UTC, datetime
 
 from fastapi import FastAPI, Request
@@ -126,6 +128,8 @@ async def api_call_handler(request: Request, call_next):
 
 app.openapi = custom_openapi(app)
 
+libc = ctypes.CDLL(find_library("c"))
+
 
 ###############################################################
 # ROUTER
@@ -134,6 +138,7 @@ app.openapi = custom_openapi(app)
 
 @app.get("/", tags=["root"])
 async def root():
+    libc.malloc_trim(0)
     return {"server": SERVER_NAME}
 
 

--- a/batch/__init__.py
+++ b/batch/__init__.py
@@ -16,3 +16,12 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
+
+import ctypes
+from ctypes.util import find_library
+
+libc = ctypes.CDLL(find_library("c"))
+
+
+def free_malloc():
+    libc.malloc_trim(0)

--- a/batch/indexer_block_tx_data.py
+++ b/batch/indexer_block_tx_data.py
@@ -32,6 +32,7 @@ from app.database import BatchAsyncSessionLocal
 from app.exceptions import ServiceUnavailableError
 from app.model.db import IDXBlockData, IDXBlockDataBlockNumber, IDXTxData
 from app.utils.web3_utils import AsyncWeb3Wrapper
+from batch import free_malloc
 from batch.utils import batch_log
 from config import CHAIN_ID, INDEXER_SYNC_INTERVAL
 
@@ -162,6 +163,7 @@ async def main():
             LOG.exception("An exception occurred during event synchronization")
 
         await asyncio.sleep(INDEXER_SYNC_INTERVAL)
+        free_malloc()
 
 
 if __name__ == "__main__":

--- a/batch/indexer_dvp_delivery.py
+++ b/batch/indexer_dvp_delivery.py
@@ -55,6 +55,7 @@ from app.model.db import (
 )
 from app.utils.contract_utils import AsyncContractUtils
 from app.utils.web3_utils import AsyncWeb3Wrapper
+from batch import free_malloc
 from batch.utils import batch_log
 from config import (
     DVP_DATA_ENCRYPTION_KEY,
@@ -833,6 +834,7 @@ async def main():
             LOG.error(ex)
 
         await asyncio.sleep(INDEXER_SYNC_INTERVAL)
+        free_malloc()
 
 
 if __name__ == "__main__":

--- a/batch/indexer_e2e_messaging.py
+++ b/batch/indexer_e2e_messaging.py
@@ -43,6 +43,7 @@ from app.model.db import (
 from app.utils.contract_utils import AsyncContractUtils
 from app.utils.e2ee_utils import E2EEUtils
 from app.utils.web3_utils import AsyncWeb3Wrapper
+from batch import free_malloc
 from batch.utils import batch_log
 from config import (
     E2E_MESSAGING_CONTRACT_ADDRESS,
@@ -338,6 +339,7 @@ async def main():
 
         elapsed_time = time.time() - start_time
         await asyncio.sleep(max(INDEXER_SYNC_INTERVAL - elapsed_time, 0))
+        free_malloc()
 
 
 if __name__ == "__main__":

--- a/batch/indexer_issue_redeem.py
+++ b/batch/indexer_issue_redeem.py
@@ -40,6 +40,7 @@ from app.model.db import (
 )
 from app.utils.contract_utils import AsyncContractEventsView, AsyncContractUtils
 from app.utils.web3_utils import AsyncWeb3Wrapper
+from batch import free_malloc
 from batch.utils import batch_log
 from config import INDEXER_BLOCK_LOT_MAX_SIZE, INDEXER_SYNC_INTERVAL
 
@@ -299,6 +300,7 @@ async def main():
             LOG.exception("An exception occurred during event synchronization")
 
         await asyncio.sleep(INDEXER_SYNC_INTERVAL)
+        free_malloc()
 
 
 if __name__ == "__main__":

--- a/batch/indexer_personal_info.py
+++ b/batch/indexer_personal_info.py
@@ -48,6 +48,7 @@ from app.model.db import (
     TokenType,
 )
 from app.utils.web3_utils import AsyncWeb3Wrapper
+from batch import free_malloc
 from batch.utils import batch_log
 from config import INDEXER_BLOCK_LOT_MAX_SIZE, INDEXER_SYNC_INTERVAL, ZERO_ADDRESS
 
@@ -330,6 +331,7 @@ async def main():
             LOG.exception("An exception occurred during event synchronization")
 
         await asyncio.sleep(INDEXER_SYNC_INTERVAL)
+        free_malloc()
 
 
 if __name__ == "__main__":

--- a/batch/indexer_position_bond.py
+++ b/batch/indexer_position_bond.py
@@ -51,6 +51,7 @@ from app.model.db import (
 from app.utils.asyncio_utils import SemaphoreTaskGroup
 from app.utils.contract_utils import AsyncContractUtils
 from app.utils.web3_utils import AsyncWeb3Wrapper
+from batch import free_malloc
 from batch.utils import batch_log
 from config import INDEXER_BLOCK_LOT_MAX_SIZE, INDEXER_SYNC_INTERVAL, ZERO_ADDRESS
 
@@ -1492,6 +1493,7 @@ async def main():
             LOG.exception("An exception occurred during event synchronization")
 
         await asyncio.sleep(INDEXER_SYNC_INTERVAL)
+        free_malloc()
 
 
 if __name__ == "__main__":

--- a/batch/indexer_position_share.py
+++ b/batch/indexer_position_share.py
@@ -51,6 +51,7 @@ from app.model.db import (
 from app.utils.asyncio_utils import SemaphoreTaskGroup
 from app.utils.contract_utils import AsyncContractUtils
 from app.utils.web3_utils import AsyncWeb3Wrapper
+from batch import free_malloc
 from batch.utils import batch_log
 from config import INDEXER_BLOCK_LOT_MAX_SIZE, INDEXER_SYNC_INTERVAL, ZERO_ADDRESS
 
@@ -1494,6 +1495,7 @@ async def main():
             LOG.exception("An exception occurred during event synchronization")
 
         await asyncio.sleep(INDEXER_SYNC_INTERVAL)
+        free_malloc()
 
 
 if __name__ == "__main__":

--- a/batch/indexer_token_cache.py
+++ b/batch/indexer_token_cache.py
@@ -30,6 +30,7 @@ from app.database import BatchAsyncSessionLocal
 from app.exceptions import ServiceUnavailableError
 from app.model.blockchain import IbetShareContract, IbetStraightBondContract
 from app.model.db import Account, Token, TokenStatus, TokenType
+from batch import free_malloc
 from batch.utils import batch_log
 from config import INDEXER_SYNC_INTERVAL
 
@@ -95,6 +96,7 @@ async def main():
             LOG.exception("An exception occurred during event synchronization")
 
         await asyncio.sleep(INDEXER_SYNC_INTERVAL)
+        free_malloc()
 
 
 if __name__ == "__main__":

--- a/batch/indexer_token_holders.py
+++ b/batch/indexer_token_holders.py
@@ -40,6 +40,7 @@ from app.model.db import (
 )
 from app.utils.contract_utils import AsyncContractUtils
 from app.utils.web3_utils import AsyncWeb3Wrapper
+from batch import free_malloc
 from batch.utils import batch_log
 from config import (
     INDEXER_BLOCK_LOT_MAX_SIZE,
@@ -537,6 +538,7 @@ async def main():
             LOG.exception("An exception occurred during event synchronization")
 
         await asyncio.sleep(INDEXER_SYNC_INTERVAL)
+        free_malloc()
 
 
 if __name__ == "__main__":

--- a/batch/indexer_transfer.py
+++ b/batch/indexer_transfer.py
@@ -43,6 +43,7 @@ from app.model.db import (
 )
 from app.utils.contract_utils import AsyncContractEventsView, AsyncContractUtils
 from app.utils.web3_utils import AsyncWeb3Wrapper
+from batch import free_malloc
 from batch.utils import batch_log
 from config import INDEXER_BLOCK_LOT_MAX_SIZE, INDEXER_SYNC_INTERVAL, ZERO_ADDRESS
 
@@ -328,6 +329,7 @@ async def main():
             LOG.exception("An exception occurred during event synchronization")
 
         await asyncio.sleep(INDEXER_SYNC_INTERVAL)
+        free_malloc()
 
 
 if __name__ == "__main__":

--- a/batch/indexer_transfer_approval.py
+++ b/batch/indexer_transfer_approval.py
@@ -44,6 +44,7 @@ from app.model.db import (
 )
 from app.utils.contract_utils import AsyncContractEventsView, AsyncContractUtils
 from app.utils.web3_utils import AsyncWeb3Wrapper
+from batch import free_malloc
 from batch.utils import batch_log
 from config import INDEXER_BLOCK_LOT_MAX_SIZE, INDEXER_SYNC_INTERVAL, ZERO_ADDRESS
 
@@ -736,6 +737,7 @@ async def main():
             LOG.error(ex)
 
         await asyncio.sleep(INDEXER_SYNC_INTERVAL)
+        free_malloc()
 
 
 if __name__ == "__main__":

--- a/batch/processor_batch_create_child_account.py
+++ b/batch/processor_batch_create_child_account.py
@@ -39,6 +39,7 @@ from app.model.db import (
     PersonalInfoEventType,
     TmpChildAccountBatchCreate,
 )
+from batch import free_malloc
 from batch.utils import batch_log
 from batch.utils.signal_handler import setup_signal_handler
 
@@ -146,6 +147,7 @@ async def main():
                 LOG.exception(ex)
 
             await asyncio.sleep(10)
+            free_malloc()
     finally:
         LOG.info("Service is shutdown")
 

--- a/batch/processor_batch_issue_redeem.py
+++ b/batch/processor_batch_issue_redeem.py
@@ -52,6 +52,7 @@ from app.model.db import (
     TokenVersion,
 )
 from app.utils.e2ee_utils import E2EEUtils
+from batch import free_malloc
 from batch.utils import batch_log
 from batch.utils.signal_handler import setup_signal_handler
 from config import BULK_TX_LOT_SIZE
@@ -465,6 +466,7 @@ async def main():
                 if is_shutdown.is_set():
                     break
                 await asyncio.sleep(1)
+            free_malloc()
     finally:
         LOG.info("Service is shutdown")
 

--- a/batch/processor_batch_register_personal_info.py
+++ b/batch/processor_batch_register_personal_info.py
@@ -53,6 +53,7 @@ from app.model.db import (
     TokenType,
 )
 from app.utils.web3_utils import AsyncWeb3Wrapper
+from batch import free_malloc
 from batch.utils import batch_log
 from batch.utils.signal_handler import setup_signal_handler
 from config import (
@@ -461,6 +462,7 @@ class Worker:
                 if self.is_shutdown.is_set():
                     break
                 await asyncio.sleep(1)
+            free_malloc()
 
 
 async def main():

--- a/batch/processor_bulk_transfer.py
+++ b/batch/processor_bulk_transfer.py
@@ -49,6 +49,7 @@ from app.model.db import (
 )
 from app.utils.e2ee_utils import E2EEUtils
 from app.utils.web3_utils import AsyncWeb3Wrapper
+from batch import free_malloc
 from batch.utils import batch_log
 from batch.utils.signal_handler import setup_signal_handler
 from config import (
@@ -585,6 +586,7 @@ class Worker:
                 if self.is_shutdown.is_set():
                     break
                 await asyncio.sleep(1)
+            free_malloc()
 
 
 async def main():

--- a/batch/processor_create_ledger.py
+++ b/batch/processor_create_ledger.py
@@ -43,6 +43,7 @@ from app.utils.ledger_utils import (
     finalize_ledger,
     sync_request_with_registered_personal_info,
 )
+from batch import free_malloc
 from batch.utils import batch_log
 from batch.utils.signal_handler import setup_signal_handler
 
@@ -167,6 +168,7 @@ async def main():
                 LOG.exception("An error occurred during processing")
 
             await asyncio.sleep(10)
+            free_malloc()
     finally:
         LOG.info("Service is shutdown")
 

--- a/batch/processor_create_utxo.py
+++ b/batch/processor_create_utxo.py
@@ -35,6 +35,7 @@ from app.model.db import UTXO, Account, Token, TokenStatus, TokenType, UTXOBlock
 from app.utils.contract_utils import AsyncContractEventsView, AsyncContractUtils
 from app.utils.ledger_utils import request_ledger_creation
 from app.utils.web3_utils import AsyncWeb3Wrapper
+from batch import free_malloc
 from batch.utils import batch_log
 from config import (
     CREATE_UTXO_BLOCK_LOT_MAX_SIZE,
@@ -530,6 +531,7 @@ async def main():
         else:
             elapsed_time = time.time() - start_time
             await asyncio.sleep(max(CREATE_UTXO_INTERVAL - elapsed_time, 0))
+        free_malloc()
 
 
 if __name__ == "__main__":

--- a/batch/processor_dvp_async_tx.py
+++ b/batch/processor_dvp_async_tx.py
@@ -46,6 +46,7 @@ from app.model.db import (
 )
 from app.utils.contract_utils import AsyncContractUtils
 from app.utils.e2ee_utils import E2EEUtils
+from batch import free_malloc
 from batch.utils import batch_log
 from batch.utils.signal_handler import setup_signal_handler
 
@@ -393,6 +394,7 @@ async def main():
                 if is_shutdown.is_set():
                     break
                 await asyncio.sleep(1)
+            free_malloc()
     finally:
         LOG.info("Service is shutdown")
 

--- a/batch/processor_generate_rsa_key.py
+++ b/batch/processor_generate_rsa_key.py
@@ -31,6 +31,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.database import BatchAsyncSessionLocal
 from app.model.db import Account, AccountRsaKeyTemporary, AccountRsaStatus
 from app.utils.e2ee_utils import E2EEUtils
+from batch import free_malloc
 from batch.utils import batch_log
 
 """
@@ -144,6 +145,7 @@ async def main():
             LOG.exception(ex)
 
         await asyncio.sleep(10)
+        free_malloc()
 
 
 if __name__ == "__main__":

--- a/batch/processor_modify_personal_info.py
+++ b/batch/processor_modify_personal_info.py
@@ -46,6 +46,7 @@ from app.model.db import (
     TokenType,
 )
 from app.utils.contract_utils import AsyncContractUtils
+from batch import free_malloc
 from batch.utils import batch_log
 from batch.utils.signal_handler import setup_signal_handler
 from config import ZERO_ADDRESS
@@ -326,6 +327,7 @@ async def main():
                 LOG.exception(ex)
 
             await asyncio.sleep(10)
+            free_malloc()
     finally:
         LOG.info("Service is shutdown")
 

--- a/batch/processor_monitor_block_sync.py
+++ b/batch/processor_monitor_block_sync.py
@@ -31,6 +31,7 @@ from web3.middleware import ExtraDataToPOAMiddleware
 from app.database import BatchAsyncSessionLocal
 from app.exceptions import ServiceUnavailableError
 from app.model.db import Node
+from batch import free_malloc
 from batch.utils import batch_log
 from config import (
     BLOCK_GENERATION_SPEED_THRESHOLD,
@@ -261,6 +262,7 @@ async def main():
             LOG.exception(ex)
 
         await asyncio.sleep(BLOCK_SYNC_STATUS_SLEEP_INTERVAL)
+        free_malloc()
 
 
 if __name__ == "__main__":

--- a/batch/processor_rotate_e2e_messaging_rsa_key.py
+++ b/batch/processor_rotate_e2e_messaging_rsa_key.py
@@ -41,6 +41,7 @@ from app.model.blockchain import E2EMessaging
 from app.model.db import E2EMessagingAccount, E2EMessagingAccountRsaKey
 from app.utils.contract_utils import AsyncContractUtils
 from app.utils.e2ee_utils import E2EEUtils
+from batch import free_malloc
 from batch.utils import batch_log
 from config import E2E_MESSAGING_CONTRACT_ADDRESS, ROTATE_E2E_MESSAGING_RSA_KEY_INTERVAL
 
@@ -220,6 +221,7 @@ async def main():
         await asyncio.sleep(
             max(ROTATE_E2E_MESSAGING_RSA_KEY_INTERVAL - elapsed_time, 0)
         )
+        free_malloc()
 
 
 if __name__ == "__main__":

--- a/batch/processor_scheduled_events.py
+++ b/batch/processor_scheduled_events.py
@@ -56,6 +56,7 @@ from app.model.db import (
 )
 from app.utils.e2ee_utils import E2EEUtils
 from app.utils.web3_utils import AsyncWeb3Wrapper
+from batch import free_malloc
 from batch.utils import batch_log
 from batch.utils.signal_handler import setup_signal_handler
 from config import SCHEDULED_EVENTS_INTERVAL, SCHEDULED_EVENTS_WORKER_COUNT
@@ -362,6 +363,7 @@ class Worker:
                 if self.is_shutdown.is_set():
                     break
                 await asyncio.sleep(1)
+            free_malloc()
 
 
 async def main():

--- a/batch/processor_update_token.py
+++ b/batch/processor_update_token.py
@@ -59,6 +59,7 @@ from app.model.db import (
 )
 from app.utils.contract_utils import AsyncContractUtils
 from app.utils.e2ee_utils import E2EEUtils
+from batch import free_malloc
 from batch.utils import batch_log
 from batch.utils.signal_handler import setup_signal_handler
 from config import TOKEN_LIST_CONTRACT_ADDRESS, UPDATE_TOKEN_INTERVAL
@@ -399,6 +400,7 @@ async def main():
                 LOG.error(ex)
 
             await asyncio.sleep(UPDATE_TOKEN_INTERVAL)
+            free_malloc()
     finally:
         LOG.info("Service is shutdown")
 


### PR DESCRIPTION
When a Python process runs for an extended period, unused memory may not be released and returned to the OS.
To address this, I have implemented periodic execution of malloc_trim(0) to free up unused heap memory as much as possible.