### PR TITLE
Clear notification_events list after inserting events in DVP delivery indexer (25.6)

### DIFF
--- a/batch/indexer_dvp_delivery.py
+++ b/batch/indexer_dvp_delivery.py
@@ -142,6 +142,7 @@ class Processor:
 
                 # Insert notification events
                 await self.__insert_notification_events(db_session)
+                self.notification_events = []
 
                 await db_session.commit()
         finally:

--- a/tests/batch/test_indexer_dvp_delivery.py
+++ b/tests/batch/test_indexer_dvp_delivery.py
@@ -2313,6 +2313,25 @@ class TestProcessor:
         ).first()
         assert _idx_delivery_block_number.latest_block_number == block_number
 
+        _notifications = (
+            await async_db.scalars(select(Notification).order_by(Notification.created))
+        ).all()
+        assert len(_notifications) == 1
+        assert _notifications[0].issuer_address == issuer_address
+        assert _notifications[0].priority == 0
+        assert _notifications[0].type == NotificationType.DVP_DELIVERY_INFO
+        assert _notifications[0].code == 0
+        assert _notifications[0].metainfo == {
+            "exchange_address": ibet_security_token_dvp_contract.address,
+            "delivery_id": 1,
+            "token_address": token_address_2,
+            "token_type": TokenType.IBET_STRAIGHT_BOND,
+            "seller_address": issuer_address,
+            "buyer_address": user_address_1,
+            "agent_address": agent_address,
+            "amount": 30,
+        }
+
         assert (
             caplog.record_tuples.count(
                 (


### PR DESCRIPTION
## 📌 Description

This pull request includes a small change to the `batch/indexer_dvp_delivery.py` file. The change ensures that the `notification_events` attribute is reset to an empty list after inserting notification events, not to save the same data twice.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- Fix #803 

## 🔄 Changes

<!-- List the major changes in this PR. -->

- Reset `notification_events` attribute to an empty list after inserting notification events in `batch/indexer_dvp_delivery.py`

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
