### PR TITLE
Fix event log handling for trade-related transactions by adding null check for event_log

### DIFF
--- a/app/model/db/ibet_wst.py
+++ b/app/model/db/ibet_wst.py
@@ -310,7 +310,7 @@ class EthIbetWSTTx(Base):
     finalized: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     # Event log of the transaction
     # - Set if the transaction emits events and the block is finalized
-    # - Not set if the tx_tye is "DEPLOY"
+    # - Not set if the tx_type is "DEPLOY"
     event_log: Mapped[
         IbetWSTEventLogMint
         | IbetWSTEventLogBurn

--- a/app/routers/misc/ibet_wst.py
+++ b/app/routers/misc/ibet_wst.py
@@ -360,20 +360,21 @@ async def list_ibet_wst_transactions(
     for wst_tx in wst_txs:
         # Set event_log
         event_log = wst_tx.event_log
-        if wst_tx.tx_type in [
-            IbetWSTTxType.REQUEST_TRADE,
-            IbetWSTTxType.CANCEL_TRADE,
-            IbetWSTTxType.ACCEPT_TRADE,
-            IbetWSTTxType.REJECT_TRADE,
-        ]:
-            # For trade-related transactions, set additional event_log fields
-            sc_value = wst_tx.event_log.get("sc_value", 0)
-            sc_decimals = wst_tx.event_log.get("sc_decimals", 6)
-            event_log["sc_value"] = sc_value
-            event_log["sc_decimals"] = sc_decimals
-            event_log["display_sc_value"] = str(
-                Decimal(str(sc_value)) / Decimal(str(10**sc_decimals))
-            )
+        if event_log is not None:
+            if wst_tx.tx_type in [
+                IbetWSTTxType.REQUEST_TRADE,
+                IbetWSTTxType.CANCEL_TRADE,
+                IbetWSTTxType.ACCEPT_TRADE,
+                IbetWSTTxType.REJECT_TRADE,
+            ]:
+                # For trade-related transactions, set additional event_log fields
+                sc_value = wst_tx.event_log.get("sc_value", 0)
+                sc_decimals = wst_tx.event_log.get("sc_decimals", 6)
+                event_log["sc_value"] = sc_value
+                event_log["sc_decimals"] = sc_decimals
+                event_log["display_sc_value"] = str(
+                    Decimal(str(sc_value)) / Decimal(str(10**sc_decimals))
+                )
 
         # Set created datetime
         _created_datetime = (
@@ -440,20 +441,21 @@ async def get_ibet_wst_transaction(
 
     # Set event_log
     event_log = wst_tx.event_log
-    if wst_tx.tx_type in [
-        IbetWSTTxType.REQUEST_TRADE,
-        IbetWSTTxType.CANCEL_TRADE,
-        IbetWSTTxType.ACCEPT_TRADE,
-        IbetWSTTxType.REJECT_TRADE,
-    ]:
-        # For trade-related transactions, set additional event_log fields
-        sc_value = wst_tx.event_log.get("sc_value", 0)
-        sc_decimals = wst_tx.event_log.get("sc_decimals", 6)
-        event_log["sc_value"] = sc_value
-        event_log["sc_decimals"] = sc_decimals
-        event_log["display_sc_value"] = str(
-            Decimal(str(sc_value)) / Decimal(str(10**sc_decimals))
-        )
+    if event_log is not None:
+        if wst_tx.tx_type in [
+            IbetWSTTxType.REQUEST_TRADE,
+            IbetWSTTxType.CANCEL_TRADE,
+            IbetWSTTxType.ACCEPT_TRADE,
+            IbetWSTTxType.REJECT_TRADE,
+        ]:
+            # For trade-related transactions, set additional event_log fields
+            sc_value = wst_tx.event_log.get("sc_value", 0)
+            sc_decimals = wst_tx.event_log.get("sc_decimals", 6)
+            event_log["sc_value"] = sc_value
+            event_log["sc_decimals"] = sc_decimals
+            event_log["display_sc_value"] = str(
+                Decimal(str(sc_value)) / Decimal(str(10**sc_decimals))
+            )
 
     # Set created datetime
     _created_datetime = (


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

This pull request introduces a small fix and a minor logic update related to handling event logs in ibet WST transactions. The main changes ensure that event log processing only occurs when an event log is present, preventing potential errors.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- Fix #892 

## 🔄 Changes

<!-- List the major changes in this PR. -->

Event log handling improvements:

* Added checks to ensure that event log processing in both `list_ibet_wst_transactions` and `get_ibet_wst_transaction` only occurs if the `event_log` is not `None`, improving robustness. [[1]](diffhunk://#diff-5f30c7009cfc64532aa4bab8d802cd4bd1f229a48d83bf105b2e22d68d609607R363) [[2]](diffhunk://#diff-5f30c7009cfc64532aa4bab8d802cd4bd1f229a48d83bf105b2e22d68d609607R444)

Minor typo fix:

* Corrected a comment typo in the `EthIbetWSTTx` class, changing `tx_tye` to `tx_type` for clarity.

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
