### PR TITLE
Set boto3 and botocore log level to WARNING

### DIFF
--- a/app/log.py
+++ b/app/log.py
@@ -39,6 +39,8 @@ logging.getLogger("web3.manager.RequestManager").addHandler(logging.NullHandler(
 logging.getLogger("pyroscope").setLevel(logging.ERROR)
 logging.getLogger("py_spy").setLevel(logging.ERROR)
 logging.getLogger("opentelemetry").setLevel(logging.ERROR)
+logging.getLogger("boto3").setLevel(logging.WARNING)
+logging.getLogger("botocore").setLevel(logging.WARNING)
 
 INFO_FORMAT = "[%(asctime)s] {}[%(process)d] [%(levelname)s] %(message)s"
 DEBUG_FORMAT = "[%(asctime)s] {}[%(process)d] [%(levelname)s] %(message)s [in %(pathname)s:%(lineno)d]"

--- a/batch/utils/batch_log.py
+++ b/batch/utils/batch_log.py
@@ -28,6 +28,8 @@ def get_logger(process_name: str = None):
     logging.getLogger("pyroscope").setLevel(logging.ERROR)
     logging.getLogger("py_spy").setLevel(logging.ERROR)
     logging.getLogger("opentelemetry").setLevel(logging.ERROR)
+    logging.getLogger("boto3").setLevel(logging.WARNING)
+    logging.getLogger("botocore").setLevel(logging.WARNING)
 
     LOG_FORMAT = (
         f"[%(asctime)s] [{process_name}] [%(process)d] [%(levelname)s] %(message)s"


### PR DESCRIPTION
This pull request updates logging configurations to reduce noise from AWS SDK libraries in both the main application and batch logging utilities. 

## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- Close #915

## 🔄 Changes

<!-- List the major changes in this PR. -->


Logging configuration improvements:

* Set the log level for the `boto3` logger to `WARNING` in `app/log.py`, reducing unnecessary informational and debug logs from the AWS SDK.
* Set the log level for the `botocore` logger to `WARNING` in `app/log.py`, further minimizing verbose output from AWS SDK dependencies.
* Applied the same log level settings for both `boto3` and `botocore` loggers in the `get_logger` function in `batch/utils/batch_log.py`, ensuring consistent log verbosity across batch processing utilities.

## 📌 Checklist

- [ ] I have added tests where necessary.
- [ ] I have updated the documentation where necessary.
