### PR TITLE
Validate Ethereum addresses to prevent zero address usage in IbetWST transactions

### DIFF
--- a/app/model/__init__.py
+++ b/app/model/__init__.py
@@ -24,6 +24,8 @@ from pydantic import WrapValidator
 from pydantic_core.core_schema import ValidatorFunctionWrapHandler
 from web3 import Web3
 
+from config import ZERO_ADDRESS
+
 
 def ethereum_address_validator(
     value: Any, handler: ValidatorFunctionWrapHandler, *args, **kwargs
@@ -51,6 +53,8 @@ def checksum_ethereum_address_validator(
             raise ValueError("invalid ethereum address")
         if not Web3.to_checksum_address(value) == value:
             raise ValueError("ethereum address must be in checksum format")
+        if value == ZERO_ADDRESS:
+            raise ValueError("ethereum address must not be zero address")
     return value
 
 


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

This pull request introduces a validation to ensure Ethereum addresses are not the zero address (`0x0000000000000000000000000000000000000000`). 

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- Related to #812

## 🔄 Changes

<!-- List the major changes in this PR. -->

### Validation Enhancements:

* Added a check in the `checksum_ethereum_address_validator` function to raise a `ValueError` if the Ethereum address is the zero address. (`app/model/__init__.py`, [app/model/__init__.pyR56-R57](diffhunk://#diff-80fe5522af71e5f72c071140b09297637f4b30d6b33fad7754e6fb0c69c1ba10R56-R57))

## 📌 Checklist

- [ ] I have added tests where necessary.
- [ ] I have updated the documentation where necessary.
