### PR TITLE
Add a Soft Delete Feature to Scheduled Events

### DIFF
--- a/app/model/db/scheduled_events.py
+++ b/app/model/db/scheduled_events.py
@@ -17,7 +17,7 @@
 from datetime import datetime
 from enum import IntEnum, StrEnum
 
-from sqlalchemy import JSON, DateTime, Integer, String
+from sqlalchemy import JSON, Boolean, DateTime, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from .base import Base
@@ -58,3 +58,7 @@ class ScheduledEvents(Base):
     )
     # transaction data
     data: Mapped[dict] = mapped_column(JSON, nullable=False)
+    # soft deleted
+    is_soft_deleted: Mapped[bool] = mapped_column(
+        Boolean, default=False, nullable=False
+    )

--- a/app/model/schema/__init__.py
+++ b/app/model/schema/__init__.py
@@ -128,6 +128,7 @@ from .position import (
     PositionResponse,
 )
 from .scheduled_events import (
+    DeleteScheduledEventQuery,
     IbetShareScheduledUpdate,
     IbetStraightBondScheduledUpdate,
     ListAllScheduledEventsQuery,

--- a/app/model/schema/scheduled_events.py
+++ b/app/model/schema/scheduled_events.py
@@ -51,6 +51,7 @@ class ScheduledEvent(BaseModel):
     status: ScheduledEventStatus
     data: Dict[str, Any]
     created: str
+    is_soft_deleted: bool
 
 
 class ScheduledEventWithTokenAttributes(ScheduledEvent):
@@ -101,6 +102,12 @@ class ListAllScheduledEventsQuery(BasePaginationQuery):
     sort_order: Optional[SortOrder] = Field(
         SortOrder.DESC, description=SortOrder.__doc__
     )
+
+
+class DeleteScheduledEventQuery(BaseModel):
+    """DeleteScheduledBondTokenUpdateEvent query parameters"""
+
+    soft_delete: Optional[bool] = Field(False, description="Soft delete flag")
 
 
 ############################

--- a/app/routers/issuer/token_common.py
+++ b/app/routers/issuer/token_common.py
@@ -237,6 +237,7 @@ async def list_all_scheduled_events(
                 "status": _event.status,
                 "data": _event.data,
                 "created": _created,
+                "is_soft_deleted": _event.is_soft_deleted,
                 "token_attributes": token_attr.__dict__,
             }
         )

--- a/batch/processor_scheduled_events.py
+++ b/batch/processor_scheduled_events.py
@@ -113,6 +113,7 @@ class Processor:
                             ScheduledEvents.status == 0,
                             ScheduledEvents.scheduled_datetime <= filter_time,
                             ScheduledEvents.issuer_address.notin_(processing_issuers),
+                            ScheduledEvents.is_soft_deleted != True,
                         )
                     )
                     .order_by(ScheduledEvents.scheduled_datetime, ScheduledEvents.id)
@@ -132,6 +133,7 @@ class Processor:
                         ScheduledEvents.status == 0,
                         ScheduledEvents.scheduled_datetime <= filter_time,
                         ScheduledEvents.issuer_address == issuer_address,
+                        ScheduledEvents.is_soft_deleted != True,
                     )
                 )
                 .order_by(ScheduledEvents.scheduled_datetime, ScheduledEvents.id)

--- a/docs/ibet_prime.yaml
+++ b/docs/ibet_prime.yaml
@@ -2051,6 +2051,17 @@ paths:
           schema:
             type: string
             title: Scheduled Event Id
+        - name: soft_delete
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: boolean
+              - type: 'null'
+            description: Soft delete flag
+            default: false
+            title: Soft Delete
+          description: Soft delete flag
         - name: issuer-address
           in: header
           required: true
@@ -6577,6 +6588,17 @@ paths:
           schema:
             type: string
             title: Scheduled Event Id
+        - name: soft_delete
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: boolean
+              - type: 'null'
+            description: Soft delete flag
+            default: false
+            title: Soft Delete
+          description: Soft delete flag
         - name: issuer-address
           in: header
           required: true
@@ -15687,6 +15709,9 @@ components:
         created:
           type: string
           title: Created
+        is_soft_deleted:
+          type: boolean
+          title: Is Soft Deleted
       type: object
       required:
         - scheduled_event_id
@@ -15697,6 +15722,7 @@ components:
         - status
         - data
         - created
+        - is_soft_deleted
       title: ScheduledEvent
       description: Scheduled event
     ScheduledEventIdListResponse:
@@ -15761,6 +15787,9 @@ components:
         created:
           type: string
           title: Created
