### PR TITLE
Add personal info history tracking for off-chain data

### DIFF
--- a/app/routers/issuer/bond.py
+++ b/app/routers/issuer/bond.py
@@ -86,11 +86,13 @@ from app.model.db import (
     IDXLock,
     IDXLockedPosition,
     IDXPersonalInfo,
+    IDXPersonalInfoHistory,
     IDXPosition,
     IDXTransfer,
     IDXTransferApproval,
     IDXTransferApprovalsSortItem,
     IDXUnlock,
+    PersonalInfoEventType,
     ScheduledEvents,
     Token,
     TokenHolderExtraInfo,
@@ -2803,12 +2805,20 @@ async def register_bond_token_holder_personal_info(
         }
     )
     if personal_info.data_source == PersonalInfoDataSource.OFF_CHAIN:
+        # Add off-chain personal info
         _off_personal_info = IDXPersonalInfo()
         _off_personal_info.issuer_address = issuer_address
         _off_personal_info.account_address = personal_info.account_address
         _off_personal_info.personal_info = input_personal_info
         _off_personal_info.data_source = PersonalInfoDataSource.OFF_CHAIN
         await db.merge(_off_personal_info)
+        # Add personal info history
+        _personal_info_history = IDXPersonalInfoHistory()
+        _personal_info_history.issuer_address = issuer_address
+        _personal_info_history.account_address = personal_info.account_address
+        _personal_info_history.event_type = PersonalInfoEventType.REGISTER
+        _personal_info_history.personal_info = input_personal_info
+        db.add(_personal_info_history)
         await db.commit()
     else:
         # Check the length of personal info content

--- a/app/routers/issuer/share.py
+++ b/app/routers/issuer/share.py
@@ -87,11 +87,13 @@ from app.model.db import (
     IDXLock,
     IDXLockedPosition,
     IDXPersonalInfo,
+    IDXPersonalInfoHistory,
     IDXPosition,
     IDXTransfer,
     IDXTransferApproval,
     IDXTransferApprovalsSortItem,
     IDXUnlock,
+    PersonalInfoEventType,
     ScheduledEvents,
     Token,
     TokenHolderExtraInfo,
@@ -2726,12 +2728,20 @@ async def register_share_token_holder_personal_info(
         }
     )
     if personal_info.data_source == PersonalInfoDataSource.OFF_CHAIN:
+        # Add off-chain personal info
         _off_personal_info = IDXPersonalInfo()
         _off_personal_info.issuer_address = issuer_address
         _off_personal_info.account_address = personal_info.account_address
         _off_personal_info.personal_info = input_personal_info
         _off_personal_info.data_source = PersonalInfoDataSource.OFF_CHAIN
         await db.merge(_off_personal_info)
+        # Add personal info history
+        _personal_info_history = IDXPersonalInfoHistory()
+        _personal_info_history.issuer_address = issuer_address
+        _personal_info_history.account_address = personal_info.account_address
+        _personal_info_history.event_type = PersonalInfoEventType.REGISTER
+        _personal_info_history.personal_info = input_personal_info
+        db.add(_personal_info_history)
         await db.commit()
     else:
         # Check the length of personal info content

--- a/tests/app/test_bond_personal_info_RegisterBondTokenHolderPersonalInfo.py
+++ b/tests/app/test_bond_personal_info_RegisterBondTokenHolderPersonalInfo.py
@@ -21,13 +21,14 @@ import hashlib
 from unittest.mock import patch
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import and_, select
 
 from app.exceptions import SendTransactionError
 from app.model.db import (
     Account,
     AuthToken,
     IDXPersonalInfo,
+    IDXPersonalInfoHistory,
     Token,
     TokenType,
     TokenVersion,
@@ -240,6 +241,33 @@ class TestRegisterBondTokenHolderPersonalInfo:
                 "tax_category": 10,
             }
             assert _off_personal_info.data_source == PersonalInfoDataSource.OFF_CHAIN
+
+            _personal_info_history = (
+                await async_db.scalars(
+                    select(IDXPersonalInfoHistory)
+                    .where(
+                        and_(
+                            IDXPersonalInfoHistory.issuer_address == _issuer_address,
+                            IDXPersonalInfoHistory.account_address
+                            == _test_account_address,
+                        )
+                    )
+                    .limit(1)
+                )
+            ).first()
+            assert _personal_info_history.id is not None
+            assert _personal_info_history.issuer_address == _issuer_address
+            assert _personal_info_history.account_address == _test_account_address
+            assert _personal_info_history.personal_info == {
+                "key_manager": "test_key_manager",
+                "name": "test_name",
+                "address": "test_address",
+                "postal_code": "test_postal_code",
+                "email": "test_email",
+                "birth": "test_birth",
+                "is_corporate": False,
+                "tax_category": 10,
+            }
 
     # <Normal_2_1>
     # Optional items

--- a/tests/app/test_share_personal_info_RegisterShareTokenHolderPersonalInfo.py
+++ b/tests/app/test_share_personal_info_RegisterShareTokenHolderPersonalInfo.py
@@ -21,13 +21,14 @@ import hashlib
 from unittest.mock import patch
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import and_, select
 
 from app.exceptions import SendTransactionError
 from app.model.db import (
     Account,
     AuthToken,
     IDXPersonalInfo,
+    IDXPersonalInfoHistory,
     Token,
     TokenType,
     TokenVersion,
@@ -240,6 +241,33 @@ class TestRegisterShareTokenHolderPersonalInfo:
                 "tax_category": 10,
             }
             assert _off_personal_info.data_source == PersonalInfoDataSource.OFF_CHAIN
+
+            _personal_info_history = (
+                await async_db.scalars(
+                    select(IDXPersonalInfoHistory)
+                    .where(
+                        and_(
+                            IDXPersonalInfoHistory.issuer_address == _issuer_address,
+                            IDXPersonalInfoHistory.account_address
+                            == _test_account_address,
+                        )
+                    )
+                    .limit(1)
+                )
+            ).first()
+            assert _personal_info_history.id is not None
+            assert _personal_info_history.issuer_address == _issuer_address
+            assert _personal_info_history.account_address == _test_account_address
+            assert _personal_info_history.personal_info == {
+                "key_manager": "test_key_manager",
+                "name": "test_name",
+                "address": "test_address",
+                "postal_code": "test_postal_code",
+                "email": "test_email",
+                "birth": "test_birth",
+                "is_corporate": False,
+                "tax_category": 10,
+            }
 
     # <Normal_2_1>
     # Optional items


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

This pull request introduces functionality to track the history of personal information updates for bond and share token holders.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- Close #869 

## 🔄 Changes

<!-- List the major changes in this PR. -->

### API Endpoint Updates:
  - Enhanced the `register_bond_token_holder_personal_info` and `register_share_token_holder_personal_info` endpoints to log personal information changes into the `IDXPersonalInfoHistory` table whenever off-chain personal information is registered. [[1]](diffhunk://#diff-d423ad219858d5cadb48390db542fd1449ff9d6562213d33ff3150f48b7fbbe9R2808-R2821) [[2]](diffhunk://#diff-95d74a3e746fba065d4d5d96590dff5859b62a05b1f1c68769a083b04cad2991R2731-R2744)

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
