### PR TITLE
Handle DBAPIError during ledger commit to manage 64-bit integer limit

### DIFF
--- a/app/routers/issuer/ledger.py
+++ b/app/routers/issuer/ledger.py
@@ -396,7 +396,9 @@ async def retrieve_ledger_template(
     "/{token_address}/template",
     operation_id="CreateUpdateLedgerTemplate",
     response_model=None,
-    responses=get_routers_responses(422, 404, InvalidParameterError),
+    responses=get_routers_responses(
+        422, 404, InvalidParameterError, Integer64bitLimitExceededError
+    ),
 )
 async def create_update_ledger_template(
     db: DBAsyncSession,

--- a/docs/ibet_prime.yaml
+++ b/docs/ibet_prime.yaml
@@ -4470,7 +4470,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/InvalidParameterErrorResponse'
+                anyOf:
+                  - $ref: '#/components/schemas/Integer64bitLimitExceededErrorResponse'
+                  - $ref: '#/components/schemas/InvalidParameterErrorResponse'
+                title: Response 400 Createupdateledgertemplate
     delete:
       tags:
         - token_common


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

This pull request introduces improved error handling to the ledger template creation process in the `app/routers/issuer/ledger.py` file.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
None

## 🔄 Changes

<!-- List the major changes in this PR. -->


Error handling improvements:

* Imported `DBAPIError` to enable catching database exceptions during commit operations.
* Wrapped the `db.commit()` call in a try-except block to catch `DBAPIError`, raising `Integer64bitLimitExceededError` when the 64-bit integer limit is exceeded.

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
