### PR TITLE
Allow setting a message for ForceLock/ForceUnlock

### DIFF
--- a/app/model/schema/__init__.py
+++ b/app/model/schema/__init__.py
@@ -125,8 +125,10 @@ from .position import (
     ListAllLockEventsSortItem,
     ListAllPositionResponse,
     ListAllPositionsQuery,
+    LockDataMessage,
     LockEventCategory,
     PositionResponse,
+    UnlockDataMessage,
 )
 from .scheduled_events import (
     DeleteScheduledEventQuery,

--- a/app/model/schema/position.py
+++ b/app/model/schema/position.py
@@ -70,7 +70,29 @@ class LockEventCategory(StrEnum):
     Unlock = "Unlock"
 
 
+class LockMessage(StrEnum):
+    garnishment = "garnishment"
+    inheritance = "inheritance"
+    force_lock = "force_lock"
+
+
+class LockDataMessage(BaseModel):
+    message: LockMessage
+
+
+class UnlockMessage(StrEnum):
+    garnishment = "garnishment"
+    inheritance = "inheritance"
+    force_unlock = "force_unlock"
+
+
+class UnlockDataMessage(BaseModel):
+    message: UnlockMessage
+
+
 class LockEvent(BaseModel):
+    """Lock/Unlock event"""
+
     category: LockEventCategory = Field(description="Event category")
     is_forced: bool = Field(description="Set to `True` for force lock/unlock events")
     transaction_hash: str = Field(description="Transaction hash")
@@ -85,7 +107,9 @@ class LockEvent(BaseModel):
         default=None, description="Recipient address"
     )
     value: int = Field(description="Lock/Unlock amount")
-    data: dict = Field(description="Message at lock/unlock")
+    data: LockDataMessage | UnlockDataMessage | dict = Field(
+        description="Message at lock/unlock"
+    )
     block_timestamp: str = Field(
         description="block_timestamp when Lock log was emitted"
     )
@@ -137,6 +161,9 @@ class ListAllLockEventsQuery(BasePaginationQuery):
 class ForceLockRequest(BaseModel):
     token_address: EthereumAddress = Field(..., description="Token address")
     lock_address: EthereumAddress = Field(..., description="Lock address")
+    message: Optional[LockMessage] = Field(
+        LockMessage.force_lock, description="Lock message"
+    )
     value: PositiveInt = Field(..., description="Lock amount")
 
 
@@ -144,6 +171,9 @@ class ForceUnlockRequest(BaseModel):
     token_address: EthereumAddress = Field(..., description="Token address")
     lock_address: EthereumAddress = Field(..., description="Lock address")
     recipient_address: EthereumAddress = Field(..., description="Recipient address")
+    message: Optional[UnlockMessage] = Field(
+        UnlockMessage.force_unlock, description="Unlock message"
+    )
     value: PositiveInt = Field(..., description="Unlock amount")
 
 

--- a/app/model/schema/transfer.py
+++ b/app/model/schema/transfer.py
@@ -70,7 +70,7 @@ class Transfer(TransferBase):
     data: None = Field(description="Event data")
 
 
