### PR TITLE
Update action versions in GitHub workflows for auto-assign and PR checks

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -10,4 +10,4 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: kentaro-m/auto-assign-action@v2.0.0
+      - uses: kentaro-m/auto-assign-action@f4648c0a9fdb753479e9e75fc251f507ce17bb7e  # v2.0.0

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/ruff-action@v1
+      - uses: astral-sh/ruff-action@v3
   unit-test-postgres:
     name: 'Unit tests (PostgreSQL)'
     runs-on: ubuntu-latest
@@ -87,7 +87,7 @@ jobs:
         run: jrm cov/pytest.xml "cov/pytest-*.xml"
       - name: Pytest coverage comment
         id: coverageComment
-        uses: MishaKav/pytest-coverage-comment@v1
+        uses: MishaKav/pytest-coverage-comment@13d3c18e21895566c746187c9ea74736372e5e91  # v1.1.54
         with:
           report-only-changed-files: true
           pytest-xml-coverage-path: cov/coverage.xml


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

This pull request updates the versions of several GitHub Actions used in the repository's workflows to ensure compatibility and stability. The updates include pinning specific commit SHAs or upgrading to newer versions.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- None

## 🔄 Changes

<!-- List the major changes in this PR. -->

### Workflow updates:

- `.github/workflows/auto-assign.yml`: 
  - Updated `kentaro-m/auto-assign-action` to a specific commit SHA (`f4648c0a9fdb753479e9e75fc251f507ce17bb7e`) for better version control and stability.
- `.github/workflows/pr.yml`: 
  - Upgraded `astral-sh/ruff-action` from `v1` to `v3` to use the latest features and improvements.
  - Updated `MishaKav/pytest-coverage-comment` to a specific commit SHA (`13d3c18e21895566c746187c9ea74736372e5e91`), corresponding to version `v1.1.54`, for enhanced functionality and reliability.

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
