### PR TITLE
Fix response limit checks in blockchain explorer

### DIFF
--- a/app/routers/misc/bc_explorer.py
+++ b/app/routers/misc/bc_explorer.py
@@ -17,6 +17,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
+import sys
 from typing import Annotated, Any, Dict, Sequence, Tuple
 
 from eth_utils import to_checksum_address
@@ -110,7 +111,7 @@ async def service_list_block_data(
     if get_query.offset is not None:
         stmt = stmt.offset(get_query.offset)
 
-    if max(total, get_query.limit or 0) > BLOCK_RESPONSE_LIMIT:
+    if min(total, get_query.limit or sys.maxsize) > BLOCK_RESPONSE_LIMIT:
         raise ResponseLimitExceededError("Search results exceed the limit")
 
     block_data_tmp: Sequence[IDXBlockData] = (await db.scalars(stmt)).all()
@@ -205,7 +206,7 @@ async def service_list_tx_data(
     if get_query.offset is not None:
         stmt = stmt.offset(get_query.offset)
 
-    if max(total, get_query.limit or 0) > TX_RESPONSE_LIMIT:
+    if min(total, get_query.limit or sys.maxsize) > TX_RESPONSE_LIMIT:
         raise ResponseLimitExceededError("Search results exceed the limit")
 
     tx_data_tmp: Sequence[IDXTxData] = (await db.scalars(stmt)).all()


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

Fix response limit checks in blockchain explorer.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
None

## 🔄 Changes

<!-- List the major changes in this PR. -->
Fix response limit check logic:

* Updated the response limit checks in both `service_list_block_data` and `service_list_tx_data` to use `min(total, get_query.limit or sys.maxsize)` instead of `max(total, get_query.limit or 0)`, ensuring that the limit is enforced only when the number of results could actually exceed the allowed maximum. [[1]](diffhunk://#diff-f4b3f55c47919e2ad38aeceb2ce90809736522923e032158aa520d4090941120L113-R114) [[2]](diffhunk://#diff-f4b3f55c47919e2ad38aeceb2ce90809736522923e032158aa520d4090941120L208-R209)

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
