### PR TITLE
Enforce required integer validation for valid_after and valid_before fields in IbetWST transfer

### DIFF
--- a/app/model/schema/ibet_wst.py
+++ b/app/model/schema/ibet_wst.py
@@ -143,10 +143,10 @@ class TransferIbetWSTRequest(BaseModel):
     from_address: ChecksumEthereumAddress = Field(description="Sender address")
     to_address: ChecksumEthereumAddress = Field(description="Recipient address")
     value: PositiveInt = Field(description="Amount of IbetWST to transfer")
-    valid_after: Optional[PositiveInt] = Field(
+    valid_after: PositiveInt = Field(
         default=1, description="Valid after timestamp (Unix time)"
     )
-    valid_before: Optional[PositiveInt] = Field(
+    valid_before: PositiveInt = Field(
         default=2**64 - 1,
         description="Valid before timestamp (Unix time)",
         le=2**64 - 1,

--- a/docs/ibet_prime.yaml
+++ b/docs/ibet_prime.yaml
@@ -18370,19 +18370,15 @@ components:
           title: Value
           description: Amount of IbetWST to transfer
         valid_after:
-          anyOf:
-            - type: integer
-              exclusiveMinimum: 0.0
-            - type: 'null'
+          type: integer
+          exclusiveMinimum: 0.0
           title: Valid After
           description: Valid after timestamp (Unix time)
           default: 1
         valid_before:
-          anyOf:
-            - type: integer
-              maximum: 1.8446744073709552e+19
-              exclusiveMinimum: 0.0
-            - type: 'null'
+          type: integer
+          maximum: 1.8446744073709552e+19
+          exclusiveMinimum: 0.0
           title: Valid Before
           description: Valid before timestamp (Unix time)
           default: 18446744073709551615


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->
This pull request modifies the handling of `valid_after` and `valid_before` fields in the IbetWST transfer functionality.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- Related to #812

## 🔄 Changes

<!-- List the major changes in this PR. -->

### Schema and Model Updates:
* [`app/model/schema/ibet_wst.py`](diffhunk://#diff-f68404341792a531155f615f4f170c082a2f86fb1a4c4b7d9908404aa4122b29L146-R149): Changed `valid_after` and `valid_before` fields from `Optional[PositiveInt]` to mandatory `PositiveInt` with default values, ensuring stricter validation.

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
