### PR TITLE
Refactor AccountAuthTokenRequest schema

### DIFF
--- a/app/model/schema/account.py
+++ b/app/model/schema/account.py
@@ -126,11 +126,9 @@ class AccountChangeRSAPassphraseRequest(BaseModel):
 
 
 class AccountAuthTokenRequest(BaseModel):
-    """Account Create Auth Token schema (REQUEST)"""
+    """Generate Account Auth Token schema (REQUEST)"""
 
-    valid_duration: int = Field(
-        None, ge=0, le=259200
-    )  # The maximum valid duration shall be 3 days.
+    valid_duration: int = Field(None, ge=0, description="Valid duration (seconds)")
 
 
 class CreateUpdateChildAccountRequest(BaseModel):

--- a/docs/ibet_prime.yaml
+++ b/docs/ibet_prime.yaml
@@ -11696,12 +11696,12 @@ components:
       properties:
         valid_duration:
           type: integer
-          maximum: 259200.0
           minimum: 0.0
           title: Valid Duration
+          description: Valid duration (seconds)
       type: object
       title: AccountAuthTokenRequest
-      description: Account Create Auth Token schema (REQUEST)
+      description: Generate Account Auth Token schema (REQUEST)
     AccountAuthTokenResponse:
       properties:
         auth_token:


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

This pull request updates the validation logic for the `valid_duration` field in the account authentication token request, removing the upper limit restriction.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- Close #908 

## 🔄 Changes

<!-- List the major changes in this PR. -->

**Validation and schema changes:**

* The maximum value restriction (`le=259200`) for the `valid_duration` field in the `AccountAuthTokenRequest` model (`account.py`) has been removed, allowing any non-negative integer value. The field description is also updated.
* The OpenAPI specification (`ibet_prime.yaml`) is updated: the maximum value for `valid_duration` is removed, and the description and schema title are updated to match the code.

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