-class DataMessage(BaseModel):
+class UnlockTransferDataMessage(BaseModel):
     message: Literal[
         "garnishment",
         "inheritance",
@@ -82,7 +82,7 @@ class UnlockTransfer(TransferBase):
     source_event: Literal[
         TransferSourceEventType.Unlock, TransferSourceEventType.ForceUnlock
     ] = Field(description="Source Event")
-    data: DataMessage | dict = Field(description="Event data")
+    data: UnlockTransferDataMessage | dict = Field(description="Event data")
 
 
 ############################

--- a/app/routers/issuer/position.py
+++ b/app/routers/issuer/position.py
@@ -17,7 +17,6 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-import json
 from typing import Annotated, Optional, Sequence
 
 from eth_keyfile import decode_keyfile_json
@@ -65,8 +64,10 @@ from app.model.schema import (
     ListAllLockEventsSortItem,
     ListAllPositionResponse,
     ListAllPositionsQuery,
+    LockDataMessage,
     LockEventCategory,
     PositionResponse,
+    UnlockDataMessage,
 )
 from app.utils.check_utils import (
     address_is_valid_address,
@@ -583,11 +584,14 @@ async def force_lock(
         )
 
     # Force lock
+    lock_message_data = LockDataMessage(message=data.message).model_dump_json(
+        exclude_none=True
+    )
     lock_data = {
         "lock_address": data.lock_address,
         "account_address": account_address,
         "value": data.value,
-        "data": json.dumps({"message": "force_lock"}),
+        "data": lock_message_data,
     }
     try:
         await IbetSecurityTokenInterface(data.token_address).force_lock(
@@ -671,12 +675,15 @@ async def force_unlock(
         raise InvalidParameterError("this token is temporarily unavailable")
 
     # Force unlock
+    unlock_message_data = UnlockDataMessage(message=data.message).model_dump_json(
+        exclude_none=True
+    )
     unlock_data = {
         "lock_address": data.lock_address,
         "account_address": account_address,
         "recipient_address": data.recipient_address,
         "value": data.value,
-        "data": json.dumps({"message": "force_unlock"}),
+        "data": unlock_message_data,
     }
     try:
         await IbetSecurityTokenInterface(data.token_address).force_unlock(

--- a/docs/ibet_prime.yaml
+++ b/docs/ibet_prime.yaml
@@ -11857,19 +11857,6 @@ components:
         - notice_type
         - metainfo
       title: DVPDeliveryInfoNotification
-    DataMessage:
-      properties:
-        message:
-          type: string
-          enum:
-            - garnishment
-            - inheritance
-            - force_unlock
-          title: Message
-      type: object
-      required:
-        - message
-      title: DataMessage
     DeliveryStatus:
       type: integer
       enum:
@@ -12275,6 +12262,12 @@ components:
           type: string
           title: Lock Address
           description: Lock address
+        message:
+          anyOf:
+            - $ref: '#/components/schemas/LockMessage'
+            - type: 'null'
+          description: Lock message
+          default: force_lock
         value:
           type: integer
           exclusiveMinimum: 0.0
@@ -12300,6 +12293,12 @@ components:
           type: string
           title: Recipient Address
           description: Recipient address
+        message:
+          anyOf:
+            - $ref: '#/components/schemas/UnlockMessage'
+            - type: 'null'
+          description: Unlock message
+          default: force_unlock
         value:
           type: integer
           exclusiveMinimum: 0.0
@@ -14454,6 +14453,14 @@ components:
         - to_address_name
         - amount
       title: ListTransferHistorySortItem
+    LockDataMessage:
+      properties:
+        message:
+          $ref: '#/components/schemas/LockMessage'
+      type: object
+      required:
+        - message
+      title: LockDataMessage
     LockEvent:
       properties:
         category:
@@ -14507,7 +14514,10 @@ components:
           title: Value
           description: Lock/Unlock amount
         data:
-          type: object
+          anyOf:
+            - $ref: '#/components/schemas/LockDataMessage'
+            - $ref: '#/components/schemas/UnlockDataMessage'
+            - type: object
           title: Data
           description: Message at lock/unlock
         block_timestamp:
@@ -14529,6 +14539,7 @@ components:
         - data
         - block_timestamp
       title: LockEvent
+      description: Lock/Unlock event
     LockEventCategory:
       type: string
       enum:
@@ -14599,6 +14610,13 @@ components:
         - notice_type
         - metainfo
       title: LockInfoNotification
+    LockMessage:
+      type: string
+      enum:
+        - garnishment
+        - inheritance
+        - force_lock
+      title: LockMessage
     LockedPosition:
       properties:
         issuer_address:
@@ -16732,6 +16750,14 @@ components:
     TxDataResponse:
       $ref: '#/components/schemas/TxDataDetail'
       title: TxDataResponse
+    UnlockDataMessage:
+      properties:
+        message:
+          $ref: '#/components/schemas/UnlockMessage'
+      type: object
+      required:
+        - message
+      title: UnlockDataMessage
     UnlockInfoMetaInfo:
       properties:
         token_address:
@@ -16800,6 +16826,13 @@ components:
         - notice_type
         - metainfo
       title: UnlockInfoNotification
+    UnlockMessage:
+      type: string
+      enum:
+        - garnishment
+        - inheritance
+        - force_unlock
+      title: UnlockMessage
     UnlockTransfer:
       properties:
         transaction_hash:
@@ -16837,7 +16870,7 @@ components:
           description: Source Event
         data:
           anyOf:
-            - $ref: '#/components/schemas/DataMessage'
+            - $ref: '#/components/schemas/UnlockTransferDataMessage'
             - type: object
           title: Data
           description: Event data
@@ -16854,6 +16887,19 @@ components:
         - source_event
         - data
       title: UnlockTransfer
+    UnlockTransferDataMessage:
+      properties:
+        message:
+          type: string
+          enum:
+            - garnishment
+            - inheritance
+            - force_unlock
+          title: Message
+      type: object
+      required:
+        - message
+      title: UnlockTransferDataMessage
     UpdateFreezeLogRequest:
       properties:
         account_address:

--- a/tests/app/test_positions_ForceLock.py
+++ b/tests/app/test_positions_ForceLock.py
@@ -39,11 +39,12 @@ class TestForceLock:
     # Normal Case
     ###########################################################################
 
-    # <Normal_1>
+    # <Normal_1_1>
     # Authorization by eoa-password
+    # - message is not set
     @mock.patch("app.model.blockchain.token.IbetSecurityTokenInterface.force_lock")
     @pytest.mark.asyncio
-    async def test_normal_1(
+    async def test_normal_1_1(
         self, IbetSecurityTokenInterface_mock, async_client, async_db
     ):
         account_address = "0x1234567890123456789012345678900000000000"
@@ -99,7 +100,83 @@ class TestForceLock:
                     "lock_address": _lock_address,
                     "account_address": account_address,
                     "value": 10,
-                    "data": json.dumps({"message": "force_lock"}),
+                    "data": json.dumps(
+                        {"message": "force_lock"}, separators=(",", ":")
+                    ),
+                }
+            ),
+            tx_from=_admin_address,
+            private_key=ANY,
+        )
+
+        assert resp.status_code == 200
+        assert resp.json() is None
+
+    # <Normal_1_2>
+    # Authorization by eoa-password
+    # - message is set
+    @mock.patch("app.model.blockchain.token.IbetSecurityTokenInterface.force_lock")
+    @pytest.mark.asyncio
+    async def test_normal_1_2(
+        self, IbetSecurityTokenInterface_mock, async_client, async_db
+    ):
+        account_address = "0x1234567890123456789012345678900000000000"
+
+        _admin_account = config_eth_account("user1")
+        _admin_address = _admin_account["address"]
+        _admin_keyfile = _admin_account["keyfile_json"]
+
+        _lock_address = config_eth_account("user2")["address"]
+
+        _token_address = "0xd9F55747DE740297ff1eEe537aBE0f8d73B7D783"
+
+        # prepare data
+        account = Account()
+        account.issuer_address = _admin_address
+        account.keyfile = _admin_keyfile
+        account.eoa_password = E2EEUtils.encrypt("password")
+        async_db.add(account)
+
+        token = Token()
+        token.type = TokenType.IBET_STRAIGHT_BOND
+        token.tx_hash = ""
+        token.issuer_address = _admin_address
+        token.token_address = _token_address
+        token.abi = {}
+        token.version = TokenVersion.V_25_06
+        async_db.add(token)
+
+        await async_db.commit()
+
+        # mock
+        IbetSecurityTokenInterface_mock.side_effect = [None]
+
+        # request target API
+        req_param = {
+            "token_address": _token_address,
+            "lock_address": _lock_address,
+            "message": "garnishment",
+            "value": 10,
+        }
+        resp = await async_client.post(
+            self.test_url.format(account_address=account_address),
+            json=req_param,
+            headers={
+                "issuer-address": _admin_address,
+                "eoa-password": E2EEUtils.encrypt("password"),
+            },
+        )
+
+        # assertion
+        IbetSecurityTokenInterface_mock.assert_any_call(
+            data=ForceLockParams(
+                **{
+                    "lock_address": _lock_address,
+                    "account_address": account_address,
+                    "value": 10,
+                    "data": json.dumps(
+                        {"message": "garnishment"}, separators=(",", ":")
+                    ),
                 }
             ),
             tx_from=_admin_address,
@@ -172,7 +249,9 @@ class TestForceLock:
                     "lock_address": _lock_address,
                     "account_address": account_address,
                     "value": 10,
-                    "data": json.dumps({"message": "force_lock"}),
+                    "data": json.dumps(
+                        {"message": "force_lock"}, separators=(",", ":")
+                    ),
                 }
             ),
             tx_from=_admin_address,
@@ -279,7 +358,7 @@ class TestForceLock:
             ],
         }
 
