### PR TITLE
Add key manager type filter to ListAllHoldersQuery

### DIFF
--- a/app/model/schema/token.py
+++ b/app/model/schema/token.py
@@ -36,6 +36,7 @@ from .base import (
     IbetShareContractVersion,
     IbetStraightBond,
     IbetStraightBondContractVersion,
+    KeyManagerType,
     MMDD_constr,
     ResultSet,
     SortOrder,
@@ -385,6 +386,10 @@ class ListAllHoldersSortItem(StrEnum):
 
 class ListAllHoldersQuery(BasePaginationQuery):
     include_former_holder: bool = Field(default=False)
+    key_manager_type: Optional[KeyManagerType] = Field(
+        None, description="Key manager type (**this affects total number**)"
+    )
+    key_manager: Optional[str] = Field(None, description="key manager(partial match)")
     balance: Optional[int] = Field(None, description="Token balance")
     balance_operator: Optional[ValueOperator] = Field(
         ValueOperator.EQUAL,
@@ -412,7 +417,6 @@ class ListAllHoldersQuery(BasePaginationQuery):
         None, description="account address(partial match)"
     )
     holder_name: Optional[str] = Field(None, description="holder name(partial match)")
-    key_manager: Optional[str] = Field(None, description="key manager(partial match)")
 
     sort_item: Annotated[ListAllHoldersSortItem, Query(description="Sort Item")] = (
         ListAllHoldersSortItem.created

--- a/app/routers/issuer/bond.py
+++ b/app/routers/issuer/bond.py
@@ -170,7 +170,7 @@ from app.model.schema import (
     UpdateTransferApprovalOperationType,
     UpdateTransferApprovalRequest,
 )
-from app.model.schema.base import ValueOperator
+from app.model.schema.base import KeyManagerType, ValueOperator
 from app.utils.check_utils import (
     address_is_valid_address,
     check_auth,
@@ -1971,7 +1971,7 @@ async def list_all_bond_token_holders(
     # Validate Headers
     validate_headers(issuer_address=(issuer_address, address_is_valid_address))
 
-    # Get Account
+    # Check issuer existence
     _account = (
         await db.scalars(
             select(Account).where(Account.issuer_address == issuer_address).limit(1)
@@ -1980,7 +1980,7 @@ async def list_all_bond_token_holders(
     if _account is None:
         raise InvalidParameterError("issuer does not exist")
 
-    # Get Token
+    # Check token existence
     _token: Token | None = (
         await db.scalars(
             select(Token)
@@ -2000,7 +2000,7 @@ async def list_all_bond_token_holders(
     if _token.token_status == TokenStatus.PENDING:
         raise InvalidParameterError("this token is temporarily unavailable")
 
-    # Get Holders
+    # Base query
     locked_value = func.sum(IDXLockedPosition.value)
     stmt = (
         select(
@@ -2043,13 +2043,23 @@ async def list_all_bond_token_holders(
             IDXLockedPosition.account_address,
         )
     )
+    match get_query.key_manager_type:
+        case KeyManagerType.SELF:
+            stmt = stmt.where(
+                IDXPersonalInfo._personal_info["key_manager"].as_string() == "SELF"
+            )
+        case KeyManagerType.OTHERS:
+            stmt = stmt.where(
+                IDXPersonalInfo._personal_info["key_manager"].as_string() != "SELF"
+            )
 
     total = await db.scalar(
-        select(func.count())
-        .select_from(IDXPosition)
-        .where(IDXPosition.token_address == token_address)
+        select(func.count()).select_from(
+            stmt.with_only_columns(1).order_by(None).subquery()
+        )
     )
 
+    # Apply filters
     if not get_query.include_former_holder:
         stmt = stmt.where(
             or_(
@@ -2138,7 +2148,9 @@ async def list_all_bond_token_holders(
         )
 
     count = await db.scalar(
-        select(func.count()).select_from(stmt.with_only_columns(1).order_by(None))
+        select(func.count()).select_from(
+            stmt.with_only_columns(1).order_by(None).subquery()
+        )
     )
 
     # Sort

--- a/docs/ibet_prime.yaml
+++ b/docs/ibet_prime.yaml
@@ -2155,6 +2155,26 @@ paths:
             type: boolean
             default: false
             title: Include Former Holder
+        - name: key_manager_type
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - $ref: '#/components/schemas/KeyManagerType'
+              - type: 'null'
+            description: Key manager type (**this affects total number**)
+            title: Key Manager Type
+          description: Key manager type (**this affects total number**)
+        - name: key_manager
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: 'null'
+            description: key manager(partial match)
+            title: Key Manager
+          description: key manager(partial match)
         - name: balance
           in: query
           required: false
@@ -2267,16 +2287,6 @@ paths:
             description: holder name(partial match)
             title: Holder Name
           description: holder name(partial match)
-        - name: key_manager
-          in: query
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: key manager(partial match)
-            title: Key Manager
-          description: key manager(partial match)
         - name: sort_item
           in: query
           required: false
@@ -6772,6 +6782,26 @@ paths:
             type: boolean
             default: false
             title: Include Former Holder
+        - name: key_manager_type
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - $ref: '#/components/schemas/KeyManagerType'
+              - type: 'null'
+            description: Key manager type (**this affects total number**)
+            title: Key Manager Type
+          description: Key manager type (**this affects total number**)
+        - name: key_manager
+          in: query
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: 'null'
+            description: key manager(partial match)
+            title: Key Manager
+          description: key manager(partial match)
         - name: balance
           in: query
           required: false
@@ -6884,16 +6914,6 @@ paths:
             description: holder name(partial match)
             title: Holder Name
           description: holder name(partial match)
-        - name: key_manager
-          in: query
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: 'null'
-            description: key manager(partial match)
-            title: Key Manager
-          description: key manager(partial match)
         - name: sort_item
           in: query
           required: false

--- a/tests/app/test_bond_holders_ListAllBondTokenHolders.py
+++ b/tests/app/test_bond_holders_ListAllBondTokenHolders.py
@@ -348,10 +348,10 @@ class TestListAllBondTokenHolders:
             ],
         }
 
-    # <Normal_3>
+    # <Normal_3_1>
     # Multi record
     @pytest.mark.asyncio
-    async def test_normal_3(self, async_client, async_db):
+    async def test_normal_3_1(self, async_client, async_db):
         user = config_eth_account("user1")
         _issuer_address = user["address"]
         _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
@@ -612,6 +612,129 @@ class TestListAllBondTokenHolders:
                     "pending_transfer": 99,
                     "locked": 30,
                     "modified": "2023-10-24T05:00:00",
+                },
+            ],
+        }
+
+    # <Normal_3_2>
+    # Multi record
+    # Base query: key_manager_type
+    @pytest.mark.asyncio
+    async def test_normal_3_2(self, async_client, async_db):
+        user = config_eth_account("user1")
+        _issuer_address = user["address"]
+        _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
+        _account_address_1 = "0xb75c7545b9230FEe99b7af370D38eBd3DAD929f7"
+        _account_address_2 = "0x3F198534Bbe3B2a197d3B317d41392F348EAC707"
+        _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
+
+        account = Account()
+        account.issuer_address = _issuer_address
+        async_db.add(account)
+
+        token = Token()
+        token.type = TokenType.IBET_STRAIGHT_BOND
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = {}
+        token.version = TokenVersion.V_25_06
+        async_db.add(token)
+
+        # prepare data: account_address_1
+        idx_position_1 = IDXPosition()
+        idx_position_1.token_address = _token_address
+        idx_position_1.account_address = _account_address_1
+        idx_position_1.balance = 10
+        idx_position_1.exchange_balance = 11
+        idx_position_1.exchange_commitment = 12
+        idx_position_1.pending_transfer = 5
+        idx_position_1.modified = datetime(2023, 10, 24, 0, 0, 0)
+        async_db.add(idx_position_1)
+
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = _account_address_1
+        idx_personal_info_1.issuer_address = _issuer_address
+        idx_personal_info_1.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
+        async_db.add(idx_personal_info_1)
+
+        # prepare data: account_address_2
+        idx_position_2 = IDXPosition()
+        idx_position_2.token_address = _token_address
+        idx_position_2.account_address = _account_address_2
+        idx_position_2.balance = 20
+        idx_position_2.exchange_balance = 21
+        idx_position_2.exchange_commitment = 22
+        idx_position_2.pending_transfer = 10
+        idx_position_2.modified = datetime(2023, 10, 24, 2, 0, 0)
+        async_db.add(idx_position_2)
+
+        idx_personal_info_2 = IDXPersonalInfo()
+        idx_personal_info_2.account_address = _account_address_2
+        idx_personal_info_2.issuer_address = _issuer_address
+        idx_personal_info_2.personal_info = {
+            "key_manager": "SELF",
+            "name": "name_test2",
+            "postal_code": "postal_code_test2",
+            "address": "address_test2",
+            "email": "email_test2",
+            "birth": "birth_test2",
+            "is_corporate": False,
+            "tax_category": 20,
+        }
+        idx_personal_info_2.data_source = PersonalInfoDataSource.OFF_CHAIN
+        async_db.add(idx_personal_info_2)
+
+        await async_db.commit()
+
+        # request target API
+        resp = await async_client.get(
+            self.base_url.format(_token_address),
+            headers={"issuer-address": _issuer_address},
+            params={"key_manager_type": "SELF"},
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "result_set": {"count": 1, "total": 1, "offset": None, "limit": None},
+            "holders": [
+                {
+                    "account_address": _account_address_2,
+                    "personal_information": {
+                        "key_manager": "SELF",
+                        "name": "name_test2",
+                        "postal_code": "postal_code_test2",
+                        "address": "address_test2",
+                        "email": "email_test2",
+                        "birth": "birth_test2",
+                        "is_corporate": False,
+                        "tax_category": 20,
+                    },
+                    "holder_extra_info": {
+                        "external_id1_type": None,
+                        "external_id1": None,
+                        "external_id2_type": None,
+                        "external_id2": None,
+                        "external_id3_type": None,
+                        "external_id3": None,
+                    },
+                    "balance": 20,
+                    "exchange_balance": 21,
+                    "exchange_commitment": 22,
+                    "pending_transfer": 10,
+                    "locked": 0,
+                    "modified": "2023-10-24T02:00:00",
                 },
             ],
         }

--- a/tests/app/test_share_holders_ListAllShareTokenHolders.py
+++ b/tests/app/test_share_holders_ListAllShareTokenHolders.py
@@ -348,10 +348,10 @@ class TestListAllShareTokenHolders:
             ],
         }
 
-    # <Normal_3>
+    # <Normal_3_1>
     # Multi record
     @pytest.mark.asyncio
-    async def test_normal_3(self, async_client, async_db):
+    async def test_normal_3_1(self, async_client, async_db):
         user = config_eth_account("user1")
         _issuer_address = user["address"]
         _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
@@ -612,6 +612,129 @@ class TestListAllShareTokenHolders:
                     "pending_transfer": 99,
                     "locked": 30,
                     "modified": "2023-10-24T05:00:00",
+                },
+            ],
+        }
+
+    # <Normal_3_2>
+    # Multi record
+    # Base query: key_manager_type
+    @pytest.mark.asyncio
+    async def test_normal_3_2(self, async_client, async_db):
+        user = config_eth_account("user1")
+        _issuer_address = user["address"]
+        _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
+        _account_address_1 = "0xb75c7545b9230FEe99b7af370D38eBd3DAD929f7"
+        _account_address_2 = "0x3F198534Bbe3B2a197d3B317d41392F348EAC707"
+        _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
+
+        account = Account()
+        account.issuer_address = _issuer_address
+        async_db.add(account)
+
+        token = Token()
+        token.type = TokenType.IBET_SHARE
+        token.tx_hash = ""
+        token.issuer_address = _issuer_address
+        token.token_address = _token_address
+        token.abi = {}
+        token.version = TokenVersion.V_25_06
+        async_db.add(token)
+
+        # prepare data: account_address_1
+        idx_position_1 = IDXPosition()
+        idx_position_1.token_address = _token_address
+        idx_position_1.account_address = _account_address_1
+        idx_position_1.balance = 10
+        idx_position_1.exchange_balance = 11
+        idx_position_1.exchange_commitment = 12
+        idx_position_1.pending_transfer = 5
+        idx_position_1.modified = datetime(2023, 10, 24, 0, 0, 0)
+        async_db.add(idx_position_1)
+
+        idx_personal_info_1 = IDXPersonalInfo()
+        idx_personal_info_1.account_address = _account_address_1
+        idx_personal_info_1.issuer_address = _issuer_address
+        idx_personal_info_1.personal_info = {
+            "key_manager": "key_manager_test1",
+            "name": "name_test1",
+            "postal_code": "postal_code_test1",
+            "address": "address_test1",
+            "email": "email_test1",
+            "birth": "birth_test1",
+            "is_corporate": False,
+            "tax_category": 10,
+        }
+        idx_personal_info_1.data_source = PersonalInfoDataSource.ON_CHAIN
+        async_db.add(idx_personal_info_1)
+
+        # prepare data: account_address_2
+        idx_position_2 = IDXPosition()
+        idx_position_2.token_address = _token_address
+        idx_position_2.account_address = _account_address_2
+        idx_position_2.balance = 20
+        idx_position_2.exchange_balance = 21
+        idx_position_2.exchange_commitment = 22
+        idx_position_2.pending_transfer = 10
+        idx_position_2.modified = datetime(2023, 10, 24, 2, 0, 0)
+        async_db.add(idx_position_2)
+
+        idx_personal_info_2 = IDXPersonalInfo()
+        idx_personal_info_2.account_address = _account_address_2
+        idx_personal_info_2.issuer_address = _issuer_address
+        idx_personal_info_2.personal_info = {
+            "key_manager": "SELF",
+            "name": "name_test2",
+            "postal_code": "postal_code_test2",
+            "address": "address_test2",
+            "email": "email_test2",
+            "birth": "birth_test2",
+            "is_corporate": False,
+            "tax_category": 20,
+        }
+        idx_personal_info_2.data_source = PersonalInfoDataSource.OFF_CHAIN
+        async_db.add(idx_personal_info_2)
+
+        await async_db.commit()
+
+        # request target API
+        resp = await async_client.get(
+            self.base_url.format(_token_address),
+            headers={"issuer-address": _issuer_address},
+            params={"key_manager_type": "SELF"},
+        )
+
+        # assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "result_set": {"count": 1, "total": 1, "offset": None, "limit": None},
+            "holders": [
+                {
+                    "account_address": _account_address_2,
+                    "personal_information": {
+                        "key_manager": "SELF",
+                        "name": "name_test2",
+                        "postal_code": "postal_code_test2",
+                        "address": "address_test2",
+                        "email": "email_test2",
+                        "birth": "birth_test2",
+                        "is_corporate": False,
+                        "tax_category": 20,
+                    },
+                    "holder_extra_info": {
+                        "external_id1_type": None,
+                        "external_id1": None,
+                        "external_id2_type": None,
+                        "external_id2": None,
+                        "external_id3_type": None,
+                        "external_id3": None,
+                    },
+                    "balance": 20,
+                    "exchange_balance": 21,
+                    "exchange_commitment": 22,
+                    "pending_transfer": 10,
+                    "locked": 0,
+                    "modified": "2023-10-24T02:00:00",
                 },
             ],
         }


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

This pull request introduces enhancements to the token holder query functionality by adding support for filtering based on `key_manager_type` and refactoring the query logic for improved clarity. It also updates the API documentation and test cases to reflect these changes.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- Close #796

## 🔄 Changes

<!-- List the major changes in this PR. -->

### Schema and Query Enhancements
* Added a new `KeyManagerType` enum to the schema and incorporated `key_manager_type` and `key_manager` fields into the `ListAllHoldersQuery` class for filtering token holders based on key manager type or partial match on key manager. (`app/model/schema/token.py`)
* Updated the `list_all_bond_token_holders` and `list_all_share_token_holders` functions to include filtering logic for `key_manager_type`. This ensures token holders are filtered by whether their key manager is `SELF` or `OTHERS`. (`app/routers/issuer/bond.py`, `app/routers/issuer/share.py`)

### Test Case Additions
* Added a new test cases to validate the `key_manager_type` filtering functionality for token holders. (`tests/app/test_bond_holders_ListAllBondTokenHolders.py`)

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