+        is_soft_deleted:
+          type: boolean
+          title: Is Soft Deleted
         token_attributes:
           anyOf:
             - $ref: '#/components/schemas/IbetStraightBond'
@@ -15777,6 +15806,7 @@ components:
         - status
         - data
         - created
+        - is_soft_deleted
         - token_attributes
       title: ScheduledEventWithTokenAttributes
       description: Scheduled event with token attributes

--- a/migrations/versions/e1f6370e8197_v25_6_0_feature_772.py
+++ b/migrations/versions/e1f6370e8197_v25_6_0_feature_772.py
@@ -1,0 +1,40 @@
+"""v25_6_0_feature_772
+
+Revision ID: e1f6370e8197
+Revises: 67981ef57b71
+Create Date: 2025-03-24 19:24:24.795378
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import update
+
+from app.database import get_db_schema
+from app.model.db import ScheduledEvents
+
+# revision identifiers, used by Alembic.
+revision = "e1f6370e8197"
+down_revision = "67981ef57b71"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "scheduled_events",
+        sa.Column("is_soft_deleted", sa.Boolean(), nullable=True),
+        schema=get_db_schema(),
+    )
+    op.get_bind().execute(update(ScheduledEvents).values(is_soft_deleted=False))
+    op.alter_column(
+        "scheduled_events",
+        "is_soft_deleted",
+        existing_type=sa.Boolean(),
+        nullable=False,
+        schema=get_db_schema(),
+    )
+
+
+def downgrade():
+    op.drop_column("scheduled_events", "is_soft_deleted", schema=get_db_schema())

--- a/tests/app/test_bond_scheduled_events_DeleteScheduledBondTokenUpdateEvent.py
+++ b/tests/app/test_bond_scheduled_events_DeleteScheduledBondTokenUpdateEvent.py
@@ -40,6 +40,7 @@ class TestDeleteScheduledBondTokenUpdateEvent:
     ###########################################################################
 
     # <Normal_1>
+    # soft_delete = False (default)
     @pytest.mark.asyncio
     async def test_normal_1(self, async_client, async_db):
         test_account = config_eth_account("user1")
@@ -114,6 +115,7 @@ class TestDeleteScheduledBondTokenUpdateEvent:
             "status": 0,
             "data": data,
             "created": datetime_now_str,
+            "is_soft_deleted": False,
         }
         token_event = (
             await async_db.scalars(
@@ -123,6 +125,95 @@ class TestDeleteScheduledBondTokenUpdateEvent:
             )
         ).first()
         assert token_event is None
+
+    # <Normal_2>
+    # soft_delete = True
+    @pytest.mark.asyncio
+    async def test_normal_2(self, async_client, async_db):
+        test_account = config_eth_account("user1")
+        _issuer_address = test_account["address"]
+        _keyfile = test_account["keyfile_json"]
+        _token_address = "token_address_test"
+
+        # prepare data
+        account = Account()
+        account.issuer_address = _issuer_address
+        account.keyfile = _keyfile
+        account.eoa_password = E2EEUtils.encrypt("password")
+        async_db.add(account)
+
+        await async_db.commit()
+
+        datetime_now_utc = datetime.now(UTC).replace(tzinfo=None)
+        datetime_now_str = (
+            pytz.timezone("UTC")
+            .localize(datetime_now_utc)
+            .astimezone(self.local_tz)
+            .isoformat()
+        )
+        data = {
+            "face_value": 10000,
+            "interest_rate": 0.5,
+            "interest_payment_date": ["0101", "0701"],
+            "redemption_value": 11000,
+            "transferable": False,
+            "status": False,
+            "is_offering": False,
+            "is_redeemed": True,
+            "tradable_exchange_contract_address": "0xe883A6f441Ad5682d37DF31d34fc012bcB07A740",
+            "personal_info_contract_address": "0xa4CEe3b909751204AA151860ebBE8E7A851c2A1a",
+            "contact_information": "問い合わせ先test",
+            "privacy_policy": "プライバシーポリシーtest",
+            "memo": "memo_test1",
+        }
+        event_id = str(uuid.uuid4())
+
+        token_event = ScheduledEvents()
+        token_event.event_id = event_id
+        token_event.issuer_address = _issuer_address
+        token_event.token_address = _token_address
+        token_event.token_type = TokenType.IBET_STRAIGHT_BOND
+        token_event.event_type = ScheduledEventType.UPDATE
+        token_event.scheduled_datetime = datetime_now_utc
+        token_event.status = 0
+        token_event.data = data
+        token_event.created = datetime_now_utc
+        async_db.add(token_event)
+
+        await async_db.commit()
+
+        # request target API
+        resp = await async_client.delete(
+            self.base_url.format(_token_address, event_id),
+            headers={
+                "issuer-address": _issuer_address,
+                "eoa-password": E2EEUtils.encrypt("password"),
+            },
+            params={"soft_delete": True},
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "scheduled_event_id": event_id,
+            "token_address": _token_address,
+            "token_type": TokenType.IBET_STRAIGHT_BOND,
+            "scheduled_datetime": datetime_now_str,
+            "event_type": ScheduledEventType.UPDATE,
+            "status": 0,
+            "data": data,
+            "created": datetime_now_str,
+            "is_soft_deleted": True,
+        }
+        token_event = (
+            await async_db.scalars(
+                select(ScheduledEvents)
+                .where(ScheduledEvents.event_id == event_id)
+                .limit(1)
+            )
+        ).first()
+        assert token_event is not None
+        assert token_event.is_soft_deleted is True
 
     #########################################################################
     # Error Case

--- a/tests/app/test_bond_scheduled_events_ListAllScheduledBondTokenUpdateEvents.py
+++ b/tests/app/test_bond_scheduled_events_ListAllScheduledBondTokenUpdateEvents.py
@@ -105,6 +105,7 @@ class TestListAllScheduledBondTokenUpdateEvents:
                 "status": 0,
                 "data": update_data,
                 "created": datetime_now_str,
+                "is_soft_deleted": False,
             }
         ]
 
@@ -181,6 +182,7 @@ class TestListAllScheduledBondTokenUpdateEvents:
                 .localize(datetime_list[0])
                 .astimezone(self.local_tz)
                 .isoformat(),
+                "is_soft_deleted": False,
             },
             {
                 "scheduled_event_id": uuid_list[1],
@@ -197,6 +199,7 @@ class TestListAllScheduledBondTokenUpdateEvents:
                 .localize(datetime_list[1])
                 .astimezone(self.local_tz)
                 .isoformat(),
+                "is_soft_deleted": False,
             },
         ]
 

--- a/tests/app/test_bond_scheduled_events_RetrieveScheduledBondTokenUpdateEvent.py
+++ b/tests/app/test_bond_scheduled_events_RetrieveScheduledBondTokenUpdateEvent.py
@@ -104,6 +104,7 @@ class TestRetrieveScheduledBondTokenUpdateEvent:
             "status": 0,
             "data": update_data,
             "created": datetime_now_str,
+            "is_soft_deleted": False,
         }
 
     # <Normal_2>
@@ -170,6 +171,7 @@ class TestRetrieveScheduledBondTokenUpdateEvent:
             "status": 0,
             "data": update_data,
             "created": datetime_now_str,
+            "is_soft_deleted": False,
         }
 
     #########################################################################

--- a/tests/app/test_share_scheduled_events_ListAllScheduledShareTokenUpdateEvents.py
+++ b/tests/app/test_share_scheduled_events_ListAllScheduledShareTokenUpdateEvents.py
@@ -105,6 +105,7 @@ class TestListAllScheduledShareTokenUpdateEvents:
                 "status": 0,
                 "data": update_data,
                 "created": datetime_now_str,
+                "is_soft_deleted": False,
             }
         ]
 
@@ -181,6 +182,7 @@ class TestListAllScheduledShareTokenUpdateEvents:
                 .localize(datetime_list[0])
                 .astimezone(self.local_tz)
                 .isoformat(),
+                "is_soft_deleted": False,
             },
             {
                 "scheduled_event_id": uuid_list[1],
@@ -197,6 +199,7 @@ class TestListAllScheduledShareTokenUpdateEvents:
                 .localize(datetime_list[1])
                 .astimezone(self.local_tz)
                 .isoformat(),
+                "is_soft_deleted": False,
             },
         ]
 

--- a/tests/app/test_share_scheduled_events_RetrieveScheduledShareTokenUpdateEvent.py
+++ b/tests/app/test_share_scheduled_events_RetrieveScheduledShareTokenUpdateEvent.py
@@ -104,6 +104,7 @@ class TestRetrieveScheduledShareTokenUpdateEvent:
             "status": 0,
             "data": update_data,
             "created": datetime_now_str,
+            "is_soft_deleted": False,
         }
 
     # <Normal_2>
@@ -170,6 +171,7 @@ class TestRetrieveScheduledShareTokenUpdateEvent:
             "status": 0,
             "data": update_data,
             "created": datetime_now_str,
+            "is_soft_deleted": False,
         }
 
     #########################################################################

--- a/tests/app/test_token_common_ListAllScheduledEvents.py
+++ b/tests/app/test_token_common_ListAllScheduledEvents.py
@@ -247,6 +247,7 @@ class TestListAllScheduledEvents:
                         .astimezone(self.local_tz)
                         .isoformat()
                     ),
+                    "is_soft_deleted": False,
                     "token_attributes": token_2_attr,
                 },
                 {
@@ -268,6 +269,7 @@ class TestListAllScheduledEvents:
                         .astimezone(self.local_tz)
                         .isoformat()
                     ),
+                    "is_soft_deleted": False,
                     "token_attributes": token_1_attr,
                 },
             ],
@@ -414,6 +416,7 @@ class TestListAllScheduledEvents:
                         .astimezone(self.local_tz)
                         .isoformat()
                     ),
+                    "is_soft_deleted": False,
                     "token_attributes": token_2_attr,
                 },
                 {
@@ -435,6 +438,7 @@ class TestListAllScheduledEvents:
                         .astimezone(self.local_tz)
                         .isoformat()
                     ),
+                    "is_soft_deleted": False,
                     "token_attributes": token_1_attr,
                 },
             ],
@@ -568,6 +572,7 @@ class TestListAllScheduledEvents:
                     "status": 0,
                     "data": update_data,
                     "created": mock.ANY,
+                    "is_soft_deleted": False,
                     "token_attributes": token_1_attr,
                 },
             ],
@@ -714,6 +719,7 @@ class TestListAllScheduledEvents:
                     "status": 0,
                     "data": update_data_1,
                     "created": mock.ANY,
+                    "is_soft_deleted": False,
                     "token_attributes": token_1_attr,
                 },
             ],
@@ -860,6 +866,7 @@ class TestListAllScheduledEvents:
                     "status": 0,
                     "data": update_data_1,
                     "created": mock.ANY,
+                    "is_soft_deleted": False,
                     "token_attributes": token_1_attr,
                 },
             ],
@@ -990,6 +997,7 @@ class TestListAllScheduledEvents:
                     "status": 0,
                     "data": update_data,
                     "created": mock.ANY,
+                    "is_soft_deleted": False,
                     "token_attributes": token_1_attr,
                 },
             ],
@@ -1178,6 +1186,7 @@ class TestListAllScheduledEvents:
                         .astimezone(self.local_tz)
                         .isoformat()
                     ),
+                    "is_soft_deleted": False,
                     "token_attributes": token_1_attr,
                 },
                 {
@@ -1199,6 +1208,7 @@ class TestListAllScheduledEvents:
                         .astimezone(self.local_tz)
                         .isoformat()
                     ),
+                    "is_soft_deleted": False,
                     "token_attributes": token_2_attr,
                 },
             ],
@@ -1387,6 +1397,7 @@ class TestListAllScheduledEvents:
                         .astimezone(self.local_tz)
                         .isoformat()
                     ),
+                    "is_soft_deleted": False,
                     "token_attributes": token_1_attr,
                 },
                 {
@@ -1408,6 +1419,7 @@ class TestListAllScheduledEvents:
                         .astimezone(self.local_tz)
                         .isoformat()
                     ),
+                    "is_soft_deleted": False,
                     "token_attributes": token_2_attr,
                 },
             ],
@@ -1596,6 +1608,7 @@ class TestListAllScheduledEvents:
                         .astimezone(self.local_tz)
                         .isoformat()
                     ),
+                    "is_soft_deleted": False,
                     "token_attributes": token_1_attr,
                 },
                 {
@@ -1617,6 +1630,7 @@ class TestListAllScheduledEvents:
                         .astimezone(self.local_tz)
                         .isoformat()
                     ),
+                    "is_soft_deleted": False,
                     "token_attributes": token_2_attr,
                 },
             ],
@@ -1772,6 +1786,7 @@ class TestListAllScheduledEvents:
                         .astimezone(self.local_tz)
                         .isoformat()
                     ),
+                    "is_soft_deleted": False,
                     "token_attributes": token_2_attr,
                 },
             ],


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

I have modified the functionality so that it is possible to manage the soft/logical deletion state for ScheduledEvents.
In the soft deletion state, it is controlled so that it is not subject to batch processing.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- Close #772

## 🔄 Changes

<!-- List the major changes in this PR. -->

- I added a field called `is_soft_deleted` to the TBL.
- I made it possible to specify a soft delete parameter in the delete API. If the parameter is not set, the event data will be physically deleted.
- For the event data extraction process in batch processing, I modified the query so that data in a logical deletion state is not extracted.

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
