### PR TITLE
Add gas_used field to IbetWST transactions

### DIFF
--- a/app/model/db/ibet_wst.py
+++ b/app/model/db/ibet_wst.py
@@ -286,6 +286,8 @@ class EthIbetWSTTx(Base):
     # Block number
     # - Block number when the transaction was mined
     block_number: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    # Gas used
+    gas_used: Mapped[int | None] = mapped_column(BigInteger)
     # Block finalized
     # - True if the block is finalized, False otherwise
     finalized: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)

--- a/batch/processor_eth_wst_monitor_txreceipt.py
+++ b/batch/processor_eth_wst_monitor_txreceipt.py
@@ -115,6 +115,7 @@ class ProcessorEthWSTMonitorTxReceipt:
                     # Transaction succeeded
                     wst_tx.status = IbetWSTTxStatus.SUCCEEDED
                     wst_tx.block_number = block_number
+                    wst_tx.gas_used = tx_receipt.get("gasUsed")
                     LOG.info(
                         f"Transaction succeeded: id={wst_tx.tx_id}, block_number={block_number}, gas_used={tx_receipt.get('gasUsed')}"
                     )
@@ -122,6 +123,7 @@ class ProcessorEthWSTMonitorTxReceipt:
                     # Transaction failed
                     wst_tx.status = IbetWSTTxStatus.FAILED
                     wst_tx.block_number = block_number
+                    wst_tx.gas_used = tx_receipt.get("gasUsed")
                     LOG.info(
                         f"Transaction failed: id={wst_tx.tx_id}, block_number={block_number}, gas_used={tx_receipt.get('gasUsed')}"
                     )

--- a/migrations/versions/cfb5c6ce3197_v25_9_0_feature_812_3.py
+++ b/migrations/versions/cfb5c6ce3197_v25_9_0_feature_812_3.py
@@ -1,0 +1,31 @@
+"""v25_9_0_feature_812_3
+
+Revision ID: cfb5c6ce3197
+Revises: 662535a57229
+Create Date: 2025-07-15 08:33:07.078589
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+from app.database import get_db_schema
+
+# revision identifiers, used by Alembic.
+revision = "cfb5c6ce3197"
+down_revision = "662535a57229"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "eth_ibet_wst_tx",
+        sa.Column("gas_used", sa.BigInteger(), nullable=True),
+        schema=get_db_schema(),
+    )
+
+
+def downgrade():
+    op.drop_column("eth_ibet_wst_tx", "gas_used", schema=get_db_schema())

--- a/tests/batch/test_processor_eth_wst_monitor_txreceipt.py
+++ b/tests/batch/test_processor_eth_wst_monitor_txreceipt.py
@@ -197,6 +197,7 @@ class TestProcessor:
         ).first()
         assert wst_tx_af.status == IbetWSTTxStatus.SUCCEEDED
         assert wst_tx_af.block_number == 100
+        assert wst_tx_af.gas_used == 21000
         assert wst_tx_af.finalized is False
 
         assert caplog.messages == [
@@ -251,6 +252,7 @@ class TestProcessor:
         ).first()
         assert wst_tx_af.status == IbetWSTTxStatus.FAILED
         assert wst_tx_af.block_number == 100
+        assert wst_tx_af.gas_used == 21000
         assert wst_tx_af.finalized is False
 
         assert caplog.messages == [
@@ -321,6 +323,7 @@ class TestProcessor:
         ).first()
         assert wst_tx_af.status == IbetWSTTxStatus.SUCCEEDED
         assert wst_tx_af.block_number == 100
+        assert wst_tx_af.gas_used == 21000
         assert wst_tx_af.finalized is True
 
         token_af = (
@@ -415,6 +418,7 @@ class TestProcessor:
         ).first()
         assert wst_tx_af.status == IbetWSTTxStatus.SUCCEEDED
         assert wst_tx_af.block_number == 100
+        assert wst_tx_af.gas_used == 21000
         assert wst_tx_af.finalized is True
         assert wst_tx_af.event_log == {
             "to_address": self.user1["address"],
@@ -505,6 +509,7 @@ class TestProcessor:
         ).first()
         assert wst_tx_af.status == IbetWSTTxStatus.SUCCEEDED
         assert wst_tx_af.block_number == 100
+        assert wst_tx_af.gas_used == 21000
         assert wst_tx_af.finalized is True
         assert wst_tx_af.event_log == {
             "from_address": self.user1["address"],
@@ -593,6 +598,7 @@ class TestProcessor:
         ).first()
         assert wst_tx_af.status == IbetWSTTxStatus.SUCCEEDED
         assert wst_tx_af.block_number == 100
+        assert wst_tx_af.gas_used == 21000
         assert wst_tx_af.finalized is True
         assert wst_tx_af.event_log == {
             "account_address": self.user1["address"],
@@ -680,6 +686,7 @@ class TestProcessor:
         ).first()
         assert wst_tx_af.status == IbetWSTTxStatus.SUCCEEDED
         assert wst_tx_af.block_number == 100
+        assert wst_tx_af.gas_used == 21000
         assert wst_tx_af.finalized is True
         assert wst_tx_af.event_log == {
             "account_address": self.user1["address"],
@@ -781,6 +788,7 @@ class TestProcessor:
         ).first()
         assert wst_tx_af.status == IbetWSTTxStatus.SUCCEEDED
         assert wst_tx_af.block_number == 100
+        assert wst_tx_af.gas_used == 21000
         assert wst_tx_af.finalized is True
         assert wst_tx_af.event_log == {
             "index": 1,
@@ -880,6 +888,7 @@ class TestProcessor:
         ).first()
         assert wst_tx_af.status == IbetWSTTxStatus.SUCCEEDED
         assert wst_tx_af.block_number == 100
+        assert wst_tx_af.gas_used == 21000
         assert wst_tx_af.finalized is True
         assert wst_tx_af.event_log == {
             "index": 1,
@@ -979,6 +988,7 @@ class TestProcessor:
         ).first()
         assert wst_tx_af.status == IbetWSTTxStatus.SUCCEEDED
         assert wst_tx_af.block_number == 100
+        assert wst_tx_af.gas_used == 21000
         assert wst_tx_af.finalized is True
         assert wst_tx_af.event_log == {
             "index": 1,
@@ -1078,6 +1088,7 @@ class TestProcessor:
         ).first()
         assert wst_tx_af.status == IbetWSTTxStatus.SUCCEEDED
         assert wst_tx_af.block_number == 100
+        assert wst_tx_af.gas_used == 21000
         assert wst_tx_af.finalized is True
         assert wst_tx_af.event_log == {
             "index": 1,
@@ -1178,6 +1189,7 @@ class TestProcessor:
         ).first()
         assert wst_tx_af.status == IbetWSTTxStatus.SUCCEEDED
         assert wst_tx_af.block_number == 100
+        assert wst_tx_af.gas_used == 21000
         assert wst_tx_af.finalized is True
         assert wst_tx_af.event_log == {
             "from_address": self.user1["address"],


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

This pull request introduces a new feature to track the gas used in Ethereum transactions (`gas_used`) for the `EthIbetWSTTx` model.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- Related to #812

## 🔄 Changes

<!-- List the major changes in this PR. -->

### Database Schema Updates:
* Updated the `EthIbetWSTTx` model to include the `gas_used` attribute, allowing the application to store and retrieve this information. (`app/model/db/ibet_wst.py`)

### Application Logic Updates:
* Modified the `run` method in `batch/processor_eth_wst_monitor_txreceipt.py` to populate the `gas_used` field from the transaction receipt data. (`batch/processor_eth_wst_monitor_txreceipt.py`)

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
