### PR TITLE
Update dependabot configuration to group all dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,26 +7,45 @@ updates:
       day: "monday"
       time: "00:00"
     allow:
-    - dependency-name: "*"
-      dependency-type: "direct"
+      - dependency-name: "*"
+        dependency-type: "direct"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     allow:
-    - dependency-name: "*"
-      dependency-type: "direct"
+      - dependency-name: "*"
+        dependency-type: "direct"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
   - package-ecosystem: docker-compose
     directory: "/"
     schedule:
       interval: "monthly"
     ignore:
-    - dependency-name: "*"
-      update-types: ["version-update:semver-major"]
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
     allow:
-    - dependency-name: "*"
-      dependency-type: "direct"
+      - dependency-name: "*"
+        dependency-type: "direct"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

This pull request updates the `.github/dependabot.yml` configuration to introduce dependency grouping for all supported package ecosystems.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
None

## 🔄 Changes

<!-- List the major changes in this PR. -->

Dependency update grouping:

* Added an `all-dependencies` group for each package ecosystem (`bundler`, `github-actions`, `docker-compose`, and `npm`) in `.github/dependabot.yml`, ensuring that all dependency updates are bundled into a single pull request per update cycle.

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
