### PR TITLE
Add support for StableCoin decimals in IbetWST transactions

### DIFF
--- a/app/model/db/ibet_wst.py
+++ b/app/model/db/ibet_wst.py
@@ -191,6 +191,7 @@ class IbetWSTEventLogTradeRequested(TypedDict):
     buyer_sc_account_address: str  # Buyer's StableCoin account address
     st_value: int  # Amount of IbetWST traded
     sc_value: int  # Amount of StableCoin traded
+    sc_decimals: int  # Decimals of the StableCoin token
 
 
 class IbetWSTEventLogTradeCancelled(TypedDict):
@@ -204,6 +205,7 @@ class IbetWSTEventLogTradeCancelled(TypedDict):
     buyer_sc_account_address: str  # Buyer's StableCoin account address
     st_value: int  # Amount of IbetWST traded
     sc_value: int  # Amount of StableCoin traded
+    sc_decimals: int  # Decimals of the StableCoin token
 
 
 class IbetWSTEventLogTradeAccepted(TypedDict):
@@ -217,6 +219,7 @@ class IbetWSTEventLogTradeAccepted(TypedDict):
     buyer_sc_account_address: str  # Buyer's StableCoin account address
     st_value: int  # Amount of IbetWST traded
     sc_value: int  # Amount of StableCoin traded
+    sc_decimals: int  # Decimals of the StableCoin token
 
 
 class IbetWSTEventLogTradeRejected(TypedDict):
@@ -230,6 +233,7 @@ class IbetWSTEventLogTradeRejected(TypedDict):
     buyer_sc_account_address: str  # Buyer's StableCoin account address
     st_value: int  # Amount of IbetWST traded
     sc_value: int  # Amount of StableCoin traded
+    sc_decimals: int  # Decimals of the StableCoin token
 
 
 class EthIbetWSTTx(Base):

--- a/app/model/eth/wst.py
+++ b/app/model/eth/wst.py
@@ -90,6 +90,19 @@ class ERC20:
             default_returns=0,
         )
 
