### PR TITLE
Add ibet_wst_name field and validation for IbetWST activation

### DIFF
--- a/app/model/db/token.py
+++ b/app/model/db/token.py
@@ -84,6 +84,8 @@ class Token(Base):
     ibet_wst_deployed: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
     # IbetWST contract address
     ibet_wst_address: Mapped[str | None] = mapped_column(String(42), nullable=True)
+    # IbetWST name
+    ibet_wst_name: Mapped[str | None] = mapped_column(String(100), nullable=True)
 
 
 class TokenAttrUpdate(Base):

--- a/app/model/schema/token.py
+++ b/app/model/schema/token.py
@@ -88,7 +88,7 @@ class IbetStraightBondCreate(BaseModel):
     activate_ibet_wst: Optional[Literal[True]] = Field(
         default=None, description="Activate IbetWST"
     )
-    wst_name: Optional[str] = Field(
+    ibet_wst_name: Optional[str] = Field(
         default=None, max_length=100, description="IbetWST name"
     )
 
@@ -127,10 +127,12 @@ class IbetStraightBondCreate(BaseModel):
 
     @model_validator(mode="after")
     @classmethod
-    def wst_name_required_if_activated(cls, v: Self):
+    def ibet_wst_name_required_if_activated(cls, v: Self):
         if v.activate_ibet_wst:
-            if v.wst_name is None:
-                raise ValueError("wst_name is required when activate_ibet_wst is true")
+            if v.ibet_wst_name is None:
+                raise ValueError(
+                    "ibet_wst_name is required when activate_ibet_wst is true"
+                )
         return v
 
 
@@ -162,7 +164,7 @@ class IbetStraightBondUpdate(BaseModel):
     activate_ibet_wst: Optional[Literal[True]] = Field(
         default=None, description="Activate IbetWST"
     )
-    wst_name: Optional[str] = Field(
+    ibet_wst_name: Optional[str] = Field(
         default=None, max_length=100, description="IbetWST name"
     )
 
@@ -206,10 +208,12 @@ class IbetStraightBondUpdate(BaseModel):
 
     @model_validator(mode="after")
     @classmethod
-    def wst_name_required_if_activated(cls, v: Self):
+    def ibet_wst_name_required_if_activated(cls, v: Self):
         if v.activate_ibet_wst:
-            if v.wst_name is None:
-                raise ValueError("wst_name is required when activate_ibet_wst is true")
+            if v.ibet_wst_name is None:
+                raise ValueError(
+                    "ibet_wst_name is required when activate_ibet_wst is true"
+                )
         return v
 
 
@@ -262,7 +266,7 @@ class IbetShareCreate(BaseModel):
     activate_ibet_wst: Optional[Literal[True]] = Field(
         default=None, description="Activate IbetWST"
     )
-    wst_name: Optional[str] = Field(
+    ibet_wst_name: Optional[str] = Field(
         default=None, max_length=100, description="IbetWST name"
     )
 
@@ -278,10 +282,12 @@ class IbetShareCreate(BaseModel):
 
     @model_validator(mode="after")
     @classmethod
-    def wst_name_required_if_activated(cls, v: Self):
+    def ibet_wst_name_required_if_activated(cls, v: Self):
         if v.activate_ibet_wst:
-            if v.wst_name is None:
-                raise ValueError("wst_name is required when activate_ibet_wst is true")
+            if v.ibet_wst_name is None:
+                raise ValueError(
+                    "ibet_wst_name is required when activate_ibet_wst is true"
+                )
         return v
 
 
@@ -308,7 +314,7 @@ class IbetShareUpdate(BaseModel):
     activate_ibet_wst: Optional[Literal[True]] = Field(
         default=None, description="Activate IbetWST"
     )
-    wst_name: Optional[str] = Field(
+    ibet_wst_name: Optional[str] = Field(
         default=None, max_length=100, description="IbetWST name"
     )
 
@@ -341,10 +347,12 @@ class IbetShareUpdate(BaseModel):
 
     @model_validator(mode="after")
     @classmethod
-    def wst_name_required_if_activated(cls, v: Self):
+    def ibet_wst_name_required_if_activated(cls, v: Self):
         if v.activate_ibet_wst:
-            if v.wst_name is None:
-                raise ValueError("wst_name is required when activate_ibet_wst is true")
+            if v.ibet_wst_name is None:
+                raise ValueError(
+                    "ibet_wst_name is required when activate_ibet_wst is true"
+                )
         return v
 
 
@@ -590,6 +598,7 @@ class IbetStraightBondResponse(IbetStraightBond):
     ibet_wst_version: Optional[str] = Field(..., description="IbetWST version")
     ibet_wst_deployed: bool = Field(..., description="IbetWST deployed")
     ibet_wst_address: Optional[str] = Field(..., description="IbetWST contract address")
+    ibet_wst_name: Optional[str] = Field(..., description="IbetWST name")
 
 
 class IbetShareResponse(IbetShare):
@@ -604,6 +613,7 @@ class IbetShareResponse(IbetShare):
     ibet_wst_version: Optional[str] = Field(..., description="IbetWST version")
     ibet_wst_deployed: bool = Field(..., description="IbetWST deployed")
     ibet_wst_address: Optional[str] = Field(..., description="IbetWST contract address")
+    ibet_wst_name: Optional[str] = Field(..., description="IbetWST name")
 
 
 class TokenOperationLogResponse(BaseModel):

--- a/app/routers/issuer/bond.py
+++ b/app/routers/issuer/bond.py
@@ -365,6 +365,7 @@ async def issue_bond_token(
         _token.ibet_wst_activated = True
         _token.ibet_wst_version = IbetWSTVersion.V_1
         _token.ibet_wst_tx_id = tx_id
+        _token.ibet_wst_name = token.ibet_wst_name
         # Register IbetWST transaction
         _ibet_wst_tx = EthIbetWSTTx()
         _ibet_wst_tx.tx_id = tx_id
@@ -372,7 +373,7 @@ async def issue_bond_token(
         _ibet_wst_tx.version = IbetWSTVersion.V_1
         _ibet_wst_tx.status = IbetWSTTxStatus.PENDING
         _ibet_wst_tx.tx_params = IbetWSTTxParamsDeploy(
-            name=token.wst_name, initial_owner=issuer_address
+            name=token.ibet_wst_name, initial_owner=issuer_address
         )
         _ibet_wst_tx.tx_sender = ETH_MASTER_ACCOUNT_ADDRESS
         db.add(_ibet_wst_tx)
@@ -455,6 +456,7 @@ async def list_all_bond_tokens(
         bond_token["ibet_wst_version"] = token.ibet_wst_version
         bond_token["ibet_wst_deployed"] = True if token.ibet_wst_deployed else False
         bond_token["ibet_wst_address"] = token.ibet_wst_address
+        bond_token["ibet_wst_name"] = token.ibet_wst_name
 
         bond_tokens.append(bond_token)
 
@@ -505,6 +507,7 @@ async def retrieve_bond_token(
     bond_token["ibet_wst_version"] = _token.ibet_wst_version
     bond_token["ibet_wst_deployed"] = True if _token.ibet_wst_deployed else False
     bond_token["ibet_wst_address"] = _token.ibet_wst_address
+    bond_token["ibet_wst_name"] = _token.ibet_wst_name
 
     return json_response(bond_token)
 
@@ -648,6 +651,7 @@ async def update_bond_token(
         _token.ibet_wst_activated = True
         _token.ibet_wst_version = IbetWSTVersion.V_1
         _token.ibet_wst_tx_id = tx_id
+        _token.ibet_wst_name = update_data.ibet_wst_name
 
         # Register IbetWST transaction
         _ibet_wst_tx = EthIbetWSTTx()
@@ -656,7 +660,7 @@ async def update_bond_token(
         _ibet_wst_tx.version = IbetWSTVersion.V_1
         _ibet_wst_tx.status = IbetWSTTxStatus.PENDING
         _ibet_wst_tx.tx_params = IbetWSTTxParamsDeploy(
-            name=update_data.wst_name, initial_owner=issuer_address
+            name=update_data.ibet_wst_name, initial_owner=issuer_address
         )
         _ibet_wst_tx.tx_sender = ETH_MASTER_ACCOUNT_ADDRESS
         db.add(_ibet_wst_tx)

--- a/app/routers/issuer/share.py
+++ b/app/routers/issuer/share.py
@@ -357,6 +357,7 @@ async def issue_share_token(
         _token.ibet_wst_activated = True
         _token.ibet_wst_version = IbetWSTVersion.V_1
         _token.ibet_wst_tx_id = tx_id
+        _token.ibet_wst_name = token.ibet_wst_name
         # Register IbetWST transaction
         _ibet_wst_tx = EthIbetWSTTx()
         _ibet_wst_tx.tx_id = tx_id
@@ -364,7 +365,7 @@ async def issue_share_token(
         _ibet_wst_tx.version = IbetWSTVersion.V_1
         _ibet_wst_tx.status = IbetWSTTxStatus.PENDING
         _ibet_wst_tx.tx_params = IbetWSTTxParamsDeploy(
-            name=token.wst_name, initial_owner=issuer_address
+            name=token.ibet_wst_name, initial_owner=issuer_address
         )
         _ibet_wst_tx.tx_sender = ETH_MASTER_ACCOUNT_ADDRESS
         db.add(_ibet_wst_tx)
@@ -439,6 +440,7 @@ async def list_all_share_tokens(
         share_token["ibet_wst_version"] = token.ibet_wst_version
         share_token["ibet_wst_deployed"] = True if token.ibet_wst_deployed else False
         share_token["ibet_wst_address"] = token.ibet_wst_address
+        share_token["ibet_wst_name"] = token.ibet_wst_name
 
         share_tokens.append(share_token)
 
@@ -489,6 +491,7 @@ async def retrieve_share_token(
     share_token["ibet_wst_version"] = _token.ibet_wst_version
     share_token["ibet_wst_deployed"] = True if _token.ibet_wst_deployed else False
     share_token["ibet_wst_address"] = _token.ibet_wst_address
+    share_token["ibet_wst_name"] = _token.ibet_wst_name
 
     return json_response(share_token)
 
@@ -610,6 +613,7 @@ async def update_share_token(
         _token.ibet_wst_activated = True
         _token.ibet_wst_version = IbetWSTVersion.V_1
         _token.ibet_wst_tx_id = tx_id
+        _token.ibet_wst_name = update_data.ibet_wst_name
 
         # Register IbetWST transaction
         _ibet_wst_tx = EthIbetWSTTx()
@@ -618,7 +622,7 @@ async def update_share_token(
         _ibet_wst_tx.version = IbetWSTVersion.V_1
         _ibet_wst_tx.status = IbetWSTTxStatus.PENDING
         _ibet_wst_tx.tx_params = IbetWSTTxParamsDeploy(
-            name=update_data.wst_name, initial_owner=issuer_address
+            name=update_data.ibet_wst_name, initial_owner=issuer_address
         )
         _ibet_wst_tx.tx_sender = ETH_MASTER_ACCOUNT_ADDRESS
         db.add(_ibet_wst_tx)

--- a/docs/ibet_prime.yaml
+++ b/docs/ibet_prime.yaml
@@ -14576,12 +14576,12 @@ components:
             - type: 'null'
           title: Activate Ibet Wst
           description: Activate IbetWST
-        wst_name:
+        ibet_wst_name:
           anyOf:
             - type: string
               maxLength: 100
             - type: 'null'
-          title: Wst Name
+          title: Ibet Wst Name
           description: IbetWST name
       type: object
       required:
@@ -14707,6 +14707,12 @@ components:
             - type: 'null'
           title: Ibet Wst Address
           description: IbetWST contract address
+        ibet_wst_name:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Ibet Wst Name
+          description: IbetWST name
       type: object
       required:
         - issuer_address
@@ -14738,6 +14744,7 @@ components:
         - ibet_wst_version
         - ibet_wst_deployed
         - ibet_wst_address
+        - ibet_wst_name
       title: IbetShareResponse
       description: ibet Share schema (Response)
     IbetShareScheduledUpdate:
@@ -14993,12 +15000,12 @@ components:
             - type: 'null'
           title: Activate Ibet Wst
           description: Activate IbetWST
-        wst_name:
+        ibet_wst_name:
           anyOf:
             - type: string
               maxLength: 100
             - type: 'null'
-          title: Wst Name
+          title: Ibet Wst Name
           description: IbetWST name
       type: object
       title: IbetShareUpdate
@@ -15322,12 +15329,12 @@ components:
             - type: 'null'
           title: Activate Ibet Wst
           description: Activate IbetWST
-        wst_name:
+        ibet_wst_name:
           anyOf:
             - type: string
               maxLength: 100
             - type: 'null'
-          title: Wst Name
+          title: Ibet Wst Name
           description: IbetWST name
       type: object
       required:
@@ -15474,6 +15481,12 @@ components:
             - type: 'null'
           title: Ibet Wst Address
           description: IbetWST contract address
+        ibet_wst_name:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Ibet Wst Name
+          description: IbetWST name
       type: object
       required:
         - issuer_address
@@ -15511,6 +15524,7 @@ components:
         - ibet_wst_version
         - ibet_wst_deployed
         - ibet_wst_address
+        - ibet_wst_name
       title: IbetStraightBondResponse
       description: ibet Straight Bond schema (Response)
     IbetStraightBondScheduledUpdate:
@@ -15834,12 +15848,12 @@ components:
             - type: 'null'
           title: Activate Ibet Wst
           description: Activate IbetWST
-        wst_name:
+        ibet_wst_name:
           anyOf:
             - type: string
               maxLength: 100
             - type: 'null'
-          title: Wst Name
+          title: Ibet Wst Name
           description: IbetWST name
       type: object
       title: IbetStraightBondUpdate

--- a/migrations/versions/39661c5c4bac_v25_12_0_feature_927.py
+++ b/migrations/versions/39661c5c4bac_v25_12_0_feature_927.py
@@ -1,0 +1,31 @@
+"""v25_12_0_feature_927
+
+Revision ID: 39661c5c4bac
+Revises: 2057c79e5849
+Create Date: 2025-11-18 22:11:51.898937
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+from app.database import get_db_schema
+
+# revision identifiers, used by Alembic.
+revision = "39661c5c4bac"
+down_revision = "2057c79e5849"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "token",
+        sa.Column("ibet_wst_name", sa.String(length=100), nullable=True),
+        schema=get_db_schema(),
+    )
+
+
+def downgrade():
+    op.drop_column("token", "ibet_wst_name", schema=get_db_schema())

--- a/tests/app/test_bond_tokens_IssueBondToken.py
+++ b/tests/app/test_bond_tokens_IssueBondToken.py
@@ -177,6 +177,7 @@ class TestIssueBondToken:
             assert token_1.version == TokenVersion.V_25_09
             assert token_1.ibet_wst_activated is None
             assert token_1.ibet_wst_version is None
+            assert token_1.ibet_wst_name is None
 
             position = (await async_db.scalars(select(IDXPosition).limit(1))).first()
             assert position.token_address == "contract_address_test1"
@@ -274,7 +275,7 @@ class TestIssueBondToken:
                 "privacy_policy": "privacy policy test",  # update
                 "transfer_approval_required": True,  # update
                 "activate_ibet_wst": None,
-                "wst_name": None,
+                "ibet_wst_name": None,
             }
             resp = await async_client.post(
                 self.apiurl,
@@ -329,6 +330,7 @@ class TestIssueBondToken:
             assert token_1.version == TokenVersion.V_25_09
             assert token_1.ibet_wst_activated is None
             assert token_1.ibet_wst_version is None
+            assert token_1.ibet_wst_name is None
 
             position = (await async_db.scalars(select(IDXPosition).limit(1))).first()
             assert position is None
@@ -469,6 +471,7 @@ class TestIssueBondToken:
             assert token_1.version == TokenVersion.V_25_09
             assert token_1.ibet_wst_activated is None
             assert token_1.ibet_wst_version is None
+            assert token_1.ibet_wst_name is None
 
             position = (await async_db.scalars(select(IDXPosition).limit(1))).first()
             assert position.token_address == "contract_address_test1"
@@ -557,7 +560,7 @@ class TestIssueBondToken:
                 "redemption_value_currency": "JPY",
                 "purpose": "purpose_test1",
                 "activate_ibet_wst": True,  # Activate IbetWST
-                "wst_name": "wst_name_test1",
+                "ibet_wst_name": "ibet_wst_name_test1",
             }
             resp = await async_client.post(
                 self.apiurl,
@@ -618,6 +621,7 @@ class TestIssueBondToken:
             assert token_1.version == TokenVersion.V_25_09
             assert token_1.ibet_wst_activated is True
             assert token_1.ibet_wst_version == IbetWSTVersion.V_1
+            assert token_1.ibet_wst_name == "ibet_wst_name_test1"
 
             position = (await async_db.scalars(select(IDXPosition).limit(1))).first()
             assert position.token_address == "contract_address_test1"
@@ -652,7 +656,7 @@ class TestIssueBondToken:
             assert ibet_wst_tx_1.version == IbetWSTVersion.V_1
             assert ibet_wst_tx_1.status == IbetWSTTxStatus.PENDING
             assert ibet_wst_tx_1.tx_params == {
-                "name": "wst_name_test1",
+                "name": "ibet_wst_name_test1",
                 "initial_owner": test_account["address"],
             }
             assert (
@@ -1239,7 +1243,7 @@ class TestIssueBondToken:
 
     # <Error_2_8>
     # Validation Error
-    # wst_name when activate_ibet_wst is True
+    # ibet_wst_name when activate_ibet_wst is True
     @pytest.mark.asyncio
     async def test_error_2_8(self, async_client, async_db):
         test_account = default_eth_account("user1")
@@ -1272,7 +1276,7 @@ class TestIssueBondToken:
                 {
                     "type": "value_error",
                     "loc": ["body"],
-                    "msg": "Value error, wst_name is required when activate_ibet_wst is true",
+                    "msg": "Value error, ibet_wst_name is required when activate_ibet_wst is true",
                     "input": {
                         "name": "name_test1",
                         "symbol": "symbol_test1",

--- a/tests/app/test_bond_tokens_ListAllBondTokens.py
+++ b/tests/app/test_bond_tokens_ListAllBondTokens.py
@@ -66,6 +66,7 @@ class TestListAllBondTokens:
         token.ibet_wst_version = IbetWSTVersion.V_1
         token.ibet_wst_deployed = True
         token.ibet_wst_address = "eth_token_address_test1"
+        token.ibet_wst_name = "ibet_wst_name_test1"
         async_db.add(token)
         await async_db.commit()
         _issue_datetime = (
@@ -176,6 +177,7 @@ class TestListAllBondTokens:
                 "ibet_wst_version": IbetWSTVersion.V_1,
                 "ibet_wst_deployed": True,
                 "ibet_wst_address": "eth_token_address_test1",
+                "ibet_wst_name": "ibet_wst_name_test1",
             }
         ]
 
@@ -204,6 +206,7 @@ class TestListAllBondTokens:
         token_1.ibet_wst_version = IbetWSTVersion.V_1
         token_1.ibet_wst_deployed = True
         token_1.ibet_wst_address = "eth_token_address_test1"
+        token_1.ibet_wst_name = "ibet_wst_name_test1"
         async_db.add(token_1)
         await async_db.commit()
         _issue_datetime_1 = (
@@ -382,6 +385,7 @@ class TestListAllBondTokens:
                 "ibet_wst_version": IbetWSTVersion.V_1,
                 "ibet_wst_deployed": True,
                 "ibet_wst_address": "eth_token_address_test1",
+                "ibet_wst_name": "ibet_wst_name_test1",
             },
             {
                 "issuer_address": token_2.issuer_address,
@@ -432,6 +436,7 @@ class TestListAllBondTokens:
                 "ibet_wst_version": None,
                 "ibet_wst_deployed": False,
                 "ibet_wst_address": None,
+                "ibet_wst_name": None,
             },
         ]
 
@@ -603,6 +608,7 @@ class TestListAllBondTokens:
                 "ibet_wst_version": None,
                 "ibet_wst_deployed": False,
                 "ibet_wst_address": None,
+                "ibet_wst_name": None,
             }
         ]
 
@@ -817,6 +823,7 @@ class TestListAllBondTokens:
                 "ibet_wst_version": None,
                 "ibet_wst_deployed": False,
                 "ibet_wst_address": None,
+                "ibet_wst_name": None,
             },
             {
                 "issuer_address": token_2.issuer_address,
@@ -867,6 +874,7 @@ class TestListAllBondTokens:
                 "ibet_wst_version": None,
                 "ibet_wst_deployed": False,
                 "ibet_wst_address": None,
+                "ibet_wst_name": None,
             },
         ]
 

--- a/tests/app/test_bond_tokens_ListBondOperationLogHistory.py
+++ b/tests/app/test_bond_tokens_ListBondOperationLogHistory.py
@@ -106,7 +106,7 @@ async def deploy_bond_token_contract(
 
     token_create_param.pop("image_url")
     token_create_param.pop("activate_ibet_wst")
-    token_create_param.pop("wst_name")
+    token_create_param.pop("ibet_wst_name")
 
     token_update_operation_log = TokenUpdateOperationLog()
     token_update_operation_log.issuer_address = address

--- a/tests/app/test_bond_tokens_RetrieveBondToken.py
+++ b/tests/app/test_bond_tokens_RetrieveBondToken.py
@@ -53,6 +53,7 @@ class TestRetrieveBondToken:
         token.ibet_wst_version = IbetWSTVersion.V_1
         token.ibet_wst_deployed = True
         token.ibet_wst_address = "eth_token_address_test1"
+        token.ibet_wst_name = "ibet_wst_name_test1"
         async_db.add(token)
 
         await async_db.commit()
@@ -166,6 +167,7 @@ class TestRetrieveBondToken:
             "ibet_wst_version": IbetWSTVersion.V_1,
             "ibet_wst_deployed": True,
             "ibet_wst_address": "eth_token_address_test1",
+            "ibet_wst_name": "ibet_wst_name_test1",
         }
 
         assert resp.status_code == 200
@@ -188,6 +190,7 @@ class TestRetrieveBondToken:
         token.ibet_wst_version = IbetWSTVersion.V_1
         token.ibet_wst_deployed = True
         token.ibet_wst_address = "eth_token_address_test1"
+        token.ibet_wst_name = "ibet_wst_name_test1"
         async_db.add(token)
 
         await async_db.commit()
@@ -301,6 +304,7 @@ class TestRetrieveBondToken:
             "ibet_wst_version": IbetWSTVersion.V_1,
             "ibet_wst_deployed": True,
             "ibet_wst_address": "eth_token_address_test1",
+            "ibet_wst_name": "ibet_wst_name_test1",
         }
 
         assert resp.status_code == 200

--- a/tests/app/test_bond_tokens_UpdateBondToken.py
+++ b/tests/app/test_bond_tokens_UpdateBondToken.py
@@ -146,7 +146,7 @@ class TestUpdateBondToken:
             "transfer_approval_required": True,
             "memo": "m" * 10000,
             "activate_ibet_wst": True,
-            "wst_name": "wst_name_test",
+            "ibet_wst_name": "ibet_wst_name_test",
         }
         resp = await async_client.post(
             self.base_url.format(_token_address),
@@ -178,6 +178,7 @@ class TestUpdateBondToken:
         assert token_af.ibet_wst_activated is True
         assert token_af.ibet_wst_version == IbetWSTVersion.V_1
         assert token_af.ibet_wst_tx_id is not None
+        assert token_af.ibet_wst_name == "ibet_wst_name_test"
 
         ibet_wst_tx: EthIbetWSTTx = (
             await async_db.scalars(select(EthIbetWSTTx).limit(1))
@@ -186,7 +187,7 @@ class TestUpdateBondToken:
         assert ibet_wst_tx.tx_type == IbetWSTTxType.DEPLOY
         assert ibet_wst_tx.version == IbetWSTVersion.V_1
         assert ibet_wst_tx.tx_params == {
-            "name": "wst_name_test",
+            "name": "ibet_wst_name_test",
             "initial_owner": _issuer_address,
         }
         assert ibet_wst_tx.tx_sender == "0x1234567890123456789012345678901234567890"
@@ -1193,8 +1194,8 @@ class TestUpdateBondToken:
         }
 
     # <Error_1_10>
-    # RequestValidationError: wst_name
-    # wst_name is required when activate_ibet_wst is True
+    # RequestValidationError: ibet_wst_name
+    # ibet_wst_name is required when activate_ibet_wst is True
     @pytest.mark.asyncio
     async def test_error_1_10(self, async_client, async_db):
         _token_address = "0x82b1c9374aB625380bd498a3d9dF4033B8A0E3Bb"
@@ -1214,7 +1215,7 @@ class TestUpdateBondToken:
                 {
                     "type": "value_error",
                     "loc": ["body"],
-                    "msg": "Value error, wst_name is required when activate_ibet_wst is true",
+                    "msg": "Value error, ibet_wst_name is required when activate_ibet_wst is true",
                     "input": {"activate_ibet_wst": True},
                     "ctx": {"error": {}},
                 }
@@ -1807,7 +1808,7 @@ class TestUpdateBondToken:
         # request target API
         req_param = {
             "activate_ibet_wst": True,
-            "wst_name": "wst_name_test",
+            "ibet_wst_name": "ibet_wst_name_test",
         }
         resp = await async_client.post(
             self.base_url.format(_token_address),

--- a/tests/app/test_share_tokens_IssueShareToken.py
+++ b/tests/app/test_share_tokens_IssueShareToken.py
@@ -176,6 +176,7 @@ class TestIssueShareToken:
             assert token_1.version == TokenVersion.V_25_09
             assert token_1.ibet_wst_activated is None
             assert token_1.ibet_wst_version is None
+            assert token_1.ibet_wst_name is None
 
             position = (await async_db.scalars(select(IDXPosition).limit(1))).first()
             assert position.token_address == "contract_address_test1"
@@ -310,6 +311,7 @@ class TestIssueShareToken:
             assert token_1.version == TokenVersion.V_25_09
             assert token_1.ibet_wst_activated is None
             assert token_1.ibet_wst_version is None
+            assert token_1.ibet_wst_name is None
 
             position = (await async_db.scalars(select(IDXPosition).limit(1))).first()
             assert position.token_address == "contract_address_test1"
@@ -411,7 +413,7 @@ class TestIssueShareToken:
                 "principal_value": 1000,
                 "is_canceled": True,
                 "activate_ibet_wst": None,
-                "wst_name": None,
+                "ibet_wst_name": None,
             }
             resp = await async_client.post(
                 self.apiurl,
@@ -601,6 +603,7 @@ class TestIssueShareToken:
             assert token_1.version == TokenVersion.V_25_09
             assert token_1.ibet_wst_activated is None
             assert token_1.ibet_wst_version is None
+            assert token_1.ibet_wst_name is None
 
             position = (await async_db.scalars(select(IDXPosition).limit(1))).first()
             assert position.token_address == "contract_address_test1"
@@ -862,7 +865,7 @@ class TestIssueShareToken:
                 "cancellation_date": "20221231",
                 "principal_value": 1000,
                 "activate_ibet_wst": True,  # Activate IbetWST
-                "wst_name": "wst_name_test1",
+                "ibet_wst_name": "ibet_wst_name_test1",
             }
             resp = await async_client.post(
                 self.apiurl,
@@ -921,6 +924,7 @@ class TestIssueShareToken:
             assert token_1.version == TokenVersion.V_25_09
             assert token_1.ibet_wst_activated is True
             assert token_1.ibet_wst_version == IbetWSTVersion.V_1
+            assert token_1.ibet_wst_name == "ibet_wst_name_test1"
 
             position = (await async_db.scalars(select(IDXPosition).limit(1))).first()
             assert position.token_address == "contract_address_test1"
@@ -961,7 +965,7 @@ class TestIssueShareToken:
             assert ibet_wst_tx_1.version == IbetWSTVersion.V_1
             assert ibet_wst_tx_1.status == IbetWSTTxStatus.PENDING
             assert ibet_wst_tx_1.tx_params == {
-                "name": "wst_name_test1",
+                "name": "ibet_wst_name_test1",
                 "initial_owner": test_account["address"],
             }
             assert (
@@ -1396,7 +1400,7 @@ class TestIssueShareToken:
 
     # <Error_2_7>
     # Validation Error
-    # wst_name when activate_ibet_wst is True
+    # ibet_wst_name when activate_ibet_wst is True
     @pytest.mark.asyncio
     async def test_error_2_7(self, async_client, async_db):
         test_account = default_eth_account("user1")
@@ -1428,7 +1432,7 @@ class TestIssueShareToken:
                 {
                     "type": "value_error",
                     "loc": ["body"],
-                    "msg": "Value error, wst_name is required when activate_ibet_wst is true",
+                    "msg": "Value error, ibet_wst_name is required when activate_ibet_wst is true",
                     "input": {
                         "name": "name_test1",
                         "symbol": "symbol_test1",

--- a/tests/app/test_share_tokens_ListAllShareTokens.py
+++ b/tests/app/test_share_tokens_ListAllShareTokens.py
@@ -65,6 +65,7 @@ class TestListAllShareTokens:
         token.ibet_wst_version = IbetWSTVersion.V_1
         token.ibet_wst_deployed = True
         token.ibet_wst_address = "eth_token_address_test1"
+        token.ibet_wst_name = "ibet_wst_name_test1"
         async_db.add(token)
         await async_db.commit()
 
@@ -138,6 +139,7 @@ class TestListAllShareTokens:
                 "ibet_wst_version": IbetWSTVersion.V_1,
                 "ibet_wst_deployed": True,
                 "ibet_wst_address": "eth_token_address_test1",
+                "ibet_wst_name": "ibet_wst_name_test1",
             }
         ]
 
@@ -165,6 +167,7 @@ class TestListAllShareTokens:
         token_1.ibet_wst_version = IbetWSTVersion.V_1
         token_1.ibet_wst_deployed = True
         token_1.ibet_wst_address = "eth_token_address_test1"
+        token_1.ibet_wst_name = "ibet_wst_name_test1"
         async_db.add(token_1)
         await async_db.commit()
 
@@ -285,6 +288,7 @@ class TestListAllShareTokens:
                 "ibet_wst_version": IbetWSTVersion.V_1,
                 "ibet_wst_deployed": True,
                 "ibet_wst_address": "eth_token_address_test1",
+                "ibet_wst_name": "ibet_wst_name_test1",
             },
             {
                 "issuer_address": issuer_address_2,
@@ -316,6 +320,7 @@ class TestListAllShareTokens:
                 "ibet_wst_version": None,
                 "ibet_wst_deployed": False,
                 "ibet_wst_address": None,
+                "ibet_wst_name": None,
             },
         ]
 
@@ -445,6 +450,7 @@ class TestListAllShareTokens:
                 "ibet_wst_version": None,
                 "ibet_wst_deployed": False,
                 "ibet_wst_address": None,
+                "ibet_wst_name": None,
             }
         ]
 
@@ -600,6 +606,7 @@ class TestListAllShareTokens:
                 "ibet_wst_version": None,
                 "ibet_wst_deployed": False,
                 "ibet_wst_address": None,
+                "ibet_wst_name": None,
             },
             {
                 "issuer_address": issuer_address_1,
@@ -631,6 +638,7 @@ class TestListAllShareTokens:
                 "ibet_wst_version": None,
                 "ibet_wst_deployed": False,
                 "ibet_wst_address": None,
+                "ibet_wst_name": None,
             },
         ]
 

--- a/tests/app/test_share_tokens_ListShareOperationLogHistory.py
+++ b/tests/app/test_share_tokens_ListShareOperationLogHistory.py
@@ -95,7 +95,7 @@ async def deploy_share_token_contract(
     ).__dict__
 
     token_create_param.pop("activate_ibet_wst")
-    token_create_param.pop("wst_name")
+    token_create_param.pop("ibet_wst_name")
 
     token_update_operation_log = TokenUpdateOperationLog()
     token_update_operation_log.issuer_address = address

--- a/tests/app/test_share_tokens_RetrieveShareToken.py
+++ b/tests/app/test_share_tokens_RetrieveShareToken.py
@@ -54,6 +54,7 @@ class TestRetrieveShareToken:
         token.ibet_wst_version = IbetWSTVersion.V_1
         token.ibet_wst_deployed = True
         token.ibet_wst_address = "eth_token_address_test1"
+        token.ibet_wst_name = "ibet_wst_name_test1"
         async_db.add(token)
         await async_db.commit()
 
@@ -127,6 +128,7 @@ class TestRetrieveShareToken:
             "ibet_wst_version": IbetWSTVersion.V_1,
             "ibet_wst_deployed": True,
             "ibet_wst_address": "eth_token_address_test1",
+            "ibet_wst_name": "ibet_wst_name_test1",
         }
 
         assert resp.status_code == 200
@@ -149,6 +151,7 @@ class TestRetrieveShareToken:
         token.ibet_wst_version = IbetWSTVersion.V_1
         token.ibet_wst_deployed = True
         token.ibet_wst_address = "eth_token_address_test1"
+        token.ibet_wst_name = "ibet_wst_name_test1"
         async_db.add(token)
         await async_db.commit()
 
@@ -222,6 +225,7 @@ class TestRetrieveShareToken:
             "ibet_wst_version": IbetWSTVersion.V_1,
             "ibet_wst_deployed": True,
             "ibet_wst_address": "eth_token_address_test1",
+            "ibet_wst_name": "ibet_wst_name_test1",
         }
 
         assert resp.status_code == 200

--- a/tests/app/test_share_tokens_UpdateShareToken.py
+++ b/tests/app/test_share_tokens_UpdateShareToken.py
@@ -140,7 +140,7 @@ class TestAppRoutersShareTokensTokenAddressPOST:
             "is_canceled": True,
             "memo": "m" * 10000,
             "activate_ibet_wst": True,
-            "wst_name": "wst_name_test",
+            "ibet_wst_name": "ibet_wst_name_test",
         }
         resp = await async_client.post(
             self.base_url.format(_token_address),
@@ -172,6 +172,7 @@ class TestAppRoutersShareTokensTokenAddressPOST:
         assert token_af.ibet_wst_activated is True
         assert token_af.ibet_wst_version == IbetWSTVersion.V_1
         assert token_af.ibet_wst_tx_id is not None
+        assert token_af.ibet_wst_name == "ibet_wst_name_test"
 
         ibet_wst_tx: EthIbetWSTTx = (
             await async_db.scalars(select(EthIbetWSTTx).limit(1))
@@ -180,7 +181,7 @@ class TestAppRoutersShareTokensTokenAddressPOST:
         assert ibet_wst_tx.tx_type == IbetWSTTxType.DEPLOY
         assert ibet_wst_tx.version == IbetWSTVersion.V_1
         assert ibet_wst_tx.tx_params == {
-            "name": "wst_name_test",
+            "name": "ibet_wst_name_test",
             "initial_owner": _issuer_address,
         }
         assert ibet_wst_tx.tx_sender == "0x1234567890123456789012345678901234567890"
@@ -1378,7 +1379,7 @@ class TestAppRoutersShareTokensTokenAddressPOST:
         # request target API
         req_param = {
             "activate_ibet_wst": True,
-            "wst_name": "wst_name_test",
+            "ibet_wst_name": "ibet_wst_name_test",
         }
         resp = await async_client.post(
             self.base_url.format(_token_address),
@@ -1397,8 +1398,8 @@ class TestAppRoutersShareTokensTokenAddressPOST:
         }
 
     # <Error_19>
-    # RequestValidationError: wst_name
-    # wst_name is required when activate_ibet_wst is True
+    # RequestValidationError: ibet_wst_name
+    # ibet_wst_name is required when activate_ibet_wst is True
     @pytest.mark.asyncio
     async def test_error_19(self, async_client, async_db):
         test_account = default_eth_account("user1")
@@ -1422,7 +1423,7 @@ class TestAppRoutersShareTokensTokenAddressPOST:
                 {
                     "type": "value_error",
                     "loc": ["body"],
-                    "msg": "Value error, wst_name is required when activate_ibet_wst is true",
+                    "msg": "Value error, ibet_wst_name is required when activate_ibet_wst is true",
                     "input": {"activate_ibet_wst": True},
                     "ctx": {"error": {}},
                 }


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

This pull request introduces the new `ibet_wst_name` field to the IbetWST-related models, schemas, API responses, and database, replacing the previous `wst_name` identifier. 

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- Close #927

## 🔄 Changes

<!-- List the major changes in this PR. -->

**Database and Model Updates:**
* Added the `ibet_wst_name` column to the `token` table and updated the `Token` SQLAlchemy model to include this field. [[1]](diffhunk://#diff-c2caaca71a3076b409e49b1b4279260d86da5fea3258a383054d04b1bf2289bfR1-R31) [[2]](diffhunk://#diff-fe1fb614096f724f54972b3fd6bcc1ab80ff53d770343f080d349bb8553391c2R87-R88)

**Schema and Validation Updates:**
* Replaced all instances of `wst_name` with `ibet_wst_name` in Pydantic models (`IbetStraightBondCreate`, `IbetStraightBondUpdate`, `IbetShareCreate`, `IbetShareUpdate`) and updated validators to require `ibet_wst_name` when IbetWST is activated. [[1]](diffhunk://#diff-f4e88ec2faaf9af2e2935776f1749ab69fefaed04940ac5ce0d6933603961b46L91-R91) [[2]](diffhunk://#diff-f4e88ec2faaf9af2e2935776f1749ab69fefaed04940ac5ce0d6933603961b46L130-R135) [[3]](diffhunk://#diff-f4e88ec2faaf9af2e2935776f1749ab69fefaed04940ac5ce0d6933603961b46L165-R167) [[4]](diffhunk://#diff-f4e88ec2faaf9af2e2935776f1749ab69fefaed04940ac5ce0d6933603961b46L209-R216) [[5]](diffhunk://#diff-f4e88ec2faaf9af2e2935776f1749ab69fefaed04940ac5ce0d6933603961b46L265-R269) [[6]](diffhunk://#diff-f4e88ec2faaf9af2e2935776f1749ab69fefaed04940ac5ce0d6933603961b46L281-R290) [[7]](diffhunk://#diff-f4e88ec2faaf9af2e2935776f1749ab69fefaed04940ac5ce0d6933603961b46L311-R317) [[8]](diffhunk://#diff-f4e88ec2faaf9af2e2935776f1749ab69fefaed04940ac5ce0d6933603961b46L344-R355)

**API and Response Updates:**
* Updated API endpoints to handle `ibet_wst_name` for bond and share tokens, including creation, update, retrieval, and listing operations. Also added `ibet_wst_name` to response schemas. [[1]](diffhunk://#diff-d423ad219858d5cadb48390db542fd1449ff9d6562213d33ff3150f48b7fbbe9R368-R376) [[2]](diffhunk://#diff-d423ad219858d5cadb48390db542fd1449ff9d6562213d33ff3150f48b7fbbe9R459) [[3]](diffhunk://#diff-d423ad219858d5cadb48390db542fd1449ff9d6562213d33ff3150f48b7fbbe9R510) [[4]](diffhunk://#diff-d423ad219858d5cadb48390db542fd1449ff9d6562213d33ff3150f48b7fbbe9R654) [[5]](diffhunk://#diff-d423ad219858d5cadb48390db542fd1449ff9d6562213d33ff3150f48b7fbbe9L659-R663) [[6]](diffhunk://#diff-95d74a3e746fba065d4d5d96590dff5859b62a05b1f1c68769a083b04cad2991R360-R368) [[7]](diffhunk://#diff-95d74a3e746fba065d4d5d96590dff5859b62a05b1f1c68769a083b04cad2991R443) [[8]](diffhunk://#diff-95d74a3e746fba065d4d5d96590dff5859b62a05b1f1c68769a083b04cad2991R494) [[9]](diffhunk://#diff-95d74a3e746fba065d4d5d96590dff5859b62a05b1f1c68769a083b04cad2991R616) [[10]](diffhunk://#diff-95d74a3e746fba065d4d5d96590dff5859b62a05b1f1c68769a083b04cad2991L621-R625) [[11]](diffhunk://#diff-f4e88ec2faaf9af2e2935776f1749ab69fefaed04940ac5ce0d6933603961b46R601) [[12]](diffhunk://#diff-f4e88ec2faaf9af2e2935776f1749ab69fefaed04940ac5ce0d6933603961b46R616)

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
