### PR TITLE
Add pre-transaction balance checks for IbetWST operations

### DIFF
--- a/docs/ibet_prime.yaml
+++ b/docs/ibet_prime.yaml
@@ -9874,6 +9874,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error422Model'
+        '400':
+          description: Invalid Parameter Error / Send Transaction Error / 
+            Contract Revert Error etc
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IbetWSTInsufficientBalanceErrorResponse'
   /ibet_wst/transactions:
     get:
       tags:
@@ -10143,6 +10150,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error422Model'
+        '400':
+          description: Invalid Parameter Error / Send Transaction Error / 
+            Contract Revert Error etc
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IbetWSTInsufficientBalanceErrorResponse'
   /ibet_wst/trades/{ibet_wst_address}/request:
     post:
       tags:

--- a/tests/app/test_ibet_wst_TransferIbetWST.py
+++ b/tests/app/test_ibet_wst_TransferIbetWST.py
@@ -19,6 +19,7 @@ SPDX-License-Identifier: Apache-2.0
 
 import secrets
 from unittest import mock
+from unittest.mock import AsyncMock
 
 import pytest
 from eth_utils import to_checksum_address
@@ -60,6 +61,9 @@ class TestTransferIbetWST:
 
     # <Normal_1>
     # Test normal transfer of IbetWST token
+    @mock.patch(
+        "app.routers.misc.ibet_wst.IbetWST.balance_of", AsyncMock(return_value=1000)
+    )
     @mock.patch(
         "app.routers.misc.ibet_wst.ETH_MASTER_ACCOUNT_ADDRESS",
         relayer["address"],
@@ -148,6 +152,9 @@ class TestTransferIbetWST:
 
     # <Normal_2>
     # Test not setting `valid_after` and `valid_before`
+    @mock.patch(
+        "app.routers.misc.ibet_wst.IbetWST.balance_of", AsyncMock(return_value=1000)
+    )
     @mock.patch(
         "app.routers.misc.ibet_wst.ETH_MASTER_ACCOUNT_ADDRESS",
         relayer["address"],
@@ -568,4 +575,71 @@ class TestTransferIbetWST:
         assert resp.json() == {
             "meta": {"code": 1, "title": "NotFound"},
             "detail": "IbetWST token not found",
+        }
+
+    # <Error_4>
+    # Insufficient balance for transfer
+    @mock.patch(
+        "app.routers.misc.ibet_wst.IbetWST.balance_of", AsyncMock(return_value=999)
+    )
+    async def test_error_4(self, async_db, async_client):
+        # Prepare data: Token
+        token = Token()
+        token.token_address = self.ibet_token_address
+        token.issuer_address = self.issuer["address"]
+        token.type = TokenType.IBET_STRAIGHT_BOND
+        token.tx_hash = ""
+        token.abi = {}
+        token.version = TokenVersion.V_25_09
+        token.ibet_wst_deployed = True
+        token.ibet_wst_address = self.ibet_wst_address
+        async_db.add(token)
+        await async_db.commit()
+
+        # Generate nonce
+        nonce = secrets.token_bytes(32)
+
+        # Get domain separator
+        token_st = IbetWST(self.ibet_wst_address)
+        domain_separator = await token_st.domain_separator()
+
+        # Generate digest
+        digest = IbetWSTDigestHelper.generate_transfer_digest(
+            domain_separator=domain_separator,
+            from_address=self.user1["address"],
+            to_address=self.user2["address"],
+            value=1000,
+            valid_after=1,
+            valid_before=2**64 - 1,
+            nonce=nonce,
+        )
+
+        # Sign the digest from the authorizer's private key
+        signature = EthWeb3.eth.account.unsafe_sign_hash(
+            digest, bytes.fromhex(self.user1["private_key"])
+        )
+
+        # Send request
+        resp = await async_client.post(
+            self.api_url.format(ibet_wst_address=self.ibet_wst_address),
+            json={
+                "from_address": self.user1["address"],
+                "to_address": self.user2["address"],
+                "value": 1000,
+                "valid_after": 1,
+                "valid_before": 2**64 - 1,
+                "authorizer": self.user1["address"],
+                "authorization": {
+                    "nonce": nonce.hex(),
+                    "v": signature.v,
+                    "r": signature.r.to_bytes(32).hex(),
+                    "s": signature.s.to_bytes(32).hex(),
+                },
+            },
+        )
+
+        # Check response status code and content
+        assert resp.status_code == 400
+        assert resp.json() == {
+            "meta": {"code": 13, "title": "IbetWSTInsufficientBalanceError"}
         }


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

This pull request introduces changes to enhance error handling for insufficient balance scenarios in the `IbetWST` module.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- Related to #812

## 🔄 Changes

<!-- List the major changes in this PR. -->

### Enhancements to error handling:
* Added a pre-transaction balance check in the `burn_ibet_wst_balance` and `transfer_ibet_wst` endpoints to ensure sufficient token balance before proceeding with transactions. If the balance is insufficient, an `IbetWSTInsufficientBalanceError` is raised. (`app/routers/misc/ibet_wst.py`: [[1]](diffhunk://#diff-5f30c7009cfc64532aa4bab8d802cd4bd1f229a48d83bf105b2e22d68d609607R247-R252) [[2]](diffhunk://#diff-5f30c7009cfc64532aa4bab8d802cd4bd1f229a48d83bf105b2e22d68d609607R518-R525)

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
