### PR TITLE
Add endpoints to retrieve IbetWST whitelist accounts with personal information

### DIFF
--- a/app/model/schema/__init__.py
+++ b/app/model/schema/__init__.py
@@ -108,6 +108,7 @@ from .ibet_wst import (
     GetIbetWSTTradeResponse,
     GetIbetWSTTransactionResponse,
     GetIbetWSTWhitelistResponse,
+    GetIbetWSTWhitelistWithPersonalInfoResponse,
     IbetWSTToken,
     IbetWSTTransactionResponse,
     ListAllIbetWSTTokensQuery,
@@ -120,6 +121,7 @@ from .ibet_wst import (
     RejectIbetWSTTradeRequest,
     RequestIbetWSTTradeRequest,
     RetrieveIbetWSTWhitelistAccountsResponse,
+    RetrieveIbetWSTWhitelistAccountsWithPersonalInfoResponse,
     TransferIbetWSTRequest,
 )
 from .index import BlockNumberResponse, E2EEResponse

--- a/app/model/schema/ibet_wst.py
+++ b/app/model/schema/ibet_wst.py
@@ -31,6 +31,7 @@ from app.model.schema.base import (
     SortOrder,
     TokenType,
 )
+from app.model.schema.personal_info import PersonalInfo
 
 
 ############################
@@ -456,6 +457,23 @@ class IbetWSTWhitelistAccount(BaseModel):
     )
 
 
+class IbetWSTWhitelistAccountWithPersonalInfo(BaseModel):
+    """IbetWST Whitelist Account schema"""
+
+    st_account_address: ChecksumEthereumAddress = Field(
+        description="ST account address of the whitelisted account"
+    )
+    st_account_personal_info: PersonalInfo | None = Field(
+        description="Personal information of the ST account"
+    )
+    sc_account_address_in: ChecksumEthereumAddress = Field(
+        description="SC account address for deposits"
+    )
+    sc_account_address_out: ChecksumEthereumAddress = Field(
+        description="SC account address for withdrawals"
+    )
+
+
 class RetrieveIbetWSTWhitelistAccountsResponse(BaseModel):
     """RetrieveIbetWSTWhitelistAccounts response schema"""
 
@@ -464,11 +482,37 @@ class RetrieveIbetWSTWhitelistAccountsResponse(BaseModel):
     )
 
 
