### PR TITLE
Disable retry logic in AsyncHTTPProvider for web3 connection of processor_monitor_block_sync

### DIFF
--- a/batch/processor_monitor_block_sync.py
+++ b/batch/processor_monitor_block_sync.py
@@ -119,7 +119,13 @@ class Processor:
     ):
         self.node_info[endpoint_uri] = {"priority": priority}
 
-        web3 = AsyncWeb3(AsyncHTTPProvider(endpoint_uri))
+        web3 = AsyncWeb3(
+            AsyncHTTPProvider(
+                endpoint_uri,
+                # Disabled retry logic explicitly
+                exception_retry_configuration=None,
+            )
+        )
         web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
         self.node_info[endpoint_uri]["web3"] = web3
 


### PR DESCRIPTION
## 📌 Description

This pull request updates the `__set_node_info` method in the `batch/processor_monitor_block_sync.py` file to explicitly disable retry logic for the `AsyncHTTPProvider`. This change ensures that no automatic retries occur when interacting with the specified `endpoint_uri`.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- Close #785

## 🔄 Changes

* [`batch/processor_monitor_block_sync.py`](diffhunk://#diff-cfc8127f2cced3cfd40298e76279b3e5b9e038a90b2104280b2f76be31c878baL122-R128): Modified the initialization of `AsyncHTTPProvider` within the `__set_node_info` method to set `exception_retry_configuration=None`, explicitly disabling retry logic.

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
