### PR TITLE
Fix block processing logic in monitor bridge events

### DIFF
--- a/batch/processor_eth_wst_monitor_bridge_events.py
+++ b/batch/processor_eth_wst_monitor_bridge_events.py
@@ -242,14 +242,14 @@ class WSTBridgeMonitoringProcessor:
             if latest_block > _block_to:
                 # If the range exceeds the latest block, process in chunks
                 while _block_to < latest_block:
-                    await self.__process_mint(db_session, _block_from, _block_to)
+                    await self.__process_mint(db_session, _block_from + 1, _block_to)
                     _block_to += IBET_WST_BRIDGE_BLOCK_LOT_MAX_SIZE
                     _block_from += IBET_WST_BRIDGE_BLOCK_LOT_MAX_SIZE
                 # Process the remaining blocks
-                await self.__process_mint(db_session, _block_from, latest_block)
+                await self.__process_mint(db_session, _block_from + 1, latest_block)
             else:
                 # If the range does not exceed the latest block, process all at once
-                await self.__process_mint(db_session, _block_from, latest_block)
+                await self.__process_mint(db_session, _block_from + 1, latest_block)
 
             # Update the latest synchronized block number
             await self.set_synced_block_number(
@@ -285,17 +285,19 @@ class WSTBridgeMonitoringProcessor:
             if latest_block > _block_to:
                 # If the range exceeds the latest block, process in chunks
                 while _block_to < latest_block:
-                    await self.__process_burn(db_session, _block_from, _block_to)
-                    await self.__process_transfer(db_session, _block_from, _block_to)
+                    await self.__process_burn(db_session, _block_from + 1, _block_to)
+                    await self.__process_transfer(
+                        db_session, _block_from + 1, _block_to
+                    )
                     _block_to += IBET_WST_BRIDGE_BLOCK_LOT_MAX_SIZE
                     _block_from += IBET_WST_BRIDGE_BLOCK_LOT_MAX_SIZE
                 # Process the remaining blocks
-                await self.__process_burn(db_session, _block_from, latest_block)
-                await self.__process_transfer(db_session, _block_from, latest_block)
+                await self.__process_burn(db_session, _block_from + 1, latest_block)
+                await self.__process_transfer(db_session, _block_from + 1, latest_block)
             else:
                 # If the range does not exceed the latest block, process all at once
-                await self.__process_burn(db_session, _block_from, latest_block)
-                await self.__process_transfer(db_session, _block_from, latest_block)
+                await self.__process_burn(db_session, _block_from + 1, latest_block)
+                await self.__process_transfer(db_session, _block_from + 1, latest_block)
 
             # Update the latest synchronized block number
             await self.set_synced_block_number(


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

This pull request updates the logic for processing blockchain events in the `batch/processor_eth_wst_monitor_bridge_events.py` file to ensure the correct range of blocks is processed. Specifically, it adjusts the starting block (`_block_from`) by incrementing it by 1 before passing it to the processing methods. 

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- Related to #812 

## 🔄 Changes

<!-- List the major changes in this PR. -->

### Fix block processing logic:

* **Mint processing in `ibet_to_eth`:** Updated `_block_from` to `_block_from + 1` for all calls to `__process_mint`, ensuring the starting block is excluded from repeated processing.

* **Burn and transfer processing in `eth_to_ibet`:** Updated `_block_from` to `_block_from + 1` for all calls to `__process_burn` and `__process_transfer`, ensuring the starting block is excluded from repeated processing.

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