+    async def decimals(self) -> int:
+        """
+        Get token decimals
+
+        :return: Token decimals
+        """
+        return await EthAsyncContractUtils.call_function(
+            contract=self.contract,
+            function_name="decimals",
+            args=(),
+            default_returns=18,
+        )
+
 
 class IbetWSTWhiteList(BaseModel):
     """

--- a/app/model/schema/ibet_wst.py
+++ b/app/model/schema/ibet_wst.py
@@ -17,6 +17,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
+from decimal import Decimal
 from enum import IntEnum, StrEnum
 from typing import Literal, Optional
 
@@ -412,6 +413,10 @@ class IbetWSTEventLogTrade(BaseModel):
     )
     st_value: int = Field(..., description="Value of IbetWST to trade")
     sc_value: int = Field(..., description="Value of SC token to trade")
+    display_sc_value: Decimal = Field(
+        ..., description="Value of SC token to trade (decimals considered)"
+    )
+    sc_decimals: int = Field(..., description="Decimals of the SC token")
 
 
 class GetIbetWSTTransactionResponse(BaseModel):

--- a/batch/processor_eth_wst_monitor_txreceipt.py
+++ b/batch/processor_eth_wst_monitor_txreceipt.py
@@ -47,7 +47,7 @@ from app.model.db import (
     IDXEthIbetWSTWhitelist,
     Token,
 )
-from app.model.eth import IbetWST
+from app.model.eth import ERC20, IbetWST
 from app.utils.eth_contract_utils import EthAsyncContractUtils
 from batch import free_malloc
 from batch.utils import batch_log
@@ -287,6 +287,7 @@ async def finalize_tx(
                 )
                 event = events[0] if len(events) > 0 else None
                 if event is not None:
+                    sc_token = ERC20(event["args"]["SCTokenAddress"])
                     wst_tx.event_log = IbetWSTEventLogTradeRequested(
                         index=event["args"]["index"],
                         seller_st_account_address=event["args"][
@@ -300,6 +301,7 @@ async def finalize_tx(
                         buyer_sc_account_address=event["args"]["buyerSCAccountAddress"],
                         st_value=event["args"]["STValue"],
                         sc_value=event["args"]["SCValue"],
+                        sc_decimals=(await sc_token.decimals()),
                     )
                     await db_session.merge(wst_tx)
             case IbetWSTTxType.CANCEL_TRADE:
@@ -310,6 +312,7 @@ async def finalize_tx(
                 )
                 event = events[0] if len(events) > 0 else None
                 if event is not None:
+                    sc_token = ERC20(event["args"]["SCTokenAddress"])
                     wst_tx.event_log = IbetWSTEventLogTradeCancelled(
                         index=event["args"]["index"],
                         seller_st_account_address=event["args"][
@@ -323,6 +326,7 @@ async def finalize_tx(
                         buyer_sc_account_address=event["args"]["buyerSCAccountAddress"],
                         st_value=event["args"]["STValue"],
                         sc_value=event["args"]["SCValue"],
+                        sc_decimals=(await sc_token.decimals()),
                     )
                     await db_session.merge(wst_tx)
             case IbetWSTTxType.ACCEPT_TRADE:
@@ -333,6 +337,7 @@ async def finalize_tx(
                 )
                 event = events[0] if len(events) > 0 else None
                 if event is not None:
+                    sc_token = ERC20(event["args"]["SCTokenAddress"])
                     wst_tx.event_log = IbetWSTEventLogTradeAccepted(
                         index=event["args"]["index"],
                         seller_st_account_address=event["args"][
@@ -346,6 +351,7 @@ async def finalize_tx(
                         buyer_sc_account_address=event["args"]["buyerSCAccountAddress"],
                         st_value=event["args"]["STValue"],
                         sc_value=event["args"]["SCValue"],
+                        sc_decimals=(await sc_token.decimals()),
                     )
                     await db_session.merge(wst_tx)
             case IbetWSTTxType.REJECT_TRADE:
@@ -356,6 +362,7 @@ async def finalize_tx(
                 )
                 event = events[0] if len(events) > 0 else None
                 if event is not None:
+                    sc_token = ERC20(event["args"]["SCTokenAddress"])
                     wst_tx.event_log = IbetWSTEventLogTradeRejected(
                         index=event["args"]["index"],
                         seller_st_account_address=event["args"][
@@ -369,6 +376,7 @@ async def finalize_tx(
                         buyer_sc_account_address=event["args"]["buyerSCAccountAddress"],
                         st_value=event["args"]["STValue"],
                         sc_value=event["args"]["SCValue"],
+                        sc_decimals=(await sc_token.decimals()),
                     )
                     await db_session.merge(wst_tx)
             case _:

--- a/docs/ibet_prime.yaml
+++ b/docs/ibet_prime.yaml
@@ -15961,6 +15961,14 @@ components:
           type: integer
           title: Sc Value
           description: Value of SC token to trade
+        display_sc_value:
+          type: string
+          title: Display Sc Value
+          description: Value of SC token to trade (decimals considered)
+        sc_decimals:
+          type: integer
+          title: Sc Decimals
+          description: Decimals of the SC token
       type: object
       required:
         - index
@@ -15971,6 +15979,8 @@ components:
         - buyer_sc_account_address
         - st_value
         - sc_value
+        - display_sc_value
+        - sc_decimals
       title: IbetWSTEventLogTrade
       description: IbetWST 
         TradeRequested/TradeCancelled/TradeAccepted/TradeRejected event log 

--- a/tests/app/model/eth/test_ERC20.py
+++ b/tests/app/model/eth/test_ERC20.py
@@ -276,3 +276,44 @@ class TestAllowance:
 
         # Assert that the allowance is correct
         assert allowance == 0
+
+
+@pytest.mark.asyncio
+class TestDecimals:
+    """
+    Test ERC20 contract decimals function
+    """
+
+    deployer = default_eth_account("user1")
+    issuer = default_eth_account("user2")
+
+    #################################################################
+    # Normal
+    #################################################################
+
+    # Normal_1
+    # - Test that the decimals function returns 18 when called on a contract after deploying it.
+    async def test_normal_1(self):
+        # Deploy contract
+        contract_address = await deploy_token("Test Token", self.deployer, self.issuer)
+
+        # Generate contract instance
+        contract = ERC20(contract_address)
+
+        # Call decimals function
+        decimals = await contract.decimals()
+
+        # Assert that the decimals is 18
+        assert decimals == 18
+
+    # Normal_2
+    # - Test that the decimals function returns 18 when called on a contract at the zero address.
+    async def test_normal_2(self):
+        # Generate contract instance
+        contract = ERC20(ZERO_ADDRESS)
+
+        # Call decimals function
+        decimals = await contract.decimals()
+
+        # Assert that the decimals is 18
+        assert decimals == 18

--- a/tests/app/test_ibet_wst_GetIbetWSTTransaction.py
+++ b/tests/app/test_ibet_wst_GetIbetWSTTransaction.py
@@ -25,7 +25,9 @@ import pytest
 from app.model.db import (
     EthIbetWSTTx,
     IbetWSTEventLogMint,
+    IbetWSTEventLogTradeRequested,
     IbetWSTTxParamsMint,
+    IbetWSTTxParamsRequestTrade,
     IbetWSTTxStatus,
     IbetWSTTxType,
     IbetWSTVersion,
@@ -46,9 +48,9 @@ class TestGetIbetWSTTransaction:
     # Normal
     ###########################################################################
 
-    # <Normal_1>
+    # <Normal_1_1>
     # Return transaction details
-    async def test_normal_1(self, async_db, async_client):
+    async def test_normal_1_1(self, async_db, async_client):
         # Prepare data
         tx_id = str(uuid.uuid4())
         tx = EthIbetWSTTx()
@@ -99,6 +101,83 @@ class TestGetIbetWSTTransaction:
             },
             "created": "2025-01-02T12:04:05+09:00",
         }
+
+    # <Normal_1_2>
+    # Return transaction details
+    # - For trade-related transactions, display_sc_value is set based on sc_value and sc_decimals
+    async def test_normal_1_2(self, async_db, async_client):
+        # Prepare data
+        tx_id = str(uuid.uuid4())
+        tx = EthIbetWSTTx()
+        tx.tx_id = tx_id
+        tx.tx_type = IbetWSTTxType.REQUEST_TRADE
+        tx.version = IbetWSTVersion.V_1
+        tx.status = IbetWSTTxStatus.SUCCEEDED
+        tx.ibet_wst_address = "0x1234567890abcdef1234567890abcdef12345678"
+        tx.tx_params = IbetWSTTxParamsRequestTrade(
+            seller_st_account="0x1234567890AbcdEF1234567890aBcdef12345678",
+            buyer_st_account="0x234567890abCDEf1234567890aBCdEf123456789",
+            sc_token_address="0x34567890abCdEF1234567890abcDeF1234567890",
+            st_value=100,
+            sc_value=1234567890,
+            memo="Test trade request",
+        )
+        tx.tx_sender = self.tx_sender["address"]
+        tx.authorizer = self.authorizer["address"]
+        tx.authorization = {}
+        tx.tx_hash = (
+            "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+        )
+        tx.block_number = 12345678
+        tx.finalized = True
+        tx.event_log = IbetWSTEventLogTradeRequested(
+            index=111,
+            seller_st_account_address="0x1234567890AbcdEF1234567890aBcdef12345678",
+            buyer_st_account_address="0x234567890abCDEf1234567890aBCdEf123456789",
+            sc_token_address="0x34567890abCdEF1234567890abcDeF1234567890",
+            seller_sc_account_address="0x1234567890AbcdEF1234567890aBcdef12345678",
+            buyer_sc_account_address="0x234567890abCDEf1234567890aBCdEf123456789",
+            st_value=100,
+            sc_value=1234567890,
+            sc_decimals=8,
+        )
+        tx.created = datetime.datetime(2025, 1, 2, 3, 4, 5, tzinfo=None)
+        async_db.add(tx)
+        await async_db.commit()
+
+        # Send request
+        resp = await async_client.get(self.api_url.format(tx_id=tx_id))
+
+        # Check response
+        assert resp.status_code == 200
+        assert (
+            resp.json()
+            == {
+                "tx_id": tx_id,
+                "tx_type": IbetWSTTxType.REQUEST_TRADE,
+                "version": IbetWSTVersion.V_1,
+                "status": IbetWSTTxStatus.SUCCEEDED,
+                "ibet_wst_address": "0x1234567890abcdef1234567890abcdef12345678",
+                "tx_sender": self.tx_sender["address"],
+                "authorizer": self.authorizer["address"],
+                "tx_hash": "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+                "block_number": 12345678,
+                "finalized": True,
+                "event_log": {
+                    "index": 111,
+                    "seller_st_account_address": "0x1234567890AbcdEF1234567890aBcdef12345678",
+                    "buyer_st_account_address": "0x234567890abCDEf1234567890aBCdEf123456789",
+                    "sc_token_address": "0x34567890abCdEF1234567890abcDeF1234567890",
+                    "seller_sc_account_address": "0x1234567890AbcdEF1234567890aBcdef12345678",
+                    "buyer_sc_account_address": "0x234567890abCDEf1234567890aBCdEf123456789",
+                    "st_value": 100,
+                    "sc_value": 1234567890,
+                    "display_sc_value": "12.3456789",  # Calculated from sc_value and sc_decimals
+                    "sc_decimals": 8,
+                },
+                "created": "2025-01-02T12:04:05+09:00",
+            }
+        )
 
     ###########################################################################
     # Error

--- a/tests/batch/test_processor_eth_wst_monitor_txreceipt.py
+++ b/tests/batch/test_processor_eth_wst_monitor_txreceipt.py
@@ -161,7 +161,7 @@ class TestProcessor:
             return_value={
                 "status": 1,
                 "blockNumber": 100,
-                "contractAddress": "0x9876543210abcdef1234567890abcdef12345678",
+                "contractAddress": "0x9876543210abCDef1234567890AbcDef12345678",
                 "gasUsed": 21000,
             }
         ),
@@ -203,7 +203,7 @@ class TestProcessor:
         assert wst_tx_af.gas_used == 21000
         assert wst_tx_af.finalized is False
         assert (
-            wst_tx_af.ibet_wst_address == "0x9876543210abcdef1234567890abcdef12345678"
+            wst_tx_af.ibet_wst_address == "0x9876543210abCDef1234567890AbcDef12345678"
         )
 
         assert caplog.messages == [
@@ -276,7 +276,7 @@ class TestProcessor:
             return_value={
                 "status": 1,
                 "blockNumber": 100,
-                "contractAddress": "0x9876543210abcdef1234567890abcdef12345678",
+                "contractAddress": "0x9876543210abCDef1234567890AbcDef12345678",
                 "gasUsed": 21000,
             }
         ),
@@ -338,7 +338,7 @@ class TestProcessor:
             )
         ).first()
         assert token_af.ibet_wst_deployed is True
-        assert token_af.ibet_wst_address == "0x9876543210abcdef1234567890abcdef12345678"
+        assert token_af.ibet_wst_address == "0x9876543210abCDef1234567890AbcDef12345678"
 
         assert caplog.messages == [
             f"Monitor transaction: id={tx_id}, type=deploy",
@@ -356,7 +356,7 @@ class TestProcessor:
             return_value={
                 "status": 1,
                 "blockNumber": 100,
-                "contractAddress": "0x9876543210abcdef1234567890abcdef12345678",
+                "contractAddress": "0x9876543210abCDef1234567890AbcDef12345678",
                 "gasUsed": 21000,
             }
         ),
@@ -402,7 +402,7 @@ class TestProcessor:
         wst_tx.version = IbetWSTVersion.V_1
         wst_tx.status = IbetWSTTxStatus.SENT
         wst_tx.tx_hash = self.tx_hash
-        wst_tx.ibet_wst_address = "0x9876543210abcdef1234567890abcdef12345678"
+        wst_tx.ibet_wst_address = "0x9876543210abCDef1234567890AbcDef12345678"
         wst_tx.tx_params = IbetWSTTxParamsMint(
             to_address=self.user1["address"],
             value=1000,
@@ -447,7 +447,7 @@ class TestProcessor:
             return_value={
                 "status": 1,
                 "blockNumber": 100,
-                "contractAddress": "0x9876543210abcdef1234567890abcdef12345678",
+                "contractAddress": "0x9876543210abCDef1234567890AbcDef12345678",
                 "gasUsed": 21000,
             }
         ),
@@ -493,7 +493,7 @@ class TestProcessor:
         wst_tx.version = IbetWSTVersion.V_1
         wst_tx.status = IbetWSTTxStatus.SENT
         wst_tx.tx_hash = self.tx_hash
-        wst_tx.ibet_wst_address = "0x9876543210abcdef1234567890abcdef12345678"
+        wst_tx.ibet_wst_address = "0x9876543210abCDef1234567890AbcDef12345678"
         wst_tx.tx_params = IbetWSTTxParamsBurn(
             from_address=self.user1["address"],
             value=1000,
@@ -538,7 +538,7 @@ class TestProcessor:
             return_value={
                 "status": 1,
                 "blockNumber": 100,
-                "contractAddress": "0x9876543210abcdef1234567890abcdef12345678",
+                "contractAddress": "0x9876543210abCDef1234567890AbcDef12345678",
                 "gasUsed": 21000,
             }
         ),
@@ -583,7 +583,7 @@ class TestProcessor:
         wst_tx.version = IbetWSTVersion.V_1
         wst_tx.status = IbetWSTTxStatus.SENT
         wst_tx.tx_hash = self.tx_hash
-        wst_tx.ibet_wst_address = "0x9876543210abcdef1234567890abcdef12345678"
+        wst_tx.ibet_wst_address = "0x9876543210abCDef1234567890AbcDef12345678"
         wst_tx.tx_params = IbetWSTTxParamsAddAccountWhiteList(
             st_account=self.user1["address"],
             sc_account_in=self.user2["address"],
@@ -619,7 +619,7 @@ class TestProcessor:
         assert idx_whitelist is not None
         assert (
             idx_whitelist.ibet_wst_address
-            == "0x9876543210abcdef1234567890abcdef12345678"
+            == "0x9876543210abCDef1234567890AbcDef12345678"
         )
         assert idx_whitelist.st_account_address == self.user1["address"]
         assert idx_whitelist.sc_account_address_in == self.user2["address"]
@@ -641,7 +641,7 @@ class TestProcessor:
             return_value={
                 "status": 1,
                 "blockNumber": 100,
-                "contractAddress": "0x9876543210abcdef1234567890abcdef12345678",
+                "contractAddress": "0x9876543210abCDef1234567890AbcDef12345678",
                 "gasUsed": 21000,
             }
         ),
@@ -686,7 +686,7 @@ class TestProcessor:
         wst_tx.version = IbetWSTVersion.V_1
         wst_tx.status = IbetWSTTxStatus.SENT
         wst_tx.tx_hash = self.tx_hash
-        wst_tx.ibet_wst_address = "0x9876543210abcdef1234567890abcdef12345678"
+        wst_tx.ibet_wst_address = "0x9876543210abCDef1234567890AbcDef12345678"
         wst_tx.tx_params = IbetWSTTxParamsDeleteAccountWhiteList(
             st_account=self.user1["address"],
         )
@@ -743,7 +743,7 @@ class TestProcessor:
             return_value={
                 "status": 1,
                 "blockNumber": 100,
-                "contractAddress": "0x9876543210abcdef1234567890abcdef12345678",
+                "contractAddress": "0x9876543210abCDef1234567890AbcDef12345678",
                 "gasUsed": 21000,
             }
         ),
@@ -761,7 +761,7 @@ class TestProcessor:
                         "index": 1,
                         "sellerSTAccountAddress": user1["address"],
                         "buyerSTAccountAddress": user2["address"],
-                        "SCTokenAddress": "0x876f5c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8g9h",
+                        "SCTokenAddress": "0x876543210abCdEF1234567890AbCdeF123456789",
                         "sellerSCAccountAddress": user1["address"],
                         "buyerSCAccountAddress": user2["address"],
                         "STValue": 1000,
@@ -770,6 +770,10 @@ class TestProcessor:
                 }
             ]
         ),
+    )
+    @mock.patch(
+        "app.model.eth.wst.ERC20.decimals",
+        AsyncMock(return_value=6),
     )
     async def test_normal_4_2_5(self, processor, async_db, caplog):
         tx_id = str(uuid.uuid4())
@@ -795,11 +799,11 @@ class TestProcessor:
         wst_tx.version = IbetWSTVersion.V_1
         wst_tx.status = IbetWSTTxStatus.SENT
         wst_tx.tx_hash = self.tx_hash
-        wst_tx.ibet_wst_address = "0x9876543210abcdef1234567890abcdef12345678"
+        wst_tx.ibet_wst_address = "0x9876543210abCDef1234567890AbcDef12345678"
         wst_tx.tx_params = IbetWSTTxParamsRequestTrade(
             seller_st_account=self.user1["address"],
             buyer_st_account=self.user2["address"],
-            sc_token_address="0x876f5c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8g9h",
+            sc_token_address="0x876543210abCdEF1234567890AbCdeF123456789",
             st_value=1000,
             sc_value=2000,
             memo="Test trade request",
@@ -827,11 +831,12 @@ class TestProcessor:
             "index": 1,
             "seller_st_account_address": self.user1["address"],
             "buyer_st_account_address": self.user2["address"],
-            "sc_token_address": "0x876f5c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8g9h",
+            "sc_token_address": "0x876543210abCdEF1234567890AbCdeF123456789",
             "seller_sc_account_address": self.user1["address"],
             "buyer_sc_account_address": self.user2["address"],
             "st_value": 1000,
             "sc_value": 2000,
+            "sc_decimals": 6,
         }
 
         assert caplog.messages == [
@@ -850,7 +855,7 @@ class TestProcessor:
             return_value={
                 "status": 1,
                 "blockNumber": 100,
-                "contractAddress": "0x9876543210abcdef1234567890abcdef12345678",
+                "contractAddress": "0x9876543210abCDef1234567890AbcDef12345678",
                 "gasUsed": 21000,
             }
         ),
@@ -868,7 +873,7 @@ class TestProcessor:
                         "index": 1,
                         "sellerSTAccountAddress": user1["address"],
                         "buyerSTAccountAddress": user2["address"],
-                        "SCTokenAddress": "0x876f5c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8g9h",
+                        "SCTokenAddress": "0x876543210abCdEF1234567890AbCdeF123456789",
                         "sellerSCAccountAddress": user1["address"],
                         "buyerSCAccountAddress": user2["address"],
                         "STValue": 1000,
@@ -877,6 +882,10 @@ class TestProcessor:
                 }
             ]
         ),
+    )
+    @mock.patch(
+        "app.model.eth.wst.ERC20.decimals",
+        AsyncMock(return_value=6),
     )
     async def test_normal_4_2_6(self, processor, async_db, caplog):
         tx_id = str(uuid.uuid4())
@@ -902,7 +911,7 @@ class TestProcessor:
         wst_tx.version = IbetWSTVersion.V_1
         wst_tx.status = IbetWSTTxStatus.SENT
         wst_tx.tx_hash = self.tx_hash
-        wst_tx.ibet_wst_address = "0x9876543210abcdef1234567890abcdef12345678"
+        wst_tx.ibet_wst_address = "0x9876543210abCDef1234567890AbcDef12345678"
         wst_tx.tx_params = IbetWSTTxParamsCancelTrade(index=1)
         wst_tx.tx_sender = self.eth_master["address"]
         wst_tx.finalized = False
@@ -927,11 +936,12 @@ class TestProcessor:
             "index": 1,
             "seller_st_account_address": self.user1["address"],
             "buyer_st_account_address": self.user2["address"],
-            "sc_token_address": "0x876f5c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8g9h",
+            "sc_token_address": "0x876543210abCdEF1234567890AbCdeF123456789",
             "seller_sc_account_address": self.user1["address"],
             "buyer_sc_account_address": self.user2["address"],
             "st_value": 1000,
             "sc_value": 2000,
+            "sc_decimals": 6,
         }
 
         assert caplog.messages == [
@@ -950,7 +960,7 @@ class TestProcessor:
             return_value={
                 "status": 1,
                 "blockNumber": 100,
-                "contractAddress": "0x9876543210abcdef1234567890abcdef12345678",
+                "contractAddress": "0x9876543210abCDef1234567890AbcDef12345678",
                 "gasUsed": 21000,
             }
         ),
@@ -968,7 +978,7 @@ class TestProcessor:
                         "index": 1,
                         "sellerSTAccountAddress": user1["address"],
                         "buyerSTAccountAddress": user2["address"],
-                        "SCTokenAddress": "0x876f5c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8g9h",
+                        "SCTokenAddress": "0x876543210abCdEF1234567890AbCdeF123456789",
                         "sellerSCAccountAddress": user1["address"],
                         "buyerSCAccountAddress": user2["address"],
                         "STValue": 1000,
@@ -977,6 +987,10 @@ class TestProcessor:
                 }
             ]
         ),
+    )
+    @mock.patch(
+        "app.model.eth.wst.ERC20.decimals",
+        AsyncMock(return_value=6),
     )
     async def test_normal_4_2_7(self, processor, async_db, caplog):
         tx_id = str(uuid.uuid4())
@@ -1002,7 +1016,7 @@ class TestProcessor:
         wst_tx.version = IbetWSTVersion.V_1
         wst_tx.status = IbetWSTTxStatus.SENT
         wst_tx.tx_hash = self.tx_hash
-        wst_tx.ibet_wst_address = "0x9876543210abcdef1234567890abcdef12345678"
+        wst_tx.ibet_wst_address = "0x9876543210abCDef1234567890AbcDef12345678"
         wst_tx.tx_params = IbetWSTTxParamsAcceptTrade(index=1)
         wst_tx.tx_sender = self.eth_master["address"]
         wst_tx.finalized = False
@@ -1027,11 +1041,12 @@ class TestProcessor:
             "index": 1,
             "seller_st_account_address": self.user1["address"],
             "buyer_st_account_address": self.user2["address"],
-            "sc_token_address": "0x876f5c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8g9h",
+            "sc_token_address": "0x876543210abCdEF1234567890AbCdeF123456789",
             "seller_sc_account_address": self.user1["address"],
             "buyer_sc_account_address": self.user2["address"],
             "st_value": 1000,
             "sc_value": 2000,
+            "sc_decimals": 6,
         }
 
         assert caplog.messages == [
@@ -1050,7 +1065,7 @@ class TestProcessor:
             return_value={
                 "status": 1,
                 "blockNumber": 100,
-                "contractAddress": "0x9876543210abcdef1234567890abcdef12345678",
+                "contractAddress": "0x9876543210abCDef1234567890AbcDef12345678",
                 "gasUsed": 21000,
             }
         ),
@@ -1068,7 +1083,7 @@ class TestProcessor:
                         "index": 1,
                         "sellerSTAccountAddress": user1["address"],
                         "buyerSTAccountAddress": user2["address"],
-                        "SCTokenAddress": "0x876f5c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8g9h",
+                        "SCTokenAddress": "0x876543210abCdEF1234567890AbCdeF123456789",
                         "sellerSCAccountAddress": user1["address"],
                         "buyerSCAccountAddress": user2["address"],
                         "STValue": 1000,
@@ -1077,6 +1092,10 @@ class TestProcessor:
                 }
             ]
         ),
+    )
+    @mock.patch(
+        "app.model.eth.wst.ERC20.decimals",
+        AsyncMock(return_value=6),
     )
     async def test_normal_4_2_8(self, processor, async_db, caplog):
         tx_id = str(uuid.uuid4())
@@ -1102,7 +1121,7 @@ class TestProcessor:
         wst_tx.version = IbetWSTVersion.V_1
         wst_tx.status = IbetWSTTxStatus.SENT
         wst_tx.tx_hash = self.tx_hash
-        wst_tx.ibet_wst_address = "0x9876543210abcdef1234567890abcdef12345678"
+        wst_tx.ibet_wst_address = "0x9876543210abCDef1234567890AbcDef12345678"
         wst_tx.tx_params = IbetWSTTxParamsRejectTrade(index=1)
         wst_tx.tx_sender = self.eth_master["address"]
         wst_tx.finalized = False
@@ -1127,11 +1146,12 @@ class TestProcessor:
             "index": 1,
             "seller_st_account_address": self.user1["address"],
             "buyer_st_account_address": self.user2["address"],
-            "sc_token_address": "0x876f5c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8g9h",
+            "sc_token_address": "0x876543210abCdEF1234567890AbCdeF123456789",
             "seller_sc_account_address": self.user1["address"],
             "buyer_sc_account_address": self.user2["address"],
             "st_value": 1000,
             "sc_value": 2000,
+            "sc_decimals": 6,
         }
 
         assert caplog.messages == [
@@ -1150,7 +1170,7 @@ class TestProcessor:
             return_value={
                 "status": 1,
                 "blockNumber": 100,
-                "contractAddress": "0x9876543210abcdef1234567890abcdef12345678",
+                "contractAddress": "0x9876543210abCDef1234567890AbcDef12345678",
                 "gasUsed": 21000,
             }
         ),
@@ -1197,7 +1217,7 @@ class TestProcessor:
         wst_tx.version = IbetWSTVersion.V_1
         wst_tx.status = IbetWSTTxStatus.SENT
         wst_tx.tx_hash = self.tx_hash
-        wst_tx.ibet_wst_address = "0x9876543210abcdef1234567890abcdef12345678"
+        wst_tx.ibet_wst_address = "0x9876543210abCDef1234567890AbcDef12345678"
         wst_tx.tx_params = IbetWSTTxParamsTransfer(
             from_address=self.user1["address"],
             to_address=self.user2["address"],
@@ -1246,7 +1266,7 @@ class TestProcessor:
             return_value={
                 "status": 1,
                 "blockNumber": 100,
-                "contractAddress": "0x9876543210abcdef1234567890abcdef12345678",
+                "contractAddress": "0x9876543210abCDef1234567890AbcDef12345678",
                 "gasUsed": 21000,
             }
         ),
@@ -1292,7 +1312,7 @@ class TestProcessor:
         wst_tx.version = IbetWSTVersion.V_1
         wst_tx.status = IbetWSTTxStatus.SENT
         wst_tx.tx_hash = self.tx_hash
-        wst_tx.ibet_wst_address = "0x9876543210abcdef1234567890abcdef12345678"
+        wst_tx.ibet_wst_address = "0x9876543210abCDef1234567890AbcDef12345678"
         wst_tx.tx_params = IbetWSTTxParamsForceBurn(
             account=self.user1["address"],
             value=1000,
@@ -1338,7 +1358,7 @@ class TestProcessor:
                 {
                     "status": 1,
                     "blockNumber": 100,
-                    "contractAddress": "0x9876543210abcdef1234567890abcdef12345678",
+                    "contractAddress": "0x9876543210abCDef1234567890AbcDef12345678",
                     "gasUsed": 21000,
                 },  # Successful receipt for the second call
             ]


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

This pull request enhances support for StableCoin (SC) token decimals in IbetWST trade-related transactions. It ensures that SC values are accurately represented and displayed according to their decimals, improving both backend data integrity and API responses.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- Related to #812 

## 🔄 Changes

<!-- List the major changes in this PR. -->

**StableCoin decimals support and display:**

- Added a `sc_decimals` field to all IbetWST trade event log TypedDicts (`IbetWSTEventLogTradeRequested`, `IbetWSTEventLogTradeCancelled`, `IbetWSTEventLogTradeAccepted`, `IbetWSTEventLogTradeRejected`) to store the decimals of the StableCoin token. [[1]](diffhunk://#diff-4fb31064e27d1d13f8685fa2c590e7e948d17b388c95fb1f8e616615497e52fbR194) [[2]](diffhunk://#diff-4fb31064e27d1d13f8685fa2c590e7e948d17b388c95fb1f8e616615497e52fbR208) [[3]](diffhunk://#diff-4fb31064e27d1d13f8685fa2c590e7e948d17b388c95fb1f8e616615497e52fbR222) [[4]](diffhunk://#diff-4fb31064e27d1d13f8685fa2c590e7e948d17b388c95fb1f8e616615497e52fbR236)
- Updated the batch processor (`processor_eth_wst_monitor_txreceipt.py`) to fetch and store the SC token decimals using the new `ERC20.decimals()` async method for all trade-related events. [[1]](diffhunk://#diff-7711bbe44883be877362b4127aa3ba17ea790fe9c2cca884155238913e8ce7bcL50-R50) [[2]](diffhunk://#diff-7711bbe44883be877362b4127aa3ba17ea790fe9c2cca884155238913e8ce7bcR290) [[3]](diffhunk://#diff-7711bbe44883be877362b4127aa3ba17ea790fe9c2cca884155238913e8ce7bcR304) [[4]](diffhunk://#diff-7711bbe44883be877362b4127aa3ba17ea790fe9c2cca884155238913e8ce7bcR315) [[5]](diffhunk://#diff-7711bbe44883be877362b4127aa3ba17ea790fe9c2cca884155238913e8ce7bcR329) [[6]](diffhunk://#diff-7711bbe44883be877362b4127aa3ba17ea790fe9c2cca884155238913e8ce7bcR340) [[7]](diffhunk://#diff-7711bbe44883be877362b4127aa3ba17ea790fe9c2cca884155238913e8ce7bcR354) [[8]](diffhunk://#diff-7711bbe44883be877362b4127aa3ba17ea790fe9c2cca884155238913e8ce7bcR365) [[9]](diffhunk://#diff-7711bbe44883be877362b4127aa3ba17ea790fe9c2cca884155238913e8ce7bcR379)

**API and schema enhancements:**

- Modified the API response logic for listing and retrieving IbetWST transactions to include `sc_decimals` and a new `display_sc_value` (human-readable SC value considering decimals) in the event log for trade-related transactions. [[1]](diffhunk://#diff-5f30c7009cfc64532aa4bab8d802cd4bd1f229a48d83bf105b2e22d68d609607R361-R386) [[2]](diffhunk://#diff-5f30c7009cfc64532aa4bab8d802cd4bd1f229a48d83bf105b2e22d68d609607L378-R399) [[3]](diffhunk://#diff-5f30c7009cfc64532aa4bab8d802cd4bd1f229a48d83bf105b2e22d68d609607L420-R463)

**ERC20 contract utilities:**

- Added an async `decimals()` method to the `ERC20` contract class to retrieve the decimals of any ERC20 token, defaulting to 18 if unavailable.

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
