### PR TITLE
Add validation for encrypted eoa_password in DVP delivery requests

### DIFF
--- a/app/model/schema/settlement.py
+++ b/app/model/schema/settlement.py
@@ -151,6 +151,13 @@ class FinishDVPDeliveryRequest(BaseModel):
     account_address: EthereumAddress = Field(..., description="Agent account address")
     eoa_password: str = Field(..., description="Agent account key file password")
 
+    @field_validator("eoa_password")
+    @classmethod
+    def eoa_password_is_encrypted_value(cls, v):
+        if E2EE_REQUEST_ENABLED:
+            check_value_is_encrypted("eoa_password", v)
+        return v
+
 
 class AbortDVPDeliveryRequest(BaseModel):
     """DVP delivery abort schema (REQUEST)"""
@@ -158,6 +165,13 @@ class AbortDVPDeliveryRequest(BaseModel):
     operation_type: Literal["Abort"]
     account_address: EthereumAddress = Field(..., description="Agent account address")
     eoa_password: str = Field(..., description="Agent account key file password")
+
+    @field_validator("eoa_password")
+    @classmethod
+    def eoa_password_is_encrypted_value(cls, v):
+        if E2EE_REQUEST_ENABLED:
+            check_value_is_encrypted("eoa_password", v)
+        return v
 
 
 ############################

--- a/app/utils/e2ee_utils.py
+++ b/app/utils/e2ee_utils.py
@@ -55,9 +55,7 @@ class E2EEUtils:
         if crypto_data.get("public_key") is None:
             return data
 
-        rsa_key = RSA.importKey(
-            crypto_data.get("public_key"), passphrase=E2EE_RSA_PASSPHRASE
-        )
+        rsa_key = RSA.importKey(crypto_data.get("public_key"))
         cipher = PKCS1_OAEP.new(rsa_key)
         encrypt_data = cipher.encrypt(data.encode("utf-8"))
         base64_data = base64.encodebytes(encrypt_data)

--- a/tests/app/test_settlement_agent_UpdateDVPAgentDelivery.py
+++ b/tests/app/test_settlement_agent_UpdateDVPAgentDelivery.py
@@ -425,14 +425,191 @@ class TestUpdateDVPDelivery:
     # Error Case
     ###########################################################################
 
-    # <Error_1>
+    # <Error_1_1>
+    # Invalid operation_type value
+    # -> RequestValidationError
+    @pytest.mark.asyncio
+    async def test_error_1_1(
+        self, async_client, async_db, ibet_security_token_dvp_contract
+    ):
+        user_1 = default_eth_account("user1")
+        issuer_address = user_1["address"]
+        _keyfile = user_1["keyfile_json"]
+
+        # prepare data
+        account = Account()
+        account.issuer_address = issuer_address
+        account.keyfile = _keyfile
+        account.eoa_password = E2EEUtils.encrypt("password")
+        async_db.add(account)
+
+        await async_db.commit()
+
+        # request target API
+        req_param = {
+            "operation_type": "InvalidOperation",  # invalid value
+            "account_address": "0x0000000000000000000000000000000000000000",
+            "eoa_password": E2EEUtils.encrypt("password"),
+        }
+
+        resp = await async_client.post(
+            self.base_url.format(
+                exchange_address=ibet_security_token_dvp_contract.address, delivery_id=1
+            ),
+            json=req_param,
+        )
+
+        assert resp.status_code == 422
+        assert resp.json() == {
+            "meta": {"code": 1, "title": "RequestValidationError"},
+            "detail": [
+                {
+                    "type": "literal_error",
+                    "loc": ["body", "FinishDVPDeliveryRequest", "operation_type"],
+                    "msg": "Input should be 'Finish'",
+                    "input": "InvalidOperation",
+                    "ctx": {"expected": "'Finish'"},
+                },
+                {
+                    "type": "literal_error",
+                    "loc": ["body", "AbortDVPDeliveryRequest", "operation_type"],
+                    "msg": "Input should be 'Abort'",
+                    "input": "InvalidOperation",
+                    "ctx": {"expected": "'Abort'"},
+                },
+            ],
+        }
+
+    # <Error_1_2>
+    @pytest.mark.asyncio
+    async def test_error_1_2(
+        self, async_client, async_db, ibet_security_token_dvp_contract
+    ):
+        user_1 = default_eth_account("user1")
+        issuer_address = user_1["address"]
+        _keyfile = user_1["keyfile_json"]
+
+        # prepare data
+        account = Account()
+        account.issuer_address = issuer_address
+        account.keyfile = _keyfile
+        account.eoa_password = E2EEUtils.encrypt("password")
+        async_db.add(account)
+
+        await async_db.commit()
+
+        # request target API
+        req_param = {
+            "operation_type": "Finish",
+            "account_address": "invalid_address",  # invalid address
+            "eoa_password": E2EEUtils.encrypt("password"),
+        }
+
+        resp = await async_client.post(
+            self.base_url.format(
+                exchange_address=ibet_security_token_dvp_contract.address, delivery_id=1
+            ),
+            json=req_param,
+        )
+
+        assert resp.status_code == 422
+        assert resp.json() == {
+            "meta": {"code": 1, "title": "RequestValidationError"},
+            "detail": [
+                {
+                    "type": "value_error",
+                    "loc": ["body", "FinishDVPDeliveryRequest", "account_address"],
+                    "msg": "Value error, invalid ethereum address",
+                    "input": "invalid_address",
+                    "ctx": {"error": {}},
+                },
+                {
+                    "type": "literal_error",
+                    "loc": ["body", "AbortDVPDeliveryRequest", "operation_type"],
+                    "msg": "Input should be 'Abort'",
+                    "input": "Finish",
+                    "ctx": {"expected": "'Abort'"},
+                },
+                {
+                    "type": "value_error",
+                    "loc": ["body", "AbortDVPDeliveryRequest", "account_address"],
+                    "msg": "Value error, invalid ethereum address",
+                    "input": "invalid_address",
+                    "ctx": {"error": {}},
+                },
+            ],
+        }
+
+    # <Error_1_3>
+    # Not encrypted value for eoa_password
+    # -> RequestValidationError
+    @pytest.mark.asyncio
+    async def test_error_1_3(
+        self, async_client, async_db, ibet_security_token_dvp_contract
+    ):
+        user_1 = default_eth_account("user1")
+        issuer_address = user_1["address"]
+        _keyfile = user_1["keyfile_json"]
+
+        # prepare data
+        account = Account()
+        account.issuer_address = issuer_address
+        account.keyfile = _keyfile
+        account.eoa_password = E2EEUtils.encrypt("password")
+        async_db.add(account)
+
+        await async_db.commit()
+
+        # request target API
+        req_param = {
+            "operation_type": "Finish",
+            "account_address": "0x0000000000000000000000000000000000000000",
+            "eoa_password": "password",  # not encrypted value
+        }
+
+        resp = await async_client.post(
+            self.base_url.format(
+                exchange_address=ibet_security_token_dvp_contract.address, delivery_id=1
+            ),
+            json=req_param,
+        )
+
+        assert resp.status_code == 422
+        assert resp.json() == {
+            "meta": {"code": 1, "title": "RequestValidationError"},
+            "detail": [
+                {
+                    "type": "value_error",
+                    "loc": ["body", "FinishDVPDeliveryRequest", "eoa_password"],
+                    "msg": "Value error, eoa_password is not a Base64-encoded encrypted data",
+                    "input": "password",
+                    "ctx": {"error": {}},
+                },
+                {
+                    "type": "literal_error",
+                    "loc": ["body", "AbortDVPDeliveryRequest", "operation_type"],
+                    "msg": "Input should be 'Abort'",
+                    "input": "Finish",
+                    "ctx": {"expected": "'Abort'"},
+                },
+                {
+                    "type": "value_error",
+                    "loc": ["body", "AbortDVPDeliveryRequest", "eoa_password"],
+                    "msg": "Value error, eoa_password is not a Base64-encoded encrypted data",
+                    "input": "password",
+                    "ctx": {"error": {}},
+                },
+            ],
+        }
+
+    # <Error_2>
     # DVP agent account not found
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "operation_type",
         ["Finish", "Abort"],
     )
