### PR TITLE
Add client IP tracking to IbetWST transactions

### DIFF
--- a/app/model/db/ibet_wst.py
+++ b/app/model/db/ibet_wst.py
@@ -275,6 +275,10 @@ class EthIbetWSTTx(Base):
     authorization: Mapped[IbetWSTAuthorization | None] = mapped_column(
         JSON, nullable=True, default=None
     )
+    # Client IP address
+    # - IP address of the client who initiated the transaction
+    # - This field is set when the transaction is executed directly via API call.
+    client_ip: Mapped[str | None] = mapped_column(String(40))
     # Transaction hash
     # - Hash of the transaction on the Ethereum network
     # - Set to None if the transaction is not yet sent

--- a/app/routers/misc/ibet_wst.py
+++ b/app/routers/misc/ibet_wst.py
@@ -22,7 +22,7 @@ from typing import Annotated, Sequence
 
 import pytz
 from eth_utils import to_checksum_address
-from fastapi import APIRouter, HTTPException, Path, Query
+from fastapi import APIRouter, HTTPException, Path, Query, Request
 from sqlalchemy import and_, asc, desc, func, select
 
 import config
@@ -219,6 +219,7 @@ async def get_ibet_wst_balance(
     responses=get_routers_responses(404, 422),
 )
 async def burn_ibet_wst_balance(
+    request: Request,
     db: DBAsyncSession,
     account_address: Annotated[EthereumAddress, Path(description="Account address")],
     ibet_wst_address: Annotated[
@@ -259,6 +260,7 @@ async def burn_ibet_wst_balance(
         r=req_params.authorization.r,
         s=req_params.authorization.s,
     )
+    wst_tx.client_ip = get_client_ip(request)
     db.add(wst_tx)
     await db.commit()
 
@@ -352,6 +354,7 @@ async def get_ibet_wst_whitelist(
     responses=get_routers_responses(404, 422),
 )
 async def transfer_ibet_wst(
+    request: Request,
     db: DBAsyncSession,
     ibet_wst_address: Annotated[
         EthereumAddress, Path(description="IbetWST contract address")
@@ -395,6 +398,7 @@ async def transfer_ibet_wst(
         r=req_params.authorization.r,
         s=req_params.authorization.s,
     )
+    wst_tx.client_ip = get_client_ip(request)
     db.add(wst_tx)
     await db.commit()
 
@@ -409,6 +413,7 @@ async def transfer_ibet_wst(
     responses=get_routers_responses(404, 422),
 )
 async def request_ibet_wst_trade(
+    request: Request,
     db: DBAsyncSession,
     ibet_wst_address: Annotated[
         EthereumAddress, Path(description="IbetWST contract address")
@@ -455,6 +460,7 @@ async def request_ibet_wst_trade(
         r=req_params.authorization.r,
         s=req_params.authorization.s,
     )
+    wst_tx.client_ip = get_client_ip(request)
     db.add(wst_tx)
     await db.commit()
 
@@ -469,6 +475,7 @@ async def request_ibet_wst_trade(
     responses=get_routers_responses(404, 422),
 )
 async def cancel_ibet_wst_trade(
+    request: Request,
     db: DBAsyncSession,
     ibet_wst_address: Annotated[
         EthereumAddress, Path(description="IbetWST contract address")
@@ -507,6 +514,7 @@ async def cancel_ibet_wst_trade(
         r=req_params.authorization.r,
         s=req_params.authorization.s,
     )
+    wst_tx.client_ip = get_client_ip(request)
     db.add(wst_tx)
     await db.commit()
 
@@ -523,6 +531,7 @@ async def cancel_ibet_wst_trade(
     ),
 )
 async def accept_ibet_wst_trade(
+    request: Request,
     db: DBAsyncSession,
     ibet_wst_address: Annotated[
         EthereumAddress, Path(description="IbetWST contract address")
@@ -583,6 +592,7 @@ async def accept_ibet_wst_trade(
         r=req_params.authorization.r,
         s=req_params.authorization.s,
     )
+    wst_tx.client_ip = get_client_ip(request)
     db.add(wst_tx)
     await db.commit()
 
@@ -597,6 +607,7 @@ async def accept_ibet_wst_trade(
     responses=get_routers_responses(404, 422),
 )
 async def reject_ibet_wst_trade(
+    request: Request,
     db: DBAsyncSession,
     ibet_wst_address: Annotated[
         EthereumAddress, Path(description="IbetWST contract address")
@@ -635,6 +646,7 @@ async def reject_ibet_wst_trade(
         r=req_params.authorization.r,
         s=req_params.authorization.s,
     )
+    wst_tx.client_ip = get_client_ip(request)
     db.add(wst_tx)
     await db.commit()
 
@@ -790,3 +802,18 @@ async def get_ibet_wst_trade(
         "memo": trade.memo,
     }
     return json_response(resp)
+
+
+###################################################################
+# Utility Functions
+###################################################################
+
+
+def get_client_ip(request: Request):
+    x_forwarded_for = request.headers.get("X-Forwarded-For")
+    if x_forwarded_for:
+        # If there are multiple, the first one is the client IP
+        client_ip = x_forwarded_for.split(",")[0].strip()
+    else:
+        client_ip = request.client.host
+    return client_ip

--- a/migrations/versions/662535a57229_v25_9_0_feature_812_2.py
+++ b/migrations/versions/662535a57229_v25_9_0_feature_812_2.py
@@ -1,0 +1,31 @@
+"""v25_9_0_feature_812_2
+
+Revision ID: 662535a57229
+Revises: 15540246a906
+Create Date: 2025-07-14 17:07:03.881845
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+from app.database import get_db_schema
+
+# revision identifiers, used by Alembic.
+revision = "662535a57229"
+down_revision = "15540246a906"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "eth_ibet_wst_tx",
+        sa.Column("client_ip", sa.String(length=40), nullable=True),
+        schema=get_db_schema(),
+    )
+
+
+def downgrade():
+    op.drop_column("eth_ibet_wst_tx", "client_ip", schema=get_db_schema())

--- a/tests/app/test_ibet_wst_AcceptIbetWSTTrade.py
+++ b/tests/app/test_ibet_wst_AcceptIbetWSTTrade.py
@@ -154,6 +154,7 @@ class TestCancelIbetWSTTrade:
             "r": signature.r.to_bytes(32).hex(),
             "s": signature.s.to_bytes(32).hex(),
         }
+        assert wst_tx.client_ip == "127.0.0.1"
 
     ###########################################################################
     # Error

--- a/tests/app/test_ibet_wst_BurnIbetWSTBalance.py
+++ b/tests/app/test_ibet_wst_BurnIbetWSTBalance.py
@@ -134,6 +134,7 @@ class TestBurnIbetWSTBalance:
             "r": signature.r.to_bytes(32).hex(),
             "s": signature.s.to_bytes(32).hex(),
         }
+        assert wst_tx.client_ip == "127.0.0.1"
 
     ###########################################################################
     # Error

--- a/tests/app/test_ibet_wst_CancelIbetWSTTrade.py
+++ b/tests/app/test_ibet_wst_CancelIbetWSTTrade.py
@@ -129,6 +129,7 @@ class TestCancelIbetWSTTrade:
             "r": signature.r.to_bytes(32).hex(),
             "s": signature.s.to_bytes(32).hex(),
         }
+        assert wst_tx.client_ip == "127.0.0.1"
 
     ###########################################################################
     # Error

--- a/tests/app/test_ibet_wst_RejectIbetWSTTrade.py
+++ b/tests/app/test_ibet_wst_RejectIbetWSTTrade.py
@@ -129,6 +129,7 @@ class TestRejectIbetWSTTrade:
             "r": signature.r.to_bytes(32).hex(),
             "s": signature.s.to_bytes(32).hex(),
         }
+        assert wst_tx.client_ip == "127.0.0.1"
 
     ###########################################################################
     # Error

--- a/tests/app/test_ibet_wst_RequestIbetWSTTrade.py
+++ b/tests/app/test_ibet_wst_RequestIbetWSTTrade.py
@@ -154,6 +154,7 @@ class TestAddIbetWSTWhitelist:
             "r": signature.r.to_bytes(32).hex(),
             "s": signature.s.to_bytes(32).hex(),
         }
+        assert wst_tx.client_ip == "127.0.0.1"
 
     ###########################################################################
     # Error

--- a/tests/app/test_ibet_wst_TransferIbetWST.py
+++ b/tests/app/test_ibet_wst_TransferIbetWST.py
@@ -226,6 +226,7 @@ class TestTransferIbetWST:
             "r": signature.r.to_bytes(32).hex(),
             "s": signature.s.to_bytes(32).hex(),
         }
+        assert wst_tx.client_ip == "127.0.0.1"
 
     ###########################################################################
     # Error


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

This pull request introduces a new feature to track the client IP address for transactions in the `IbetWST` module.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- Related to #812

## 🔄 Changes

<!-- List the major changes in this PR. -->

### Database Changes:
* Added a new column `client_ip` to the `eth_ibet_wst_tx` table to store the IP address of the client initiating a transaction. This column is nullable and has a maximum length of 40 characters. (`app/model/db/ibet_wst.py`, `migrations/versions/662535a57229_v25_9_0_feature_812_2.py`) [[1]](diffhunk://#diff-4fb31064e27d1d13f8685fa2c590e7e948d17b388c95fb1f8e616615497e52fbR278-R281) [[2]](diffhunk://#diff-9264fc84ddb336b73cf7768e2cb186a1208b378f0fa4d6f4fd2150a6f49464c5R1-R31)

### API Enhancements:
* Updated multiple API endpoints (`burn_ibet_wst_balance`, `transfer_ibet_wst`, `request_ibet_wst_trade`, `cancel_ibet_wst_trade`, `accept_ibet_wst_trade`, and `reject_ibet_wst_trade`) to capture and store the client IP address using a new utility function `get_client_ip`. (`app/routers/misc/ibet_wst.py`) [[1]](diffhunk://#diff-5f30c7009cfc64532aa4bab8d802cd4bd1f229a48d83bf105b2e22d68d609607R222) [[2]](diffhunk://#diff-5f30c7009cfc64532aa4bab8d802cd4bd1f229a48d83bf105b2e22d68d609607R263) [[3]](diffhunk://#diff-5f30c7009cfc64532aa4bab8d802cd4bd1f229a48d83bf105b2e22d68d609607R357) [[4]](diffhunk://#diff-5f30c7009cfc64532aa4bab8d802cd4bd1f229a48d83bf105b2e22d68d609607R401) [[5]](diffhunk://#diff-5f30c7009cfc64532aa4bab8d802cd4bd1f229a48d83bf105b2e22d68d609607R416) [[6]](diffhunk://#diff-5f30c7009cfc64532aa4bab8d802cd4bd1f229a48d83bf105b2e22d68d609607R463) [[7]](diffhunk://#diff-5f30c7009cfc64532aa4bab8d802cd4bd1f229a48d83bf105b2e22d68d609607R478) [[8]](diffhunk://#diff-5f30c7009cfc64532aa4bab8d802cd4bd1f229a48d83bf105b2e22d68d609607R517) [[9]](diffhunk://#diff-5f30c7009cfc64532aa4bab8d802cd4bd1f229a48d83bf105b2e22d68d609607R534) [[10]](diffhunk://#diff-5f30c7009cfc64532aa4bab8d802cd4bd1f229a48d83bf105b2e22d68d609607R595) [[11]](diffhunk://#diff-5f30c7009cfc64532aa4bab8d802cd4bd1f229a48d83bf105b2e22d68d609607R610) [[12]](diffhunk://#diff-5f30c7009cfc64532aa4bab8d802cd4bd1f229a48d83bf105b2e22d68d609607R649)

### Utility Function:
* Added a utility function `get_client_ip` to extract the client IP address from the `X-Forwarded-For` header or the request's client host. (`app/routers/misc/ibet_wst.py`)

## 📌 Checklist

- [ ] I have added tests where necessary.
- [ ] I have updated the documentation where necessary.
