### PR TITLE
Add error handling for event receipt processing in IbetWST transactions

### DIFF
--- a/batch/processor_eth_wst_monitor_txreceipt.py
+++ b/batch/processor_eth_wst_monitor_txreceipt.py
@@ -26,6 +26,7 @@ from sqlalchemy import and_, select
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 from web3.exceptions import TimeExhausted
+from web3.logs import DISCARD
 from web3.types import TxReceipt
 
 from app.database import BatchAsyncSessionLocal
@@ -165,7 +166,7 @@ async def finalize_tx(
         case IbetWSTTxType.MINT:
             ibet_wst = IbetWST(wst_tx.ibet_wst_address)
             events = ibet_wst.contract.events.Mint().process_receipt(
-                txn_receipt=tx_receipt
+                txn_receipt=tx_receipt, errors=DISCARD
             )
             event = events[0] if len(events) > 0 else None
             if event is not None:
@@ -177,7 +178,7 @@ async def finalize_tx(
         case IbetWSTTxType.BURN:
             ibet_wst = IbetWST(wst_tx.ibet_wst_address)
             events = ibet_wst.contract.events.Burn().process_receipt(
-                txn_receipt=tx_receipt
+                txn_receipt=tx_receipt, errors=DISCARD
             )
             event = events[0] if len(events) > 0 else None
             if event is not None:
@@ -189,7 +190,7 @@ async def finalize_tx(
         case IbetWSTTxType.ADD_WHITELIST:
             ibet_wst = IbetWST(wst_tx.ibet_wst_address)
             events = ibet_wst.contract.events.AccountWhiteListAdded().process_receipt(
-                txn_receipt=tx_receipt
+                txn_receipt=tx_receipt, errors=DISCARD
             )
             event = events[0] if len(events) > 0 else None
             if event is not None:
@@ -200,7 +201,7 @@ async def finalize_tx(
         case IbetWSTTxType.DELETE_WHITELIST:
             ibet_wst = IbetWST(wst_tx.ibet_wst_address)
             events = ibet_wst.contract.events.AccountWhiteListDeleted().process_receipt(
-                txn_receipt=tx_receipt
+                txn_receipt=tx_receipt, errors=DISCARD
             )
             event = events[0] if len(events) > 0 else None
             if event is not None:
@@ -211,7 +212,7 @@ async def finalize_tx(
         case IbetWSTTxType.REQUEST_TRADE:
             ibet_wst = IbetWST(wst_tx.ibet_wst_address)
             events = ibet_wst.contract.events.TradeRequested().process_receipt(
-                txn_receipt=tx_receipt
+                txn_receipt=tx_receipt, errors=DISCARD
             )
             event = events[0] if len(events) > 0 else None
             if event is not None:
@@ -229,7 +230,7 @@ async def finalize_tx(
         case IbetWSTTxType.CANCEL_TRADE:
             ibet_wst = IbetWST(wst_tx.ibet_wst_address)
             events = ibet_wst.contract.events.TradeCancelled().process_receipt(
-                txn_receipt=tx_receipt
+                txn_receipt=tx_receipt, errors=DISCARD
             )
             event = events[0] if len(events) > 0 else None
             if event is not None:
@@ -247,7 +248,7 @@ async def finalize_tx(
         case IbetWSTTxType.ACCEPT_TRADE:
             ibet_wst = IbetWST(wst_tx.ibet_wst_address)
             events = ibet_wst.contract.events.TradeAccepted().process_receipt(
-                txn_receipt=tx_receipt
+                txn_receipt=tx_receipt, errors=DISCARD
             )
             event = events[0] if len(events) > 0 else None
             if event is not None:
@@ -265,7 +266,7 @@ async def finalize_tx(
         case IbetWSTTxType.REJECT_TRADE:
             ibet_wst = IbetWST(wst_tx.ibet_wst_address)
             events = ibet_wst.contract.events.TradeRejected().process_receipt(
-                txn_receipt=tx_receipt
+                txn_receipt=tx_receipt, errors=DISCARD
             )
             event = events[0] if len(events) > 0 else None
             if event is not None:


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->
This pull request updates the `batch/processor_eth_wst_monitor_txreceipt.py` file to enhance error handling during transaction receipt processing. 

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- Related to: #812 

## 🔄 Changes

<!-- List the major changes in this PR. -->

Enhancements to transaction receipt processing:

* Added the `DISCARD` parameter from `web3.logs` to the `process_receipt` method across multiple transaction types (`Mint`, `Burn`, `AccountWhiteListAdded`, `AccountWhiteListDeleted`, `TradeRequested`, `TradeCancelled`, `TradeAccepted`, and `TradeRejected`) to improve error handling and avoid processing invalid logs. [[1]](diffhunk://#diff-7711bbe44883be877362b4127aa3ba17ea790fe9c2cca884155238913e8ce7bcL168-R169) [[2]](diffhunk://#diff-7711bbe44883be877362b4127aa3ba17ea790fe9c2cca884155238913e8ce7bcL180-R181) [[3]](diffhunk://#diff-7711bbe44883be877362b4127aa3ba17ea790fe9c2cca884155238913e8ce7bcL192-R193) [[4]](diffhunk://#diff-7711bbe44883be877362b4127aa3ba17ea790fe9c2cca884155238913e8ce7bcL203-R204) [[5]](diffhunk://#diff-7711bbe44883be877362b4127aa3ba17ea790fe9c2cca884155238913e8ce7bcL214-R215) [[6]](diffhunk://#diff-7711bbe44883be877362b4127aa3ba17ea790fe9c2cca884155238913e8ce7bcL232-R233) [[7]](diffhunk://#diff-7711bbe44883be877362b4127aa3ba17ea790fe9c2cca884155238913e8ce7bcL250-R251) [[8]](diffhunk://#diff-7711bbe44883be877362b4127aa3ba17ea790fe9c2cca884155238913e8ce7bcL268-R269)

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