-    async def test_error_1(
+    async def test_error_2(
         self, operation_type, async_client, async_db, ibet_security_token_dvp_contract
     ):
         user_1 = default_eth_account("user1")
@@ -452,7 +629,7 @@ class TestUpdateDVPDelivery:
         req_param = {
             "operation_type": operation_type,
             "account_address": "0x0000000000000000000000000000000000000000",
-            "eoa_password": "password",
+            "eoa_password": E2EEUtils.encrypt("password"),
         }
 
         resp = await async_client.post(
@@ -468,14 +645,14 @@ class TestUpdateDVPDelivery:
             "detail": "agent account is not exists",
         }
 
-    # <Error_2>
+    # <Error_3>
     # DVP agent password mismatch
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "operation_type",
         ["Finish", "Abort"],
     )
-    async def test_error_2(
+    async def test_error_3(
         self,
         operation_type,
         async_client,
@@ -543,14 +720,14 @@ class TestUpdateDVPDelivery:
             "detail": "password mismatch",
         }
 
-    # <Error_3>
+    # <Error_4>
     # Send Transaction Error
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "operation_type",
         ["Finish", "Abort"],
     )
-    async def test_error_3(
+    async def test_error_4(
         self,
         operation_type,
         async_client,


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

This pull request strengthens validation and encryption handling for DVP agent delivery requests, and significantly expands and refines the test coverage for error cases. The main changes include enforcing encrypted values for sensitive request fields, updating encryption logic, and reorganizing and adding detailed error tests.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
None

## 🔄 Changes

<!-- List the major changes in this PR. -->

### Validation and Security Improvements
* Added `field_validator` methods to `FinishDVPDeliveryRequest` and `AbortDVPDeliveryRequest` schemas to ensure that the `eoa_password` field is encrypted when end-to-end encryption is enabled. (`app/model/schema/settlement.py`) [[1]](diffhunk://#diff-b11227e317737c44d5629060a8421ed36f44077e655e31361ef386e1694a191aR154-R160) [[2]](diffhunk://#diff-b11227e317737c44d5629060a8421ed36f44077e655e31361ef386e1694a191aR169-R175)
* Updated the `encrypt` function in `app/utils/e2ee_utils.py` to remove the passphrase requirement when importing the RSA public key, simplifying encryption logic.

### Test Suite Enhancements
* Refactored and expanded error case tests in `tests/app/test_settlement_agent_UpdateDVPAgentDelivery.py`, including:
  - Validation for invalid `operation_type` values.
  - Validation for invalid Ethereum addresses.
  - Validation for unencrypted `eoa_password` values.

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
