### PR TITLE
Update IbetWST address handling for deploy transactions

### DIFF
--- a/app/model/db/ibet_wst.py
+++ b/app/model/db/ibet_wst.py
@@ -246,7 +246,8 @@ class EthIbetWSTTx(Base):
     status: Mapped[IbetWSTTxStatus] = mapped_column(Integer, nullable=False)
     # IbetWST contract address
     # - Address of the IbetWST contract on the Ethereum network
-    # - This field is set if the transaction is for the deployed IbetWST contract
+    # - For deploy transactions: The contract address is set when the contract is deployed.
+    # - For other transactions: The contract address is set at the time the transaction is instructed.
     ibet_wst_address: Mapped[str | None] = mapped_column(String(42), nullable=True)
     # Transaction parameters
     # - JSON object containing the parameters for the transaction

--- a/batch/processor_eth_wst_monitor_txreceipt.py
+++ b/batch/processor_eth_wst_monitor_txreceipt.py
@@ -118,6 +118,9 @@ class ProcessorEthWSTMonitorTxReceipt:
                     wst_tx.status = IbetWSTTxStatus.SUCCEEDED
                     wst_tx.block_number = block_number
                     wst_tx.gas_used = tx_receipt.get("gasUsed")
+                    # If the transaction type is DEPLOY, set the IbetWST address
+                    if wst_tx.tx_type == IbetWSTTxType.DEPLOY:
+                        wst_tx.ibet_wst_address = tx_receipt.get("contractAddress")
                     LOG.info(
                         f"Transaction succeeded: id={wst_tx.tx_id}, block_number={block_number}, gas_used={tx_receipt.get('gasUsed')}"
                     )

--- a/batch/processor_eth_wst_monitor_txreceipt.py
+++ b/batch/processor_eth_wst_monitor_txreceipt.py
@@ -139,7 +139,7 @@ class ProcessorEthWSTMonitorTxReceipt:
                 wst_tx.finalized = is_finalized
                 await db_session.merge(wst_tx)
 
-                if is_finalized:
+                if is_finalized and wst_tx.status == IbetWSTTxStatus.SUCCEEDED:
                     # Finalize the transaction
                     await finalize_tx(db_session, wst_tx, tx_receipt)
                     LOG.info(

--- a/tests/batch/test_processor_eth_wst_monitor_txreceipt.py
+++ b/tests/batch/test_processor_eth_wst_monitor_txreceipt.py
@@ -201,6 +201,9 @@ class TestProcessor:
         assert wst_tx_af.block_number == 100
         assert wst_tx_af.gas_used == 21000
         assert wst_tx_af.finalized is False
+        assert (
+            wst_tx_af.ibet_wst_address == "0x9876543210abcdef1234567890abcdef12345678"
+        )
 
         assert caplog.messages == [
             f"Monitor transaction: id={tx_id}, type=deploy",


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

This pull request improves the handling and clarity of the `ibet_wst_address` field for IbetWST contract transactions, ensures the contract address is set correctly for deploy transactions, and updates the tests to validate this behavior.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- Related to #812

## 🔄 Changes

<!-- List the major changes in this PR. -->

**Transaction contract address handling:**

* Updated the transaction processing logic in `batch/processor_eth_wst_monitor_txreceipt.py` to set the `ibet_wst_address` from the transaction receipt when the transaction type is `DEPLOY`.
* Clarified the documentation for the `ibet_wst_address` field in the `EthIbetWSTTx` model to specify that for deploy transactions, the contract address is set upon deployment, while for other transactions, it is set when instructed.

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
