### PR TITLE
Add 'id' field to notification model

### DIFF
--- a/app/model/schema/notification.py
+++ b/app/model/schema/notification.py
@@ -102,6 +102,7 @@ class DVPDeliveryInfoMetaInfo(BaseModel):
 
 
 class Notification(BaseModel):
+    id: int
     notice_id: str
     issuer_address: str
     priority: int

--- a/app/routers/issuer/notification.py
+++ b/app/routers/issuer/notification.py
@@ -88,6 +88,7 @@ async def list_all_notifications(
         )
         notifications.append(
             {
+                "id": _notification.id,
                 "notice_id": _notification.notice_id,
                 "issuer_address": _notification.issuer_address,
                 "priority": _notification.priority,

--- a/docs/ibet_prime.yaml
+++ b/docs/ibet_prime.yaml
@@ -10556,6 +10556,9 @@ components:
       title: BatchIssueRedeemProcessedMetaInfo
     BatchIssueRedeemProcessedNotification:
       properties:
+        id:
+          type: integer
+          title: Id
         notice_id:
           type: string
           title: Notice Id
@@ -10586,6 +10589,7 @@ components:
           $ref: '#/components/schemas/BatchIssueRedeemProcessedMetaInfo'
       type: object
       required:
+        - id
         - notice_id
         - issuer_address
         - priority
@@ -10704,6 +10708,9 @@ components:
       title: BatchRegisterPersonalInfoErrorMetaInfo
     BatchRegisterPersonalInfoErrorNotification:
       properties:
+        id:
+          type: integer
+          title: Id
         notice_id:
           type: string
           title: Notice Id
@@ -10732,6 +10739,7 @@ components:
           $ref: '#/components/schemas/BatchRegisterPersonalInfoErrorMetaInfo'
       type: object
       required:
+        - id
         - notice_id
         - issuer_address
         - priority
@@ -11006,6 +11014,9 @@ components:
       title: BulkTransferErrorMetaInfo
     BulkTransferErrorNotification:
       properties:
+        id:
+          type: integer
+          title: Id
         notice_id:
           type: string
           title: Notice Id
@@ -11035,6 +11046,7 @@ components:
           $ref: '#/components/schemas/BulkTransferErrorMetaInfo'
       type: object
       required:
+        - id
         - notice_id
         - issuer_address
         - priority
@@ -11545,6 +11557,9 @@ components:
       title: CreateLedgerInfoMetaInfo
     CreateLedgerInfoNotification:
       properties:
+        id:
+          type: integer
+          title: Id
         notice_id:
           type: string
           title: Notice Id
@@ -11571,6 +11586,7 @@ components:
           $ref: '#/components/schemas/CreateLedgerInfoMetaInfo'
       type: object
       required:
+        - id
         - notice_id
         - issuer_address
         - priority
@@ -11844,6 +11860,9 @@ components:
       title: DVPDeliveryInfoMetaInfo
     DVPDeliveryInfoNotification:
       properties:
+        id:
+          type: integer
+          title: Id
         notice_id:
           type: string
           title: Notice Id
@@ -11873,6 +11892,7 @@ components:
           $ref: '#/components/schemas/DVPDeliveryInfoMetaInfo'
       type: object
       required:
+        - id
         - notice_id
         - issuer_address
         - priority
@@ -13799,6 +13819,9 @@ components:
       title: IssueErrorMetaInfo
     IssueErrorNotification:
       properties:
+        id:
+          type: integer
+          title: Id
         notice_id:
           type: string
           title: Notice Id
@@ -13828,6 +13851,7 @@ components:
           $ref: '#/components/schemas/IssueErrorMetaInfo'
       type: object
       required:
+        - id
         - notice_id
         - issuer_address
         - priority
@@ -14608,6 +14632,9 @@ components:
       title: LockInfoMetaInfo
     LockInfoNotification:
       properties:
+        id:
+          type: integer
+          title: Id
         notice_id:
           type: string
           title: Notice Id
@@ -14634,6 +14661,7 @@ components:
           $ref: '#/components/schemas/LockInfoMetaInfo'
       type: object
       required:
+        - id
         - notice_id
         - issuer_address
         - priority
@@ -15811,6 +15839,9 @@ components:
       title: ScheduleEventErrorMetaInfo
     ScheduleEventErrorNotification:
       properties:
+        id:
+          type: integer
+          title: Id
         notice_id:
           type: string
           title: Notice Id
@@ -15840,6 +15871,7 @@ components:
           $ref: '#/components/schemas/ScheduleEventErrorMetaInfo'
       type: object
       required:
+        - id
         - notice_id
         - issuer_address
         - priority
@@ -16367,6 +16399,9 @@ components:
       title: TransferApprovalInfoMetaInfo
     TransferApprovalInfoNotification:
       properties:
+        id:
+          type: integer
+          title: Id
         notice_id:
           type: string
           title: Notice Id
@@ -16397,6 +16432,7 @@ components:
           $ref: '#/components/schemas/TransferApprovalInfoMetaInfo'
       type: object
       required:
+        - id
         - notice_id
         - issuer_address
         - priority
@@ -16833,6 +16869,9 @@ components:
       title: UnlockInfoMetaInfo
     UnlockInfoNotification:
       properties:
+        id:
+          type: integer
+          title: Id
         notice_id:
           type: string
           title: Notice Id
@@ -16859,6 +16898,7 @@ components:
           $ref: '#/components/schemas/UnlockInfoMetaInfo'
       type: object
       required:
+        - id
         - notice_id
         - issuer_address
         - priority

--- a/tests/app/test_notifications_ListAllNotifications.py
+++ b/tests/app/test_notifications_ListAllNotifications.py
@@ -240,6 +240,7 @@ class TestListAllNotifications:
             "result_set": {"count": 10, "offset": None, "limit": None, "total": 10},
             "notifications": [
                 {
+                    "id": 1,
                     "notice_id": "notice_id_1",
                     "issuer_address": issuer_address_1,
                     "priority": 0,
@@ -254,6 +255,7 @@ class TestListAllNotifications:
                     "created": "2022-01-02T00:20:30+09:00",
                 },
                 {
+                    "id": 2,
                     "notice_id": "notice_id_2",
                     "issuer_address": issuer_address_1,
                     "priority": 1,
@@ -267,6 +269,7 @@ class TestListAllNotifications:
                     "created": "2022-01-02T09:20:30+09:00",
                 },
                 {
+                    "id": 3,
                     "notice_id": "notice_id_3",
                     "issuer_address": issuer_address_2,
                     "priority": 2,
@@ -280,6 +283,7 @@ class TestListAllNotifications:
                     "created": "2022-01-03T00:20:30+09:00",
                 },
                 {
+                    "id": 4,
                     "notice_id": "notice_id_4",
                     "issuer_address": issuer_address_2,
                     "priority": 0,
@@ -293,6 +297,7 @@ class TestListAllNotifications:
                     "created": "2022-01-03T09:20:30+09:00",
                 },
                 {
+                    "id": 5,
                     "notice_id": "notice_id_5",
                     "issuer_address": issuer_address_2,
                     "priority": 0,
@@ -306,6 +311,7 @@ class TestListAllNotifications:
                     "created": "2022-01-05T09:20:30+09:00",
                 },
                 {
+                    "id": 6,
                     "notice_id": "notice_id_6",
                     "issuer_address": issuer_address_2,
                     "priority": 0,
@@ -319,6 +325,7 @@ class TestListAllNotifications:
                     "created": "2022-01-06T09:20:30+09:00",
                 },
                 {
+                    "id": 7,
                     "notice_id": "notice_id_7",
                     "issuer_address": issuer_address_2,
                     "priority": 0,
@@ -334,6 +341,7 @@ class TestListAllNotifications:
                     "created": "2022-01-07T09:20:30+09:00",
                 },
                 {
+                    "id": 8,
                     "notice_id": "notice_id_8",
                     "issuer_address": issuer_address_2,
                     "priority": 0,
@@ -350,6 +358,7 @@ class TestListAllNotifications:
                     "created": "2022-01-08T09:20:30+09:00",
                 },
                 {
+                    "id": 9,
                     "notice_id": "notice_id_9",
                     "issuer_address": issuer_address_2,
                     "priority": 0,
@@ -367,6 +376,7 @@ class TestListAllNotifications:
                     "created": "2022-01-09T09:20:30+09:00",
                 },
                 {
+                    "id": 10,
                     "notice_id": "notice_id_10",
                     "issuer_address": issuer_address_2,
                     "priority": 0,
@@ -482,6 +492,7 @@ class TestListAllNotifications:
             "result_set": {"count": 1, "offset": None, "limit": None, "total": 4},
             "notifications": [
                 {
+                    "id": 2,
                     "notice_id": "notice_id_2",
                     "issuer_address": issuer_address_1,
                     "priority": 1,
@@ -583,6 +594,7 @@ class TestListAllNotifications:
             "result_set": {"count": 4, "offset": 1, "limit": 2, "total": 4},
             "notifications": [
                 {
+                    "id": 2,
                     "notice_id": "notice_id_2",
                     "issuer_address": issuer_address_1,
                     "priority": 1,
@@ -596,6 +608,7 @@ class TestListAllNotifications:
                     "created": "2022-01-02T09:20:30+09:00",
                 },
                 {
+                    "id": 3,
                     "notice_id": "notice_id_3",
                     "issuer_address": issuer_address_2,
                     "priority": 2,


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->
This pull request introduces an `id` field to the notification schema and updates the corresponding API. The `id` field is an integer that uniquely identifies each notification.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
None

## 🔄 Changes

<!-- List the major changes in this PR. -->

### Schema Updates:
* Added an `id` field of type `integer` to the `Notification` schema in `app/model/schema/notification.py`.

### API Changes:
* Updated the `list_all_notifications` method in `app/routers/issuer/notification.py` to include the `id` field in the response.

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
