### PR TITLE
Add force burn functionality for IbetWST tokens with new endpoint and transaction parameters

### DIFF
--- a/app/model/db/__init__.py
+++ b/app/model/db/__init__.py
@@ -72,6 +72,7 @@ from .ibet_wst import (
     IbetWSTTxParamsCancelTrade,
     IbetWSTTxParamsDeleteAccountWhiteList,
     IbetWSTTxParamsDeploy,
+    IbetWSTTxParamsForceBurn,
     IbetWSTTxParamsMint,
     IbetWSTTxParamsRejectTrade,
     IbetWSTTxParamsRequestTrade,

--- a/app/model/db/ibet_wst.py
+++ b/app/model/db/ibet_wst.py
@@ -39,6 +39,7 @@ class IbetWSTTxType(StrEnum):
     DEPLOY = "deploy"
     MINT = "mint"
     BURN = "burn"
+    FORCE_BURN = "force_burn"
     ADD_WHITELIST = "add_whitelist"
     DELETE_WHITELIST = "delete_whitelist"
     TRANSFER = "transfer"
@@ -107,6 +108,13 @@ class IbetWSTTxParamsBurn(TypedDict):
 
     from_address: str  # Address from which the tokens will be burned
     value: int  # Amount of IbetWST to be burned
+
+
+class IbetWSTTxParamsForceBurn(TypedDict):
+    """Parameters for IbetWST forceBurnWithAuthorization Transaction"""
+
+    account: str  # Address from which the tokens will be forcefully burned
+    value: int  # Amount of IbetWST to be forcefully burned
 
 
 class IbetWSTTxParamsRequestTrade(TypedDict):
@@ -258,6 +266,7 @@ class EthIbetWSTTx(Base):
         | IbetWSTTxParamsTransfer
         | IbetWSTTxParamsMint
         | IbetWSTTxParamsBurn
+        | IbetWSTTxParamsForceBurn
         | IbetWSTTxParamsRequestTrade
         | IbetWSTTxParamsCancelTrade
         | IbetWSTTxParamsAcceptTrade

--- a/app/model/schema/__init__.py
+++ b/app/model/schema/__init__.py
@@ -100,6 +100,7 @@ from .ibet_wst import (
     BurnIbetWSTRequest,
     CancelIbetWSTTradeRequest,
     DeleteIbetWSTWhitelistRequest,
+    ForceBurnIbetWSTRequest,
     GetERC20AllowanceQuery,
     GetERC20AllowanceResponse,
     GetERC20BalanceQuery,

--- a/app/model/schema/ibet_wst.py
+++ b/app/model/schema/ibet_wst.py
@@ -69,6 +69,7 @@ IbetWSTTxType = Literal[
     "deploy",
     "mint",
     "burn",
+    "force_burn",
     "add_whitelist",
     "delete_whitelist",
     "transfer",
@@ -192,6 +193,15 @@ class BurnIbetWSTRequest(BaseModel):
     authorization: IbetWSTAuthorization = Field(
         description="Authorization for the transaction"
     )
+
+
+class ForceBurnIbetWSTRequest(BaseModel):
+    """ForceBurnIbetWST request schema"""
+
+    account_address: ChecksumEthereumAddress = Field(
+        description="Account address from which to force burn IbetWST"
+    )
+    value: PositiveInt = Field(description="Amount of IbetWST to force burn")
 
 
 class TransferIbetWSTRequest(BaseModel):

--- a/batch/processor_eth_wst_monitor_txreceipt.py
+++ b/batch/processor_eth_wst_monitor_txreceipt.py
@@ -198,6 +198,19 @@ async def finalize_tx(
                     value=event["args"]["value"],
                 )
                 await db_session.merge(wst_tx)
+        case IbetWSTTxType.FORCE_BURN:
+            # Update the IbetWST transaction with the event log
+            ibet_wst = IbetWST(wst_tx.ibet_wst_address)
+            events = ibet_wst.contract.events.Burn().process_receipt(
+                txn_receipt=tx_receipt, errors=DISCARD
+            )
+            event = events[0] if len(events) > 0 else None
+            if event is not None:
+                wst_tx.event_log = IbetWSTEventLogBurn(
+                    from_address=event["args"]["from"],
+                    value=event["args"]["value"],
+                )
+                await db_session.merge(wst_tx)
         case IbetWSTTxType.ADD_WHITELIST:
             # Update the IbetWST transaction with the event log
             ibet_wst = IbetWST(wst_tx.ibet_wst_address)

--- a/batch/processor_eth_wst_send_tx.py
+++ b/batch/processor_eth_wst_send_tx.py
@@ -38,6 +38,7 @@ from app.model.db import (
     IbetWSTTxParamsCancelTrade,
     IbetWSTTxParamsDeleteAccountWhiteList,
     IbetWSTTxParamsDeploy,
+    IbetWSTTxParamsForceBurn,
     IbetWSTTxParamsMint,
     IbetWSTTxParamsRejectTrade,
     IbetWSTTxParamsRequestTrade,
@@ -132,6 +133,11 @@ class ProcessorEthWSTSendTx:
                     elif wst_tx.tx_type == IbetWSTTxType.BURN:
                         # Send burn transaction
                         tx_hash = await send_burn_transaction(wst_tx, tx_sender_account)
+                    elif wst_tx.tx_type == IbetWSTTxType.FORCE_BURN:
+                        # Send force burn transaction
+                        tx_hash = await send_force_burn_transaction(
+                            wst_tx, tx_sender_account
+                        )
                     elif wst_tx.tx_type == IbetWSTTxType.REQUEST_TRADE:
                         # Send request trade transaction
                         tx_hash = await send_request_trade_transaction(
@@ -341,6 +347,30 @@ async def send_burn_transaction(
     tx_params: IbetWSTTxParamsBurn = wst_tx.tx_params
     tx_hash = await wst_contract.burn_with_authorization(
         from_address=tx_params["from_address"],
+        value=wst_tx.tx_params["value"],
+        authorization=IbetWSTAuthorization(
+            nonce=bytes(32).fromhex(wst_tx.authorization["nonce"]),
+            v=wst_tx.authorization["v"],
+            r=bytes(32).fromhex(wst_tx.authorization["r"]),
+            s=bytes(32).fromhex(wst_tx.authorization["s"]),
+        ),
+        tx_sender=tx_sender_account.address,
+        tx_sender_key=tx_sender_account.private_key,
+    )
+    return tx_hash
+
+
+async def send_force_burn_transaction(
+    wst_tx: EthIbetWSTTx,
+    tx_sender_account: TxSenderAccount,
+) -> str:
+    """
+    Send a transaction to force burn IbetWST tokens.
+    """
+    wst_contract = IbetWST(wst_tx.ibet_wst_address)
+    tx_params: IbetWSTTxParamsForceBurn = wst_tx.tx_params
+    tx_hash = await wst_contract.force_burn_from_with_authorization(
+        account_address=tx_params["account"],
         value=wst_tx.tx_params["value"],
         authorization=IbetWSTAuthorization(
             nonce=bytes(32).fromhex(wst_tx.authorization["nonce"]),

--- a/docs/ibet_prime.yaml
+++ b/docs/ibet_prime.yaml
@@ -8654,13 +8654,17 @@ paths:
           required: true
           schema:
             type: string
+            description: Token address
             title: Token Address
+          description: Token address
         - name: issuer-address
           in: header
           required: true
           schema:
             type: string
+            description: Issuer address
             title: Issuer-Address
+          description: Issuer address
         - name: eoa-password
           in: header
           required: false
@@ -8668,7 +8672,9 @@ paths:
             anyOf:
               - type: string
               - type: 'null'
+            description: EOA passphrase
             title: Eoa-Password
+          description: EOA passphrase
         - name: auth-token
           in: header
           required: false
@@ -8676,7 +8682,9 @@ paths:
             anyOf:
               - type: string
               - type: 'null'
+            description: JWT authentication token
             title: Auth-Token
+          description: JWT authentication token
       requestBody:
         required: true
         content:
@@ -8725,13 +8733,17 @@ paths:
           required: true
           schema:
             type: string
+            description: Token address
             title: Token Address
+          description: Token address
         - name: issuer-address
           in: header
           required: true
           schema:
             type: string
+            description: Issuer address
             title: Issuer-Address
+          description: Issuer address
         - name: eoa-password
           in: header
           required: false
@@ -8739,7 +8751,9 @@ paths:
             anyOf:
               - type: string
               - type: 'null'
+            description: EOA passphrase
             title: Eoa-Password
+          description: EOA passphrase
         - name: auth-token
           in: header
           required: false
@@ -8747,13 +8761,94 @@ paths:
             anyOf:
               - type: string
               - type: 'null'
+            description: JWT authentication token
             title: Auth-Token
+          description: JWT authentication token
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/DeleteIbetWSTWhitelistRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IbetWSTTransactionResponse'
+        '400':
+          description: Invalid Parameter Error / Send Transaction Error / 
+            Contract Revert Error etc
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400Model'
+        '404':
+          description: Not Found Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404Model'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error422Model'
+  /tokens/{token_address}/ibet_wst/positions/force_burn:
+    post:
+      tags:
+        - token_common
+      summary: Force Burn Ibet Wst Position
+      description: |-
+        Force burn an IbetWST position for a specific account
+
+        - This endpoint allows an issuer to force burn an IbetWST position for a specific account.
+      operationId: ForceBurnIbetWSTPosition
+      parameters:
+        - name: token_address
+          in: path
+          required: true
+          schema:
+            type: string
+            description: Token address
+            title: Token Address
+          description: Token address
+        - name: issuer-address
+          in: header
+          required: true
+          schema:
+            type: string
+            description: Issuer address
+            title: Issuer-Address
+          description: Issuer address
+        - name: eoa-password
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: 'null'
+            description: EOA passphrase
+            title: Eoa-Password
+          description: EOA passphrase
+        - name: auth-token
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: 'null'
+            description: JWT authentication token
+            title: Auth-Token
+          description: JWT authentication token
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ForceBurnIbetWSTRequest'
       responses:
         '200':
           description: Successful Response
@@ -10032,6 +10127,7 @@ paths:
                   - deploy
                   - mint
                   - burn
+                  - force_burn
                   - add_whitelist
                   - delete_whitelist
                   - transfer
@@ -13749,6 +13845,23 @@ components:
         - eoa_password
       title: FinishDVPDeliveryRequest
       description: DVP delivery finish schema (REQUEST)
+    ForceBurnIbetWSTRequest:
+      properties:
+        account_address:
+          type: string
+          title: Account Address
+          description: Account address from which to force burn IbetWST
+        value:
+          type: integer
+          exclusiveMinimum: 0.0
+          title: Value
+          description: Amount of IbetWST to force burn
+      type: object
+      required:
+        - account_address
+        - value
+      title: ForceBurnIbetWSTRequest
+      description: ForceBurnIbetWST request schema
     ForceLockRequest:
       properties:
         token_address:
@@ -13939,6 +14052,7 @@ components:
             - deploy
             - mint
             - burn
+            - force_burn
             - add_whitelist
             - delete_whitelist
             - transfer

--- a/tests/app/test_ibet_wst_ListIbetWSTTransactions.py
+++ b/tests/app/test_ibet_wst_ListIbetWSTTransactions.py
@@ -1098,10 +1098,10 @@ class TestListIbetWSTTransactions:
                 {
                     "type": "literal_error",
                     "loc": ["query", "tx_type"],
-                    "msg": "Input should be 'deploy', 'mint', 'burn', 'add_whitelist', 'delete_whitelist', 'transfer', 'request_trade', 'cancel_trade', 'accept_trade' or 'reject_trade'",
+                    "msg": "Input should be 'deploy', 'mint', 'burn', 'force_burn', 'add_whitelist', 'delete_whitelist', 'transfer', 'request_trade', 'cancel_trade', 'accept_trade' or 'reject_trade'",
                     "input": "invalid-type",
                     "ctx": {
-                        "expected": "'deploy', 'mint', 'burn', 'add_whitelist', 'delete_whitelist', 'transfer', 'request_trade', 'cancel_trade', 'accept_trade' or 'reject_trade'"
+                        "expected": "'deploy', 'mint', 'burn', 'force_burn', 'add_whitelist', 'delete_whitelist', 'transfer', 'request_trade', 'cancel_trade', 'accept_trade' or 'reject_trade'"
                     },
                 },
                 {

--- a/tests/app/test_token_common_ForceBurnIbetWSTPosition.py
+++ b/tests/app/test_token_common_ForceBurnIbetWSTPosition.py
@@ -1,0 +1,273 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+from unittest import mock
+
+import pytest
+from eth_utils import to_checksum_address
+from sqlalchemy import select
+
+from app.model.db import (
+    Account,
+    EthIbetWSTTx,
+    IbetWSTTxStatus,
+    IbetWSTTxType,
+    IbetWSTVersion,
+    Token,
+    TokenType,
+    TokenVersion,
+)
+from app.utils.e2ee_utils import E2EEUtils
+from tests.account_config import default_eth_account
+
+
+@pytest.mark.asyncio
+class TestAddIbetWSTWhitelist:
+    # API endpoint
+    api_url = "/tokens/{token_address}/ibet_wst/positions/force_burn"
+
+    issuer = default_eth_account("user1")
+    user = default_eth_account("user2")
+    relayer = default_eth_account("user3")
+
+    token_address = to_checksum_address("0x1234567890abcdef1234567890abcdef12345678")
+    ibet_wst_address = to_checksum_address("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd")
+
+    ###########################################################################
+    # Normal
+    ###########################################################################
+
+    # <Normal_1>
+    @mock.patch(
+        "app.routers.issuer.token_common.ETH_MASTER_ACCOUNT_ADDRESS",
+        relayer["address"],
+    )
+    async def test_normal_1(self, async_db, async_client):
+        # Prepare data
+        account = Account()
+        account.issuer_address = self.issuer["address"]
+        account.keyfile = self.issuer["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        async_db.add(account)
+
+        token = Token()
+        token.type = TokenType.IBET_STRAIGHT_BOND
+        token.tx_hash = ""
+        token.issuer_address = self.issuer["address"]
+        token.token_address = self.token_address
+        token.abi = {}
+        token.version = TokenVersion.V_25_09
+        token.ibet_wst_deployed = True
+        token.ibet_wst_address = self.ibet_wst_address
+        async_db.add(token)
+
+        await async_db.commit()
+
+        # Send request
+        resp = await async_client.post(
+            self.api_url.format(token_address=self.token_address),
+            json={
+                "account_address": self.user["address"],
+                "value": 1000,
+            },
+            headers={
+                "issuer-address": self.issuer["address"],
+                "eoa-password": E2EEUtils.encrypt("password"),
+            },
+        )
+
+        # Check response status code and content
+        assert resp.status_code == 200
+        assert resp.json() == {"tx_id": mock.ANY}
+
+        # Check transaction creation
+        wst_tx = (await async_db.scalars(select(EthIbetWSTTx).limit(1))).first()
+        assert wst_tx.tx_type == IbetWSTTxType.FORCE_BURN
+        assert wst_tx.version == IbetWSTVersion.V_1
+        assert wst_tx.status == IbetWSTTxStatus.PENDING
+        assert wst_tx.ibet_wst_address == self.ibet_wst_address
+        assert wst_tx.tx_params == {
+            "account": self.user["address"],
+            "value": 1000,
+        }
+        assert wst_tx.tx_sender == self.relayer["address"]
+        assert wst_tx.authorizer == self.issuer["address"]
+        assert wst_tx.authorization == {
+            "nonce": mock.ANY,
+            "v": mock.ANY,
+            "r": mock.ANY,
+            "s": mock.ANY,
+        }
+
+    ###########################################################################
+    # Error
+    ###########################################################################
+
+    # <Error_1>
+    # Invalid parameters
+    # - account_address is not a valid Ethereum address
+    # - value is not greater than 0
+    async def test_error_1(self, async_db, async_client):
+        # Send request with invalid parameters
+        resp = await async_client.post(
+            self.api_url.format(token_address=self.token_address),
+            json={
+                "account_address": "invalid_account_address",
+                "value": -1,
+            },
+            headers={
+                "issuer-address": self.issuer["address"],
+                "eoa-password": E2EEUtils.encrypt("password"),
+            },
+        )
+
+        # Check response status code
+        assert resp.status_code == 422
+        assert resp.json() == {
+            "meta": {"code": 1, "title": "RequestValidationError"},
+            "detail": [
+                {
+                    "type": "value_error",
+                    "loc": ["body", "account_address"],
+                    "msg": "Value error, invalid ethereum address",
+                    "input": "invalid_account_address",
+                    "ctx": {"error": {}},
+                },
+                {
+                    "type": "greater_than",
+                    "loc": ["body", "value"],
+                    "msg": "Input should be greater than 0",
+                    "input": -1,
+                    "ctx": {"gt": 0},
+                },
+            ],
+        }
+
+    # <Error_2>
+    # Invalid headers
+    # - issuer-address is not a valid address
+    # - eoa-password is not a Base64-encoded encrypted data
+    async def test_error_2(self, async_db, async_client):
+        # Send request
+        resp = await async_client.post(
+            self.api_url.format(token_address=self.token_address),
+            json={
+                "account_address": self.user["address"],
+                "value": 1000,
+            },
+            headers={
+                "issuer-address": "invalid_issuer_address",
+                "eoa-password": "invalid_password",
+            },
+        )
+
+        # Check response status code
+        assert resp.status_code == 422
+        assert resp.json() == {
+            "meta": {"code": 1, "title": "RequestValidationError"},
+            "detail": [
+                {
+                    "msg": "issuer-address is not a valid address",
+                    "loc": ["header", "issuer-address"],
+                    "input": "invalid_issuer_address",
+                    "type": "value_error",
+                },
+                {
+                    "msg": "eoa-password is not a Base64-encoded encrypted data",
+                    "loc": ["header", "eoa-password"],
+                    "input": "invalid_password",
+                    "type": "value_error",
+                },
+            ],
+        }
+
+    # <Error_3>
+    # Issuer does not exist or password mismatch
+    async def test_error_3(self, async_db, async_client):
+        # Prepare data
+        account = Account()
+        account.issuer_address = self.issuer["address"]
+        account.keyfile = self.issuer["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        async_db.add(account)
+
+        token = Token()
+        token.type = TokenType.IBET_STRAIGHT_BOND
+        token.tx_hash = ""
+        token.issuer_address = self.issuer["address"]
+        token.token_address = self.token_address
+        token.abi = {}
+        token.version = TokenVersion.V_25_09
+        token.ibet_wst_deployed = True
+        token.ibet_wst_address = self.ibet_wst_address
+        async_db.add(token)
+
+        await async_db.commit()
+
+        # Send request
+        resp = await async_client.post(
+            self.api_url.format(token_address=self.token_address),
+            json={
+                "account_address": self.user["address"],
+                "value": 1000,
+            },
+            headers={
+                "issuer-address": self.issuer["address"],
+                "eoa-password": E2EEUtils.encrypt("invalid_password"),
+            },
+        )
+
+        # Check response status code
+        assert resp.status_code == 401
+        assert resp.json() == {
+            "meta": {"code": 1, "title": "AuthorizationError"},
+            "detail": "issuer does not exist, or password mismatch",
+        }
+
+    # <Error_4>
+    # Token not found
+    async def test_error_4(self, async_db, async_client):
+        # Prepare data
+        account = Account()
+        account.issuer_address = self.issuer["address"]
+        account.keyfile = self.issuer["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        async_db.add(account)
+
+        await async_db.commit()
+
+        # Send request
+        resp = await async_client.post(
+            self.api_url.format(token_address=self.token_address),
+            json={
+                "account_address": self.user["address"],
+                "value": 1000,
+            },
+            headers={
+                "issuer-address": self.issuer["address"],
+                "eoa-password": E2EEUtils.encrypt("password"),
+            },
+        )
+
+        # Check response status code
+        assert resp.status_code == 404
+        assert resp.json() == {
+            "meta": {"code": 1, "title": "NotFound"},
+            "detail": "Token not found",
+        }

--- a/tests/batch/test_processor_eth_wst_send_tx.py
+++ b/tests/batch/test_processor_eth_wst_send_tx.py
@@ -37,6 +37,7 @@ from app.model.db import (
     IbetWSTTxParamsCancelTrade,
     IbetWSTTxParamsDeleteAccountWhiteList,
     IbetWSTTxParamsDeploy,
+    IbetWSTTxParamsForceBurn,
     IbetWSTTxParamsMint,
     IbetWSTTxParamsRequestTrade,
     IbetWSTTxParamsTransfer,
@@ -750,6 +751,72 @@ class TestProcessor:
         # Check if the log was recorded
         assert caplog.messages == [
             f"Processing transaction: id={tx_id}, type=transfer",
+            f"Transaction sent successfully: id={tx_id}",
+        ]
+
+    # Normal_2_11
+    # - Confirm that processing is performed correctly when there is target data to process
+    # - transaction type: Force Burn
+    @mock.patch(
+        "batch.processor_eth_wst_send_tx.ETH_MASTER_ACCOUNT_ADDRESS",
+        eth_master["address"],
+    )
+    @mock.patch(
+        "batch.processor_eth_wst_send_tx.ETH_MASTER_PRIVATE_KEY",
+        eth_master["private_key"],
+    )
+    @mock.patch(
+        "app.model.eth.wst.IbetWST.force_burn_from_with_authorization",
+        AsyncMock(return_value="test_tx_hash"),
+    )
+    async def test_normal_2_11(self, processor, async_db, caplog):
+        tx_id = str(uuid.uuid4())
+
+        # Prepare test data
+        account = Account()
+        account.issuer_address = self.issuer["address"]
+        account.keyfile = self.issuer["keyfile_json"]
+        async_db.add(account)
+
+        wst_tx = EthIbetWSTTx()
+        wst_tx.tx_id = tx_id
+        wst_tx.tx_type = IbetWSTTxType.FORCE_BURN
+        wst_tx.version = IbetWSTVersion.V_1
+        wst_tx.status = IbetWSTTxStatus.PENDING
+        wst_tx.ibet_wst_address = to_checksum_address(
+            "0x1234567890abcdef1234567890abcdef12345678"
+        )
+        wst_tx.tx_params = IbetWSTTxParamsForceBurn(
+            account=self.user1["address"],
+            value=1000,
+        )
+        wst_tx.authorizer = self.issuer["address"]
+        wst_tx.authorization = IbetWSTAuthorization(
+            nonce=secrets.token_bytes(32).hex(),
+            v=27,
+            r=secrets.token_bytes(32).hex(),
+            s=secrets.token_bytes(32).hex(),
+        )
+        wst_tx.tx_sender = self.eth_master["address"]
+        async_db.add(wst_tx)
+        await async_db.commit()
+
+        # Execute batch
+        await processor.run()
+        async_db.expire_all()
+
+        # Check if the transaction was processed
+        wst_tx_af = (
+            await async_db.scalars(
+                select(EthIbetWSTTx).where(EthIbetWSTTx.tx_id == tx_id).limit(1)
+            )
+        ).first()
+        assert wst_tx_af.status == IbetWSTTxStatus.SENT
+        assert wst_tx_af.tx_hash == "test_tx_hash"
+
+        # Check if the log was recorded
+        assert caplog.messages == [
+            f"Processing transaction: id={tx_id}, type=force_burn",
             f"Transaction sent successfully: id={tx_id}",
         ]
 


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

This pull request introduces support for a new "force burn" operation for IbetWST tokens, allowing issuers to forcibly burn tokens from a specific account.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- Close #886 

## 🔄 Changes

<!-- List the major changes in this PR. -->

**Force Burn Feature Implementation:**

* Added a new transaction type `FORCE_BURN` to `IbetWSTTxType` and its corresponding parameter type `IbetWSTTxParamsForceBurn`, including schema and database model updates to support force burn operations. [[1]](diffhunk://#diff-4fb31064e27d1d13f8685fa2c590e7e948d17b388c95fb1f8e616615497e52fbR42) [[2]](diffhunk://#diff-4fb31064e27d1d13f8685fa2c590e7e948d17b388c95fb1f8e616615497e52fbR113-R119) [[3]](diffhunk://#diff-4fb31064e27d1d13f8685fa2c590e7e948d17b388c95fb1f8e616615497e52fbR269) [[4]](diffhunk://#diff-60e36dee4c6b6b2dac63e891516a2805610d6fa32d4505500f94f35ccf886bb3R75) [[5]](diffhunk://#diff-052ba732d713b2d806079d83397fea06bb74e8b2056b062e0cbea89c73153712R103) [[6]](diffhunk://#diff-f68404341792a531155f615f4f170c082a2f86fb1a4c4b7d9908404aa4122b29R72) [[7]](diffhunk://#diff-f68404341792a531155f615f4f170c082a2f86fb1a4c4b7d9908404aa4122b29R198-R206)
* Implemented the `/tokens/{token_address}/ibet_wst/positions/force_burn` API endpoint, allowing issuers to force burn tokens from a specified account, with full authentication, authorization, and transaction recording.
* Added batch processor logic to send and finalize force burn transactions, including event log handling and integration with the blockchain contract. [[1]](diffhunk://#diff-4d2cf1c1712ded563abec1f461d0c534f45b35432cbad6c7b873e9618a187c13R41) [[2]](diffhunk://#diff-4d2cf1c1712ded563abec1f461d0c534f45b35432cbad6c7b873e9618a187c13R136-R140) [[3]](diffhunk://#diff-4d2cf1c1712ded563abec1f461d0c534f45b35432cbad6c7b873e9618a187c13R363-R386) [[4]](diffhunk://#diff-7711bbe44883be877362b4127aa3ba17ea790fe9c2cca884155238913e8ce7bcR201-R213)

**API Improvements and Refactoring:**

* Enhanced parameter typing and descriptions for token and issuer addresses, EOA passphrases, and authentication tokens in API endpoints for better validation and OpenAPI documentation. [[1]](diffhunk://#diff-0b51a72b2a807086c29a9458db7fbf439ffc3320c50a67a51e1861eb87b3376eL483-R490) [[2]](diffhunk://#diff-0b51a72b2a807086c29a9458db7fbf439ffc3320c50a67a51e1861eb87b3376eL511-R515) [[3]](diffhunk://#diff-0b51a72b2a807086c29a9458db7fbf439ffc3320c50a67a51e1861eb87b3376eL528-R533) [[4]](diffhunk://#diff-0b51a72b2a807086c29a9458db7fbf439ffc3320c50a67a51e1861eb87b3376eL599-R608) [[5]](diffhunk://#diff-0b51a72b2a807086c29a9458db7fbf439ffc3320c50a67a51e1861eb87b3376eL626-R632) [[6]](diffhunk://#diff-0b51a72b2a807086c29a9458db7fbf439ffc3320c50a67a51e1861eb87b3376eL643-R650) [[7]](diffhunk://#diff-0b51a72b2a807086c29a9458db7fbf439ffc3320c50a67a51e1861eb87b3376eL575-R579) [[8]](diffhunk://#diff-e54863847006bb647956a60aebd43bf13e3ce8bf1a59539d4e8692da6bed254eR8657-R8687) [[9]](diffhunk://#diff-e54863847006bb647956a60aebd43bf13e3ce8bf1a59539d4e8692da6bed254eR8736-R8766)
* Updated imports and code organization to support the new force burn types and request schemas. [[1]](diffhunk://#diff-0b51a72b2a807086c29a9458db7fbf439ffc3320c50a67a51e1861eb87b3376eR39) [[2]](diffhunk://#diff-0b51a72b2a807086c29a9458db7fbf439ffc3320c50a67a51e1861eb87b3376eL49-R57)

## 📌 Checklist

- [ ] I have added tests where necessary.
- [ ] I have updated the documentation where necessary.
