### PR TITLE
Handle generic exceptions in indexer_transfer and update test for invalid data schema

### DIFF
--- a/batch/indexer_transfer.py
+++ b/batch/indexer_transfer.py
@@ -344,6 +344,9 @@ class Processor:
             except json.JSONDecodeError:
                 data = {}
                 message = None
+            except:
+                data = {}
+                message = None
         else:
             data = None
             message = None

--- a/tests/batch/test_indexer_transfer.py
+++ b/tests/batch/test_indexer_transfer.py
@@ -668,7 +668,7 @@ class TestProcessor:
             issuer_address,
             user_address_1,
             10,
-            json.dumps({"invalid_message": "invalid_value"}),  # invalid data schema
+            "null",  # invalid data schema
         ).build_transaction(
             {
                 "chainId": CHAIN_ID,


### PR DESCRIPTION
## 📌 Description

Updated `batch/indexer_transfer.py` to Handle generic exceptions in parsing message data and updated test for invalid data schema

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- Close #784 

## 🔄 Changes

* [`batch/indexer_transfer.py`](diffhunk://#diff-9d49fe1a54b4cf0765a1e08e08dac073d05acc075bf8c50cf7eeab99b7c96855R347-R349): Added a generic exception handler in the `__sink_on_transfer` method to handle any unexpected exceptions, for the cases where the `data` and `message` to be set invalid JSON value such as "null".

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
