### PR TITLE
Support AWS Secrets Manager for Ethereum master private key management

### DIFF
--- a/config.py
+++ b/config.py
@@ -322,29 +322,18 @@ EOA_PASSWORD_CHECK_ENABLED = (
     False if os.environ.get("EOA_PASSWORD_CHECK_ENABLED") == "0" else True
 )
 
-# End-to-End Encryption (RSA)
-# NOTE:
-# about E2EE_RSA_RESOURCE_MODE
-# - 0:File, Set the file path to E2EE_RSA_RESOURCE.
-# - 1:AWS SecretsManager, Set the SecretsManagerARN to E2EE_RSA_RESOURCE.
-if "pytest" in sys.modules:  # for unit test
-    E2EE_RSA_RESOURCE_MODE = (
-        int(os.environ.get("E2EE_RSA_RESOURCE_MODE"))
-        if os.environ.get("E2EE_RSA_RESOURCE_MODE")
-        else 0
-    )
-    E2EE_RSA_RESOURCE = (
-        os.environ.get("E2EE_RSA_RESOURCE") or "tests/data/rsa_private.pem"
-    )
-    E2EE_RSA_PASSPHRASE = os.environ.get("E2EE_RSA_PASSPHRASE") or "password"
-elif (
-    "alembic" in sys.modules or "manage.py" in sys.argv[0] or APP_ENV == "local"
-):  # for migration or local
-    E2EE_RSA_RESOURCE_MODE = (
-        int(os.environ.get("E2EE_RSA_RESOURCE_MODE"))
-        if os.environ.get("E2EE_RSA_RESOURCE_MODE")
-        else 0
-    )
+# End-to-End Encryption (E2EE) settings
+#   E2EE_RSA_RESOURCE_MODE:
+#   - 0: File. Set the file path to E2EE_RSA_RESOURCE.
+#   - 1: AWS Secrets Manager. Set the Secrets Manager ARN to E2EE_RSA_RESOURCE.
+if (
+    "pytest" in sys.modules
+    or "alembic" in sys.modules
+    or "manage.py" in sys.argv[0]
+    or APP_ENV == "local"
+):
+    # For unit test / migration / local development
+    E2EE_RSA_RESOURCE_MODE = int(os.environ.get("E2EE_RSA_RESOURCE_MODE", 0))
     E2EE_RSA_RESOURCE = (
         os.environ.get("E2EE_RSA_RESOURCE") or "tests/data/rsa_private.pem"
     )


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

This pull request refactors encryption and resource management settings in `config.py` and `eth_config.py` to improve clarity and flexibility. Key changes include streamlining the configuration logic for End-to-End Encryption (E2EE) and adding support for retrieving Ethereum private keys from AWS Secrets Manager.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- Related to #812

## 🔄 Changes

<!-- List the major changes in this PR. -->

### Refactoring of E2EE settings in `config.py`:
* Consolidated conditional logic for setting `E2EE_RSA_RESOURCE_MODE` to simplify and unify handling for unit tests, migrations, and local development environments.

### Enhancements to Ethereum configuration in `eth_config.py`:
* Introduced `ETH_MASTER_PRIVATE_KEY_RESOURCE` to specify the source of the master account's private key (`os_environ` or `aws_secrets_manager`).
* Added support for retrieving the master account's private key from AWS Secrets Manager.

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
