### PR TITLE
Add whitelist checks for IbetWST transfer and trade operations

### DIFF
--- a/app/exceptions.py
+++ b/app/exceptions.py
@@ -140,6 +140,14 @@ class ERC20InsufficientAllowanceError(BadRequestError):
     code = 14
 
 
+class IbetWSTAccountNotWhitelistedError(BadRequestError):
+    """
+    IbetWST account is not whitelisted for transfer operations
+    """
+
+    code = 15
+
+
 class OperationNotAllowedStateError(BadRequestError):
     """
     Error returned when server-side data is not ready to process the request

--- a/app/model/eth/wst.py
+++ b/app/model/eth/wst.py
@@ -798,7 +798,12 @@ class IbetWST(ERC20):
             contract=self.contract,
             function_name="accountWhiteList",
             args=(to_checksum_address(account),),
-            default_returns=IbetWSTWhiteList(),
+            default_returns=(
+                ZERO_ADDRESS,  # st_account
+                ZERO_ADDRESS,  # sc_account_in
+                ZERO_ADDRESS,  # sc_account_out
+                False,  # listed
+            ),
         )
         return IbetWSTWhiteList(
             st_account=to_checksum_address(whitelist[0]),

--- a/docs/ibet_prime.yaml
+++ b/docs/ibet_prime.yaml
@@ -10188,7 +10188,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IbetWSTInsufficientBalanceErrorResponse'
+                anyOf:
+                  - $ref: '#/components/schemas/IbetWSTAccountNotWhitelistedErrorResponse'
+                  - $ref: '#/components/schemas/IbetWSTInsufficientBalanceErrorResponse'
+                title: Response 400 Transferibetwst
   /ibet_wst/trades/{ibet_wst_address}/request:
     post:
       tags:
@@ -10233,6 +10236,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error422Model'
+        '400':
+          description: Invalid Parameter Error / Send Transaction Error / 
+            Contract Revert Error etc
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IbetWSTAccountNotWhitelistedErrorResponse'
   /ibet_wst/trades/{ibet_wst_address}/cancel:
     post:
       tags:
@@ -15563,6 +15573,40 @@ components:
       type: object
       title: IbetStraightBondUpdate
       description: ibet Straight Bond schema (Update)
+    IbetWSTAccountNotWhitelistedErrorCode:
+      type: integer
+      enum:
+        - 15
+      title: IbetWSTAccountNotWhitelistedErrorCode
+    IbetWSTAccountNotWhitelistedErrorMetainfo:
+      properties:
+        code:
+          $ref: '#/components/schemas/IbetWSTAccountNotWhitelistedErrorCode'
+          examples:
+            - 15
+        title:
+          type: string
+          title: Title
+          examples:
+            - IbetWSTAccountNotWhitelistedError
+      type: object
+      required:
+        - code
+        - title
+      title: IbetWSTAccountNotWhitelistedErrorMetainfo
+    IbetWSTAccountNotWhitelistedErrorResponse:
+      properties:
+        meta:
+          $ref: '#/components/schemas/IbetWSTAccountNotWhitelistedErrorMetainfo'
+        detail:
+          type: string
+          title: Detail
+      type: object
+      required:
+        - meta
+        - detail
+      title: IbetWSTAccountNotWhitelistedErrorResponse
+      description: IbetWST account is not whitelisted for transfer operations
     IbetWSTAuthorization:
       properties:
         nonce:

--- a/tests/app/test_ibet_wst_TransferIbetWST.py
+++ b/tests/app/test_ibet_wst_TransferIbetWST.py
@@ -35,6 +35,7 @@ from app.model.db import (
     TokenVersion,
 )
 from app.model.eth import IbetWST, IbetWSTDigestHelper
+from app.model.eth.wst import IbetWSTWhiteList
 from app.utils.eth_contract_utils import EthWeb3
 from config import ZERO_ADDRESS
 from tests.account_config import default_eth_account
@@ -63,6 +64,10 @@ class TestTransferIbetWST:
     # Test normal transfer of IbetWST token
     @mock.patch(
         "app.routers.misc.ibet_wst.IbetWST.balance_of", AsyncMock(return_value=1000)
+    )
+    @mock.patch(
+        "app.routers.misc.ibet_wst.IbetWST.account_white_list",
+        AsyncMock(return_value=IbetWSTWhiteList(listed=True)),
     )
     @mock.patch(
         "app.routers.misc.ibet_wst.ETH_MASTER_ACCOUNT_ADDRESS",
@@ -154,6 +159,10 @@ class TestTransferIbetWST:
     # Test not setting `valid_after` and `valid_before`
     @mock.patch(
         "app.routers.misc.ibet_wst.IbetWST.balance_of", AsyncMock(return_value=1000)
+    )
+    @mock.patch(
+        "app.routers.misc.ibet_wst.IbetWST.account_white_list",
+        AsyncMock(return_value=IbetWSTWhiteList(listed=True)),
     )
     @mock.patch(
         "app.routers.misc.ibet_wst.ETH_MASTER_ACCOUNT_ADDRESS",
@@ -642,4 +651,150 @@ class TestTransferIbetWST:
         assert resp.status_code == 400
         assert resp.json() == {
             "meta": {"code": 13, "title": "IbetWSTInsufficientBalanceError"}
+        }
+
+    # <Error_5_1>
+    # from_address not whitelisted
+    @mock.patch(
+        "app.routers.misc.ibet_wst.IbetWST.balance_of", AsyncMock(return_value=1000)
+    )
+    @mock.patch(
+        "app.routers.misc.ibet_wst.IbetWST.account_white_list",
+        AsyncMock(
+            side_effect=[IbetWSTWhiteList(listed=False), IbetWSTWhiteList(listed=True)]
+        ),
+    )
+    async def test_error_5_1(self, async_db, async_client):
+        # Prepare data: Token
+        token = Token()
+        token.token_address = self.ibet_token_address
+        token.issuer_address = self.issuer["address"]
+        token.type = TokenType.IBET_STRAIGHT_BOND
+        token.tx_hash = ""
+        token.abi = {}
+        token.version = TokenVersion.V_25_09
+        token.ibet_wst_deployed = True
+        token.ibet_wst_address = self.ibet_wst_address
+        async_db.add(token)
+        await async_db.commit()
+
+        # Generate nonce
+        nonce = secrets.token_bytes(32)
+
+        # Get domain separator
+        token_st = IbetWST(self.ibet_wst_address)
+        domain_separator = await token_st.domain_separator()
+
+        # Generate digest
+        digest = IbetWSTDigestHelper.generate_transfer_digest(
+            domain_separator=domain_separator,
+            from_address=self.user1["address"],
+            to_address=self.user2["address"],
+            value=1000,
+            valid_after=1,
+            valid_before=2**64 - 1,
+            nonce=nonce,
+        )
+
+        # Sign the digest from the authorizer's private key
+        signature = EthWeb3.eth.account.unsafe_sign_hash(
+            digest, bytes.fromhex(self.user1["private_key"])
+        )
+
+        # Send request
+        resp = await async_client.post(
+            self.api_url.format(ibet_wst_address=self.ibet_wst_address),
+            json={
+                "from_address": self.user1["address"],
+                "to_address": self.user2["address"],
+                "value": 1000,
+                "valid_after": 1,
+                "valid_before": 2**64 - 1,
+                "authorizer": self.user1["address"],
+                "authorization": {
+                    "nonce": nonce.hex(),
+                    "v": signature.v,
+                    "r": signature.r.to_bytes(32).hex(),
+                    "s": signature.s.to_bytes(32).hex(),
+                },
+            },
+        )
+
+        # Check response status code and content
+        assert resp.status_code == 400
+        assert resp.json() == {
+            "meta": {"code": 15, "title": "IbetWSTAccountNotWhitelistedError"}
+        }
+
+    # <Error_5_2>
+    # to_address not whitelisted
+    @mock.patch(
+        "app.routers.misc.ibet_wst.IbetWST.balance_of", AsyncMock(return_value=1000)
+    )
+    @mock.patch(
+        "app.routers.misc.ibet_wst.IbetWST.account_white_list",
+        AsyncMock(
+            side_effect=[IbetWSTWhiteList(listed=True), IbetWSTWhiteList(listed=False)]
+        ),
+    )
+    async def test_error_5_2(self, async_db, async_client):
+        # Prepare data: Token
+        token = Token()
+        token.token_address = self.ibet_token_address
+        token.issuer_address = self.issuer["address"]
+        token.type = TokenType.IBET_STRAIGHT_BOND
+        token.tx_hash = ""
+        token.abi = {}
+        token.version = TokenVersion.V_25_09
+        token.ibet_wst_deployed = True
+        token.ibet_wst_address = self.ibet_wst_address
+        async_db.add(token)
+        await async_db.commit()
+
+        # Generate nonce
+        nonce = secrets.token_bytes(32)
+
+        # Get domain separator
+        token_st = IbetWST(self.ibet_wst_address)
+        domain_separator = await token_st.domain_separator()
+
+        # Generate digest
+        digest = IbetWSTDigestHelper.generate_transfer_digest(
+            domain_separator=domain_separator,
+            from_address=self.user1["address"],
+            to_address=self.user2["address"],
+            value=1000,
+            valid_after=1,
+            valid_before=2**64 - 1,
+            nonce=nonce,
+        )
+
+        # Sign the digest from the authorizer's private key
+        signature = EthWeb3.eth.account.unsafe_sign_hash(
+            digest, bytes.fromhex(self.user1["private_key"])
+        )
+
+        # Send request
+        resp = await async_client.post(
+            self.api_url.format(ibet_wst_address=self.ibet_wst_address),
+            json={
+                "from_address": self.user1["address"],
+                "to_address": self.user2["address"],
+                "value": 1000,
+                "valid_after": 1,
+                "valid_before": 2**64 - 1,
+                "authorizer": self.user1["address"],
+                "authorization": {
+                    "nonce": nonce.hex(),
+                    "v": signature.v,
+                    "r": signature.r.to_bytes(32).hex(),
+                    "s": signature.s.to_bytes(32).hex(),
+                },
+            },
+        )
+
+        # Check response status code and content
+        assert resp.status_code == 400
+        assert resp.json() == {
+            "meta": {"code": 15, "title": "IbetWSTAccountNotWhitelistedError"}
         }


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

This pull request introduces a new error type to enforce whitelisting checks for IbetWST account transfers and trades. Now, both transfer and trade operations require that the involved accounts are whitelisted; otherwise, a specific error is returned. 

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- Related to #812

## 🔄 Changes

<!-- List the major changes in this PR. -->

### Whitelisting enforcement for transfers and trades

* Added the `IbetWSTAccountNotWhitelistedError` exception, which is raised when either the sender or receiver account is not whitelisted for IbetWST transfer or trade operations (`app/exceptions.py`).
* Updated the transfer and trade endpoints to check the whitelisting status of both accounts before proceeding, raising the new error if either is not listed (`app/routers/misc/ibet_wst.py`). [[1]](diffhunk://#diff-5f30c7009cfc64532aa4bab8d802cd4bd1f229a48d83bf105b2e22d68d609607L554-R572) [[2]](diffhunk://#diff-5f30c7009cfc64532aa4bab8d802cd4bd1f229a48d83bf105b2e22d68d609607R632-R642)

### Supporting changes

* Fixed the default return value for the whitelist contract call to match expected tuple structure (`app/model/eth/wst.py`).

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
