### PR TITLE
Add index on block_data for transactions with non-null values

### DIFF
--- a/app/model/db/idx_block_data.py
+++ b/app/model/db/idx_block_data.py
@@ -17,7 +17,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-from sqlalchemy import JSON, BigInteger, Integer, String, Text
+from sqlalchemy import JSON, BigInteger, Index, Integer, String, Text, text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from .base import Base
@@ -51,6 +51,16 @@ class IDXBlockData(Base):
     hash: Mapped[str] = mapped_column(String(66), nullable=False, index=True)
     size: Mapped[int | None] = mapped_column(Integer)
     transactions: Mapped[dict | None] = mapped_column(JSON)
+
+    __table_args__ = (
+        Index(
+            "ix_block_data_has_transactions",
+            number,
+            postgresql_where=text(
+                "transactions IS NOT NULL AND json_array_length(transactions) > 0"
+            ),
+        ),
+    )
 
 
 class IDXBlockDataBlockNumber(Base):

--- a/migrations/versions/84cb5764c09a_v26_3_0_feature_950.py
+++ b/migrations/versions/84cb5764c09a_v26_3_0_feature_950.py
@@ -1,0 +1,43 @@
+"""v26_3_0_feature_950
+
+Revision ID: 84cb5764c09a
+Revises: 39661c5c4bac
+Create Date: 2025-12-29 14:39:38.279754
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+from app.database import get_db_schema
+
+# revision identifiers, used by Alembic.
+revision = "84cb5764c09a"
+down_revision = "39661c5c4bac"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index(
+        "ix_block_data_has_transactions",
+        "block_data",
+        ["number"],
+        unique=False,
+        postgresql_where=sa.text(
+            "transactions IS NOT NULL AND json_array_length(transactions) > 0"
+        ),
+        schema=get_db_schema(),
+    )
+
+
+def downgrade():
+    op.drop_index(
+        "ix_block_data_has_transactions",
+        table_name="block_data",
+        postgresql_where=sa.text(
+            "transactions IS NOT NULL AND json_array_length(transactions) > 0"
+        ),
+        schema=get_db_schema(),
+    )


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

This pull request introduces a new partial index on the `block_data` table to optimize queries involving blocks that have non-empty transactions.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- Related to #950

## 🔄 Changes

<!-- List the major changes in this PR. -->

**Database indexing improvements:**

* Added a partial index `ix_block_data_has_transactions` on the `number` column of the `block_data` table, targeting rows where `transactions` is not null and contains at least one transaction, to improve query performance for blocks with transactions.

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