-    # <Error_3>
+    # <Error_1_3>
     # RequestValidationError
     # Header and body are required
     @pytest.mark.asyncio
@@ -310,7 +389,7 @@ class TestForceLock:
             ],
         }
 
-    # <Error_4>
+    # <Error_1_4>
     # RequestValidationError
     # issuer-address is not a valid address
     @pytest.mark.asyncio
@@ -393,6 +472,60 @@ class TestForceLock:
                     "loc": ["header", "eoa-password"],
                     "msg": "eoa-password is not a Base64-encoded encrypted data",
                     "type": "value_error",
+                }
+            ],
+        }
+
+    # <Error_1_6>
+    # RequestValidationError
+    # Invalid message
+    @pytest.mark.asyncio
+    async def test_error_1_6(self, async_client, async_db):
+        account_address = "0x1234567890123456789012345678900000000000"
+
+        _admin_account = config_eth_account("user1")
+        _admin_address = _admin_account["address"]
+        _admin_keyfile = _admin_account["keyfile_json"]
+
+        _lock_address = config_eth_account("user2")["address"]
+
+        _token_address = "0xd9F55747DE740297ff1eEe537aBE0f8d73B7D783"
+
+        # prepare data
+        account = Account()
+        account.issuer_address = _admin_address
+        account.keyfile = _admin_keyfile
+        account.eoa_password = E2EEUtils.encrypt("password")
+        async_db.add(account)
+        await async_db.commit()
+
+        # request target API
+        req_param = {
+            "token_address": _token_address,
+            "lock_address": _lock_address,
+            "message": "invalid_message",
+            "value": 10,
+        }
+        resp = await async_client.post(
+            self.test_url.format(account_address=account_address),
+            json=req_param,
+            headers={
+                "issuer-address": _admin_address,
+                "eoa-password": E2EEUtils.encrypt("password"),
+            },
+        )
+
+        # assertion
+        assert resp.status_code == 422
+        assert resp.json() == {
+            "meta": {"code": 1, "title": "RequestValidationError"},
+            "detail": [
+                {
+                    "type": "enum",
+                    "loc": ["body", "message"],
+                    "msg": "Input should be 'garnishment', 'inheritance' or 'force_lock'",
+                    "input": "invalid_message",
+                    "ctx": {"expected": "'garnishment', 'inheritance' or 'force_lock'"},
                 }
             ],
         }


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

Currently, the message registered in the contract during ForceLock/ForceUnlock was fixed. This update allows selecting and registering a custom message.

The selectable messages are: “garnishment”, “Inheritance” and “force_lock / force_unlock”

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- Related to #777

## 🔄 Changes

<!-- List the major changes in this PR. -->

- Added a "message" parameter to the input fields of the ForceLock/ForceUnlock API.
- By default, "force_lock" or "force_unlock" will be set.

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