+class RetrieveIbetWSTWhitelistAccountsWithPersonalInfoResponse(BaseModel):
+    """RetrieveIbetWSTWhitelistAccountsWithPersonalInfo response schema"""
+
+    whitelist_accounts: list[IbetWSTWhitelistAccountWithPersonalInfo] = Field(
+        description="List of whitelisted accounts with personal information"
+    )
+
+
 class GetIbetWSTWhitelistResponse(BaseModel):
     """GetIbetWSTWhitelist response schema"""
 
     st_account_address: str = Field(
         description="ST account address of the whitelisted account"
+    )
+    sc_account_address_in: str = Field(description="SC account address for deposits")
+    sc_account_address_out: str = Field(
+        description="SC account address for withdrawals"
+    )
+    listed: bool = Field(
+        description="True if the account is listed in the whitelist, False otherwise"
+    )
+
+
+class GetIbetWSTWhitelistWithPersonalInfoResponse(BaseModel):
+    """GetIbetWSTWhitelistWithPersonalInfo response schema"""
+
+    st_account_address: str = Field(
+        description="ST account address of the whitelisted account"
+    )
+    st_account_personal_info: PersonalInfo | None = Field(
+        description="Personal information of the ST account"
     )
     sc_account_address_in: str = Field(description="SC account address for deposits")
     sc_account_address_out: str = Field(

--- a/app/routers/misc/ibet_wst.py
+++ b/app/routers/misc/ibet_wst.py
@@ -459,9 +459,12 @@ async def retrieve_ibet_wst_whitelist_accounts(
     # Get whitelists
     whitelist_list: Sequence[IDXEthIbetWSTWhitelist] = (
         await db.scalars(
-            select(IDXEthIbetWSTWhitelist).where(
-                IDXEthIbetWSTWhitelist.ibet_wst_address == ibet_wst_address
+            select(IDXEthIbetWSTWhitelist)
+            .where(
+                IDXEthIbetWSTWhitelist.ibet_wst_address
+                == to_checksum_address(ibet_wst_address)
             )
+            .order_by(IDXEthIbetWSTWhitelist.created.desc())
         )
     ).all()
 
@@ -501,7 +504,9 @@ async def get_ibet_wst_whitelist(
     # Check if ibet-WST exists
     _token = (
         await db.scalars(
-            select(Token).where(Token.ibet_wst_address == ibet_wst_address).limit(1)
+            select(Token)
+            .where(Token.ibet_wst_address == to_checksum_address(ibet_wst_address))
+            .limit(1)
         )
     ).first()
     if _token is None:

--- a/docs/ibet_prime.yaml
+++ b/docs/ibet_prime.yaml
@@ -8547,6 +8547,94 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ListAllScheduledEventsResponse'
+  /tokens/{token_address}/ibet_wst/whitelists:
+    get:
+      tags:
+        - token_common
+      summary: Retrieve Ibet Wst Whitelist Accounts With Personal Info
+      description: |-
+        Retrieve the whitelist accounts of an IbetWST contract with personal information
+
+        - This endpoint retrieves the whitelist accounts of an IbetWST contract along with their personal information.
+      operationId: RetrieveIbetWSTWhitelistAccountsWithPersonalInfo
+      parameters:
+        - name: token_address
+          in: path
+          required: true
+          schema:
+            type: string
+            description: Token address
+            title: Token Address
+          description: Token address
+        - name: issuer-address
+          in: header
+          required: true
+          schema:
+            type: string
+            description: Issuer address
+            title: Issuer-Address
+          description: Issuer address
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RetrieveIbetWSTWhitelistAccountsWithPersonalInfoResponse'
+        '404':
+          description: Not Found Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404Model'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error422Model'
+  /tokens/{token_address}/ibet_wst/whitelists/{account_address}:
+    get:
+      tags:
+        - token_common
+      summary: Get Ibet Wst Whitelist With Personal Info
+      description: |-
+        Get IbetWST whitelist status for a specific account with personal information
+
+        - This endpoint retrieves the whitelist status of an account address for the specified IbetWST contract.
+      operationId: GetIbetWSTWhitelistWithPersonalInfo
+      parameters:
+        - name: token_address
+          in: path
+          required: true
+          schema:
+            type: string
+            description: Token address
+            title: Token Address
+          description: Token address
+        - name: account_address
+          in: path
+          required: true
+          schema:
+            type: string
+            description: Account address
+            title: Account Address
+          description: Account address
+        - name: issuer-address
+          in: header
+          required: true
+          schema:
+            type: string
+            description: Issuer address
+            title: Issuer-Address
+          description: Issuer address
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetIbetWSTWhitelistWithPersonalInfoResponse'
   /tokens/{token_address}/ibet_wst/whitelists/add:
     post:
       tags:
@@ -13953,6 +14041,39 @@ components:
         - listed
       title: GetIbetWSTWhitelistResponse
       description: GetIbetWSTWhitelist response schema
+    GetIbetWSTWhitelistWithPersonalInfoResponse:
+      properties:
+        st_account_address:
+          type: string
+          title: St Account Address
+          description: ST account address of the whitelisted account
+        st_account_personal_info:
+          anyOf:
+            - $ref: '#/components/schemas/PersonalInfo'
+            - type: 'null'
+          description: Personal information of the ST account
+        sc_account_address_in:
+          type: string
+          title: Sc Account Address In
+          description: SC account address for deposits
+        sc_account_address_out:
+          type: string
+          title: Sc Account Address Out
+          description: SC account address for withdrawals
+        listed:
+          type: boolean
+          title: Listed
+          description: True if the account is listed in the whitelist, False 
+            otherwise
+      type: object
+      required:
+        - st_account_address
+        - st_account_personal_info
+        - sc_account_address_in
+        - sc_account_address_out
+        - listed
+      title: GetIbetWSTWhitelistWithPersonalInfoResponse
+      description: GetIbetWSTWhitelistWithPersonalInfo response schema
     HTTPValidationError:
       properties:
         detail:
@@ -15930,6 +16051,33 @@ components:
         - sc_account_address_in
         - sc_account_address_out
       title: IbetWSTWhitelistAccount
+      description: IbetWST Whitelist Account schema
+    IbetWSTWhitelistAccountWithPersonalInfo:
+      properties:
+        st_account_address:
+          type: string
+          title: St Account Address
+          description: ST account address of the whitelisted account
+        st_account_personal_info:
+          anyOf:
+            - $ref: '#/components/schemas/PersonalInfo'
+            - type: 'null'
+          description: Personal information of the ST account
+        sc_account_address_in:
+          type: string
+          title: Sc Account Address In
+          description: SC account address for deposits
+        sc_account_address_out:
+          type: string
+          title: Sc Account Address Out
+          description: SC account address for withdrawals
+      type: object
+      required:
+        - st_account_address
+        - st_account_personal_info
+        - sc_account_address_in
+        - sc_account_address_out
+      title: IbetWSTWhitelistAccountWithPersonalInfo
       description: IbetWST Whitelist Account schema
     Integer64bitLimitExceededErrorCode:
       type: integer
@@ -17975,6 +18123,20 @@ components:
         - whitelist_accounts
       title: RetrieveIbetWSTWhitelistAccountsResponse
       description: RetrieveIbetWSTWhitelistAccounts response schema
+    RetrieveIbetWSTWhitelistAccountsWithPersonalInfoResponse:
+      properties:
+        whitelist_accounts:
+          items:
+            $ref: '#/components/schemas/IbetWSTWhitelistAccountWithPersonalInfo'
+          type: array
+          title: Whitelist Accounts
+          description: List of whitelisted accounts with personal information
+      type: object
+      required:
+        - whitelist_accounts
+      title: RetrieveIbetWSTWhitelistAccountsWithPersonalInfoResponse
+      description: RetrieveIbetWSTWhitelistAccountsWithPersonalInfo response 
+        schema
     RetrieveLedgerDetailsDataHistoryResponse:
       properties:
         account_address:

--- a/tests/app/test_ibet_wst_GetIbetWSTWhiteList.py
+++ b/tests/app/test_ibet_wst_GetIbetWSTWhiteList.py
@@ -32,15 +32,9 @@ class TestGetIbetWSTWhiteList:
     # API endpoint
     api_url = "/ibet_wst/whitelists/{ibet_wst_address}/{account_address}"
 
-    st_account_address = to_checksum_address(
-        "0x1234567890abcdef1234567890abcdef12345678"
-    )
-    sc_account_address_in = to_checksum_address(
-        "0x234567890abcdef1234567890abcdef123456789"
-    )
-    sc_account_address_out = to_checksum_address(
-        "0x34567890abcdef1234567890abcdef1234567890"
-    )
+    st_account_address = "0x1234567890abcdef1234567890abcdef12345678"
+    sc_account_address_in = "0x234567890abcdef1234567890abcdef123456789"
+    sc_account_address_out = "0x34567890abcdef1234567890abcdef1234567890"
 
     ###########################################################################
     # Normal
@@ -52,9 +46,9 @@ class TestGetIbetWSTWhiteList:
         "app.routers.misc.ibet_wst.IbetWST.account_white_list",
         AsyncMock(
             return_value=IbetWSTWhiteList(
-                st_account=st_account_address,
-                sc_account_in=sc_account_address_in,
-                sc_account_out=sc_account_address_out,
+                st_account=to_checksum_address(st_account_address),
+                sc_account_in=to_checksum_address(sc_account_address_in),
+                sc_account_out=to_checksum_address(sc_account_address_out),
                 listed=True,
             )
         ),
@@ -67,14 +61,14 @@ class TestGetIbetWSTWhiteList:
 
         # Prepare data: Token
         token = Token()
-        token.token_address = ibet_token_address
-        token.issuer_address = issuer_address
+        token.token_address = to_checksum_address(ibet_token_address)
+        token.issuer_address = to_checksum_address(issuer_address)
         token.type = TokenType.IBET_STRAIGHT_BOND
         token.tx_hash = ""
         token.abi = {}
         token.version = TokenVersion.V_25_09
         token.ibet_wst_deployed = True
-        token.ibet_wst_address = ibet_wst_address
+        token.ibet_wst_address = to_checksum_address(ibet_wst_address)
         async_db.add(token)
         await async_db.commit()
 
@@ -89,9 +83,9 @@ class TestGetIbetWSTWhiteList:
         # Check response status code
         assert resp.status_code == 200
         assert resp.json() == {
-            "st_account_address": self.st_account_address,
-            "sc_account_address_in": self.sc_account_address_in,
-            "sc_account_address_out": self.sc_account_address_out,
+            "st_account_address": to_checksum_address(self.st_account_address),
+            "sc_account_address_in": to_checksum_address(self.sc_account_address_in),
+            "sc_account_address_out": to_checksum_address(self.sc_account_address_out),
             "listed": True,
         }
 

--- a/tests/app/test_ibet_wst_RetrieveIbetWSTWhitelistAccounts.py
+++ b/tests/app/test_ibet_wst_RetrieveIbetWSTWhitelistAccounts.py
@@ -18,6 +18,7 @@ SPDX-License-Identifier: Apache-2.0
 """
 
 import pytest
+from eth_utils import to_checksum_address
 
 from app.model.db import IDXEthIbetWSTWhitelist
 from tests.account_config import default_eth_account
@@ -31,8 +32,8 @@ class TestRetrieveIbetWSTWhitelistAccounts:
     user1 = default_eth_account("user1")
     user2 = default_eth_account("user2")
 
-    wst_token_address_1 = "0x1234567890AbcdEF1234567890aBcdef12345678"
-    wst_token_address_2 = "0x234567890abCDEf1234567890aBCdEf123456789"
+    wst_token_address_1 = "0x1234567890abcdef1234567890abcdef12345678"
+    wst_token_address_2 = "0x234567890abcdef1234567890abcdef123456789"
 
     ###########################################################################
     # Normal
@@ -43,7 +44,9 @@ class TestRetrieveIbetWSTWhitelistAccounts:
     async def test_normal_1(self, async_db, async_client):
         # Prepare test data
         whitelist = IDXEthIbetWSTWhitelist(
-            ibet_wst_address=self.wst_token_address_2,  # WST token address not to be queried
+            ibet_wst_address=to_checksum_address(
+                self.wst_token_address_2
+            ),  # WST token address not to be queried
             st_account_address=self.user1["address"],
             sc_account_address_in=self.user1["address"],
             sc_account_address_out=self.user1["address"],
@@ -67,13 +70,13 @@ class TestRetrieveIbetWSTWhitelistAccounts:
     async def test_normal_2(self, async_db, async_client):
         # Prepare test data
         whitelist_1 = IDXEthIbetWSTWhitelist(
-            ibet_wst_address=self.wst_token_address_1,
+            ibet_wst_address=to_checksum_address(self.wst_token_address_1),
             st_account_address=self.user1["address"],
             sc_account_address_in=self.user1["address"],
             sc_account_address_out=self.user1["address"],
         )
         whitelist_2 = IDXEthIbetWSTWhitelist(
-            ibet_wst_address=self.wst_token_address_1,
+            ibet_wst_address=to_checksum_address(self.wst_token_address_1),
             st_account_address=self.user2["address"],
             sc_account_address_in=self.user2["address"],
             sc_account_address_out=self.user2["address"],

--- a/tests/app/test_token_common_GetIbetWSTWhitelistWithPersonalInfo.py
+++ b/tests/app/test_token_common_GetIbetWSTWhitelistWithPersonalInfo.py
@@ -1,0 +1,264 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+from unittest import mock
+from unittest.mock import AsyncMock
+
+import pytest
+from eth_utils import to_checksum_address
+
+from app.model.db import (
+    IDXPersonalInfo,
+    PersonalInfoDataSource,
+    Token,
+    TokenStatus,
+    TokenType,
+    TokenVersion,
+)
+from app.model.eth.wst import IbetWSTWhiteList
+
+
+@pytest.mark.asyncio
+class TestGetIbetWSTWhiteList:
+    # API endpoint
+    api_url = "/tokens/{token_address}/ibet_wst/whitelists/{account_address}"
+
+    issuer_address = "0x1234567890abcdef1234567890abcdef12345678"
+    ibet_token_address = "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+    ibet_wst_address = "0xbcdefabcdefabcdefabcdefabcdefabcdefabcde"
+
+    st_account_address = "0x1234567890abcdef1234567890abcdef12345678"
+    sc_account_address_in = "0x234567890abcdef1234567890abcdef123456789"
+    sc_account_address_out = "0x34567890abcdef1234567890abcdef1234567890"
+
+    ###########################################################################
+    # Normal
+    ###########################################################################
+
+    # <Normal_1_1>
+    # Return whitelist status of account
+    # - Personal information is not registered
+    @mock.patch(
+        "app.routers.misc.ibet_wst.IbetWST.account_white_list",
+        AsyncMock(
+            return_value=IbetWSTWhiteList(
+                st_account=to_checksum_address(st_account_address),
+                sc_account_in=to_checksum_address(sc_account_address_in),
+                sc_account_out=to_checksum_address(sc_account_address_out),
+                listed=True,
+            )
+        ),
+    )
+    async def test_normal_1(self, async_client, async_db):
+        # Prepare data
+        token = Token(
+            type=TokenType.IBET_STRAIGHT_BOND,
+            tx_hash="0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+            issuer_address=to_checksum_address(self.issuer_address),
+            token_address=to_checksum_address(self.ibet_token_address),
+            version=TokenVersion.V_25_09,
+            abi={},
+            token_status=TokenStatus.SUCCEEDED,
+            ibet_wst_activated=True,
+            ibet_wst_deployed=True,
+            ibet_wst_address=to_checksum_address(self.ibet_wst_address),
+        )
+        async_db.add(token)
+        await async_db.commit()
+
+        # Send request
+        resp = await async_client.get(
+            self.api_url.format(
+                token_address=self.ibet_token_address,
+                account_address=self.st_account_address,
+            ),
+            headers={"issuer-address": self.issuer_address},
+        )
+
+        # Check response status code
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "st_account_address": to_checksum_address(self.st_account_address),
+            "st_account_personal_info": None,
+            "sc_account_address_in": to_checksum_address(self.sc_account_address_in),
+            "sc_account_address_out": to_checksum_address(self.sc_account_address_out),
+            "listed": True,
+        }
+
+    # <Normal_1_2>
+    # Return whitelist status of account
+    # - Personal information is registered
+    @mock.patch(
+        "app.routers.misc.ibet_wst.IbetWST.account_white_list",
+        AsyncMock(
+            return_value=IbetWSTWhiteList(
+                st_account=to_checksum_address(st_account_address),
+                sc_account_in=to_checksum_address(sc_account_address_in),
+                sc_account_out=to_checksum_address(sc_account_address_out),
+                listed=True,
+            )
+        ),
+    )
+    async def test_normal_2(self, async_client, async_db):
+        # Prepare data
+        token = Token(
+            type=TokenType.IBET_STRAIGHT_BOND,
+            tx_hash="0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+            issuer_address=to_checksum_address(self.issuer_address),
+            token_address=to_checksum_address(self.ibet_token_address),
+            version=TokenVersion.V_25_09,
+            abi={},
+            token_status=TokenStatus.SUCCEEDED,
+            ibet_wst_activated=True,
+            ibet_wst_deployed=True,
+            ibet_wst_address=to_checksum_address(self.ibet_wst_address),
+        )
+        async_db.add(token)
+
+        account_personal_info = IDXPersonalInfo(
+            account_address=to_checksum_address(self.st_account_address),
+            issuer_address=to_checksum_address(self.issuer_address),
+            _personal_info={
+                "key_manager": "test_key_manager",
+                "name": "User One",
+                "postal_code": "1234567",
+                "address": "123 User Street",
+                "email": "test@example.com",
+                "birth": "19900101",
+                "is_corporate": False,
+                "tax_category": 0,
+            },
+            data_source=PersonalInfoDataSource.OFF_CHAIN,
+        )
+        async_db.add(account_personal_info)
+        await async_db.commit()
+
+        # Send request
+        resp = await async_client.get(
+            self.api_url.format(
+                token_address=self.ibet_token_address,
+                account_address=self.st_account_address,
+            ),
+            headers={"issuer-address": self.issuer_address},
+        )
+
+        # Check response status code
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "st_account_address": to_checksum_address(self.st_account_address),
+            "st_account_personal_info": {
+                "key_manager": "test_key_manager",
+                "name": "User One",
+                "postal_code": "1234567",
+                "address": "123 User Street",
+                "email": "test@example.com",
+                "birth": "19900101",
+                "is_corporate": False,
+                "tax_category": 0,
+            },  # Personal information
+            "sc_account_address_in": to_checksum_address(self.sc_account_address_in),
+            "sc_account_address_out": to_checksum_address(self.sc_account_address_out),
+            "listed": True,
+        }
+
+    ###########################################################################
+    # Error
+    ###########################################################################
+
+    # <Error_1>
+    # Missing issuer address in request header
+    # - Expected to return 422
+    async def test_error_1(self, async_client):
+        # Send request without issuer address in header
+        resp = await async_client.get(
+            self.api_url.format(
+                token_address=self.ibet_token_address,
+                account_address=self.st_account_address,
+            ),
+        )
+
+        # Check response status code
+        assert resp.status_code == 422
+        assert resp.json() == {
+            "meta": {"code": 1, "title": "RequestValidationError"},
+            "detail": [
+                {
+                    "type": "missing",
+                    "loc": ["header", "issuer-address"],
+                    "msg": "Field required",
+                    "input": None,
+                }
+            ],
+        }
+
+    # <Error_2>
+    # Invalid addresses
+    # - Expected to return 422
+    async def test_error_2(self, async_client):
+        # Send request with invalid addresses
+        resp = await async_client.get(
+            self.api_url.format(
+                token_address="invalid_address",
+                account_address="invalid_address",
+            ),
+            headers={"issuer-address": self.issuer_address},
+        )
+
+        # Check response status code
+        assert resp.status_code == 422
+        assert resp.json() == {
+            "meta": {"code": 1, "title": "RequestValidationError"},
+            "detail": [
+                {
+                    "type": "value_error",
+                    "loc": ["path", "token_address"],
+                    "msg": "Value error, invalid ethereum address",
+                    "input": "invalid_address",
+                    "ctx": {"error": {}},
+                },
+                {
+                    "type": "value_error",
+                    "loc": ["path", "account_address"],
+                    "msg": "Value error, invalid ethereum address",
+                    "input": "invalid_address",
+                    "ctx": {"error": {}},
+                },
+            ],
+        }
+
+    # <Error_3>
+    # Token not found
+    # - Expected to return 404
+    async def test_error_3(self, async_client, async_db):
+        # Prepare data
+        # Send request
+        resp = await async_client.get(
+            self.api_url.format(
+                token_address=self.ibet_token_address,
+                account_address=self.st_account_address,
+            ),
+            headers={"issuer-address": self.issuer_address},
+        )
+
+        # Check response status code
+        assert resp.status_code == 404
+        assert resp.json() == {
+            "meta": {"code": 1, "title": "NotFound"},
+            "detail": "Token not found",
+        }

--- a/tests/app/test_token_common_RetrieveIbetWSTWhitelistAccountsWithPersonalInfo.py
+++ b/tests/app/test_token_common_RetrieveIbetWSTWhitelistAccountsWithPersonalInfo.py
@@ -1,0 +1,248 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import pytest
+from eth_utils import to_checksum_address
+
+from app.model.db import (
+    IDXEthIbetWSTWhitelist,
+    IDXPersonalInfo,
+    PersonalInfoDataSource,
+    Token,
+    TokenStatus,
+    TokenType,
+    TokenVersion,
+)
+from tests.account_config import default_eth_account
+
+
+@pytest.mark.asyncio
+class TestRetrieveIbetWSTWhitelistAccountsWithPersonalInfo:
+    # API endpoint
+    api_url = "/tokens/{token_address}/ibet_wst/whitelists"
+
+    issuer = default_eth_account("user1")
+    user1 = default_eth_account("user2")
+    user2 = default_eth_account("user3")
+
+    token_address_1 = "0x1234567890abcdef1234567890abcdef12345678"
+    wst_token_address_1 = "0xabcdef1234567890abcdef1234567890abcdef12"
+
+    token_address_2 = "0x234567890abcdef1234567890abcdef123456789"
+    wst_token_address_2 = "0xbcdef1234567890abcdef1234567890abcdef123"
+
+    ###########################################################################
+    # Normal
+    ###########################################################################
+
+    # <Normal_1>
+    # Whitelist account is not registered for the specified WST token address.
+    async def test_normal_1(self, async_db, async_client):
+        # Prepare test data
+        token = Token(
+            type=TokenType.IBET_STRAIGHT_BOND,
+            tx_hash="0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+            issuer_address=self.issuer["address"],
+            token_address=to_checksum_address(self.token_address_1),
+            version=TokenVersion.V_25_09,
+            abi={},
+            token_status=TokenStatus.SUCCEEDED,
+            ibet_wst_activated=True,
+            ibet_wst_deployed=True,
+            ibet_wst_address=to_checksum_address(self.wst_token_address_1),
+        )
+        async_db.add(token)
+
+        whitelist = IDXEthIbetWSTWhitelist(
+            ibet_wst_address=to_checksum_address(
+                self.wst_token_address_2
+            ),  # WST token address not to be queried
+            st_account_address=self.user1["address"],
+            sc_account_address_in=self.user1["address"],
+            sc_account_address_out=self.user1["address"],
+        )
+        async_db.add(whitelist)
+        await async_db.commit()
+
+        # Send request
+        resp = await async_client.get(
+            self.api_url.format(token_address=self.token_address_1),
+            headers={"issuer-address": self.issuer["address"]},
+        )
+
+        # Check response
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "whitelist_accounts": [],
+        }
+
+    # <Normal_2>
+    # Whitelist accounts are registered for the specified WST token address.
+    async def test_normal_2(self, async_db, async_client):
+        # Prepare test data
+        token = Token(
+            type=TokenType.IBET_STRAIGHT_BOND,
+            tx_hash="0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+            issuer_address=self.issuer["address"],
+            token_address=to_checksum_address(self.token_address_1),
+            version=TokenVersion.V_25_09,
+            abi={},
+            token_status=TokenStatus.SUCCEEDED,
+            ibet_wst_activated=True,
+            ibet_wst_deployed=True,
+            ibet_wst_address=to_checksum_address(self.wst_token_address_1),
+        )
+        async_db.add(token)
+
+        whitelist_1 = IDXEthIbetWSTWhitelist(
+            ibet_wst_address=to_checksum_address(self.wst_token_address_1),
+            st_account_address=self.user1["address"],
+            sc_account_address_in=self.user1["address"],
+            sc_account_address_out=self.user1["address"],
+        )
+        whitelist_2 = IDXEthIbetWSTWhitelist(
+            ibet_wst_address=to_checksum_address(self.wst_token_address_1),
+            st_account_address=self.user2["address"],
+            sc_account_address_in=self.user2["address"],
+            sc_account_address_out=self.user2["address"],
+        )
+        async_db.add(whitelist_1)
+        async_db.add(whitelist_2)
+
+        user1_personal_info = IDXPersonalInfo(
+            account_address=self.user1["address"],
+            issuer_address=self.issuer["address"],
+            _personal_info={
+                "key_manager": "test_key_manager",
+                "name": "User One",
+                "postal_code": "1234567",
+                "address": "123 User Street",
+                "email": "test@example.com",
+                "birth": "19900101",
+                "is_corporate": False,
+                "tax_category": 0,
+            },
+            data_source=PersonalInfoDataSource.OFF_CHAIN,
+        )
+        async_db.add(user1_personal_info)
+
+        await async_db.commit()
+
+        # Send request
+        resp = await async_client.get(
+            self.api_url.format(token_address=self.token_address_1),
+            headers={"issuer-address": self.issuer["address"]},
+        )
+
+        # Check response
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "whitelist_accounts": [
+                {
+                    "st_account_address": self.user2["address"],
+                    "st_account_personal_info": None,
+                    "sc_account_address_in": self.user2["address"],
+                    "sc_account_address_out": self.user2["address"],
+                },
+                {
+                    "st_account_address": self.user1["address"],
+                    "st_account_personal_info": {
+                        "key_manager": "test_key_manager",
+                        "name": "User One",
+                        "postal_code": "1234567",
+                        "address": "123 User Street",
+                        "email": "test@example.com",
+                        "birth": "19900101",
+                        "is_corporate": False,
+                        "tax_category": 0,
+                    },
+                    "sc_account_address_in": self.user1["address"],
+                    "sc_account_address_out": self.user1["address"],
+                },
+            ],
+        }
+
+    ###########################################################################
+    # Error
+    ###########################################################################
+
+    # <Error_1>
+    # Request without issuer address
+    # - Expected to return 422
+    async def test_error_1(self, async_client):
+        # Send request without issuer address in header
+        resp = await async_client.get(
+            self.api_url.format(token_address=self.token_address_1),
+        )
+
+        # Check response
+        assert resp.status_code == 422
+        assert resp.json() == {
+            "meta": {"code": 1, "title": "RequestValidationError"},
+            "detail": [
+                {
+                    "type": "missing",
+                    "loc": ["header", "issuer-address"],
+                    "msg": "Field required",
+                    "input": None,
+                }
+            ],
+        }
+
+    # <Error_2>
+    # Invalid token address format
+    # - Expected to return 422
+    async def test_error_2(self, async_client):
+        # Send request with invalid token address format
+        resp = await async_client.get(
+            self.api_url.format(token_address="invalid_address"),
+            headers={"issuer-address": self.issuer["address"]},
+        )
+
+        # Check response
+        assert resp.status_code == 422
+        assert resp.json() == {
+            "meta": {"code": 1, "title": "RequestValidationError"},
+            "detail": [
+                {
+                    "type": "value_error",
+                    "loc": ["path", "token_address"],
+                    "msg": "Value error, invalid ethereum address",
+                    "input": "invalid_address",
+                    "ctx": {"error": {}},
+                }
+            ],
+        }
+
+    # <Error_3>
+    # Token not found for the specified address
+    # - Expected to return 404
+    async def test_error_3(self, async_client):
+        # Send request with a token address that does not exist
+        resp = await async_client.get(
+            self.api_url.format(token_address=self.token_address_1),
+            headers={"issuer-address": self.issuer["address"]},
+        )
+
+        # Check response
+        assert resp.status_code == 404
+        assert resp.json() == {
+            "meta": {"code": 1, "title": "NotFound"},
+            "detail": "Token not found",
+        }


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

This pull request introduces new API endpoints to support retrieving IbetWST whitelist accounts along with associated personal information.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- Close #874

## 🔄 Changes

<!-- List the major changes in this PR. -->

**API & Schema Enhancements**

* Added two new response models: `RetrieveIbetWSTWhitelistAccountsWithPersonalInfoResponse` and `GetIbetWSTWhitelistWithPersonalInfoResponse`, along with supporting schema classes (`IbetWSTWhitelistAccountWithPersonalInfo`) to represent whitelist accounts with personal information.

**Backend Implementation**

* Implemented two new API endpoints in `app/routers/issuer/token_common.py`:
  - `retrieve_ibet_wst_whitelist_accounts_with_personal_info`: returns all whitelist accounts for a token with personal info.
  - `get_ibet_wst_whitelist_with_personal_info`: returns whitelist status and personal info for a specific account.

**Miscellaneous Improvements**

* Minor fixes to address formatting and query consistency in whitelist retrieval logic, including using `to_checksum_address` for address normalization.
* Adjusted test data and mocks in `tests/app/test_ibet_wst_GetIbetWSTWhiteList.py` to align with new address handling and response formats. 

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
