### PR TITLE
DVPDeliveryData: add 'secondary' option to delivery_type

### DIFF
--- a/app/model/schema/settlement.py
+++ b/app/model/schema/settlement.py
@@ -45,7 +45,7 @@ class DeliveryStatus(IntEnum):
 
 
 class DVPDeliveryData(BaseModel):
-    delivery_type: Literal["offering", "primary"]
+    delivery_type: Literal["offering", "primary", "secondary"]
     trade_date: str
     settlement_date: str
     settlement_service_account_id: str

--- a/docs/ibet_prime.yaml
+++ b/docs/ibet_prime.yaml
@@ -13272,6 +13272,7 @@ components:
           enum:
             - offering
             - primary
+            - secondary
           title: Delivery Type
         trade_date:
           type: string


### PR DESCRIPTION
## 📌 Description

This pull request updates the delivery type options for DVP deliveries to support an additional type, "secondary". This change is reflected both in the backend model and the API documentation to ensure consistency.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- None

## 🔄 Changes

<!-- List the major changes in this PR. -->

**Delivery type support expansion:**

* Added "secondary" as a valid value for the `delivery_type` field in the `DVPDeliveryData` model in `app/model/schema/settlement.py`.
* Updated the OpenAPI specification in `docs/ibet_prime.yaml` to include "secondary" in the `delivery_type` enum, ensuring API consumers are aware of the new option.

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
