### PR TITLE
Fix ETH_CHAIN_ID retrieval to ensure it is an integer

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - TEST_DATABASE_URL=postgresql://apluser:apluserpass@postgres/apldb
       - WEB3_HTTP_PROVIDER=http://ibet:8545
       - ETH_WEB3_HTTP_PROVIDER=http://eth:8545
+      - ETH_CHAIN_ID=2025
       - RESPONSE_VALIDATION_MODE=1
       - IBET_WST_FEATURE_ENABLED=1
       - BC_EXPLORER_ENABLED=1

--- a/eth_config.py
+++ b/eth_config.py
@@ -10,7 +10,7 @@ ETH_MASTER_ACCOUNT_ADDRESS = os.environ.get("ETH_MASTER_ACCOUNT_ADDRESS")
 ETH_MASTER_PRIVATE_KEY = os.environ.get("ETH_MASTER_PRIVATE_KEY")
 
 # Ethereum configuration settings for a blockchain application
-ETH_CHAIN_ID = os.environ.get("ETH_CHAIN_ID") or 2025
+ETH_CHAIN_ID = int(os.environ.get("ETH_CHAIN_ID")) or 2025
 ETH_WEB3_HTTP_PROVIDER = (
     os.environ.get("ETH_WEB3_HTTP_PROVIDER") or "http://localhost:8546"
 )


### PR DESCRIPTION
## 📌 Description

This pull request introduces a new environment variable `ETH_CHAIN_ID` and updates its handling in the codebase to ensure proper type conversion. These changes improve configuration flexibility and prevent potential type-related issues.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- None

## 🔄 Changes

### Environment Variable Addition:
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R30): Added `ETH_CHAIN_ID=2025` to the list of environment variables in the `services` section to specify the Ethereum chain ID.

### Code Update for Type Handling:
* [`eth_config.py`](diffhunk://#diff-6697f1dd1c7ec9a505f5d923353f312d98a8f6b5a9a3379b26a614bc8d5a45ffL13-R13): Updated the `ETH_CHAIN_ID` retrieval to explicitly convert the environment variable to an integer, ensuring type consistency.

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
