### PR TITLE
Chunk get_event_logs requests in local/dev

### DIFF
--- a/app/utils/eth_contract_utils.py
+++ b/app/utils/eth_contract_utils.py
@@ -46,6 +46,7 @@ from app.database import async_engine
 from app.exceptions import SendTransactionError, ServiceUnavailableError
 from app.model import EthereumAddress
 from app.model.db import EthereumNode
+from config import APP_ENV
 from eth_config import (
     ETH_CHAIN_ID,
     ETH_WEB3_HTTP_PROVIDER,
@@ -55,6 +56,7 @@ from eth_config import (
 
 thread_local = threading.local()
 LOG = log.get_logger()
+ETH_GET_LOGS_MAX_BLOCKS_PER_REQUEST = 10
 
 
 class EthFailOverHTTPProvider(AsyncHTTPProvider):
@@ -385,11 +387,32 @@ class EthAsyncContractUtils:
         """
         try:
             _event = getattr(contract.events, event)
-            result = await _event.get_logs(
-                from_block=block_from,
-                to_block=block_to,
-                argument_filters=argument_filters,
-            )
+            # In local/dev environment, split event log requests into 10-block chunks.
+            if (
+                APP_ENV in ["local", "dev"]
+                and block_from is not None
+                and block_to is not None
+                and block_from < block_to
+            ):
+                max_block_span = ETH_GET_LOGS_MAX_BLOCKS_PER_REQUEST - 1
+                result = []
+                request_from = block_from
+                while request_from <= block_to:
+                    request_to = min(request_from + max_block_span, block_to)
+                    result.extend(
+                        await _event.get_logs(
+                            from_block=request_from,
+                            to_block=request_to,
+                            argument_filters=argument_filters,
+                        )
+                    )
+                    request_from = request_to + 1
+            else:
+                result = await _event.get_logs(
+                    from_block=block_from,
+                    to_block=block_to,
+                    argument_filters=argument_filters,
+                )
         except ABIEventNotFound:
             return []
 

--- a/tests/app/utils/test_eth_asynccontract_utils.py
+++ b/tests/app/utils/test_eth_asynccontract_utils.py
@@ -18,7 +18,7 @@ SPDX-License-Identifier: Apache-2.0
 """
 
 import json
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from hexbytes import HexBytes
@@ -489,3 +489,74 @@ class TestGetEventLogs:
 
         # Assert
         assert logs == []
+
+    # <Normal_3_1>
+    # Split event log requests into 10-block chunks in local/dev
+    async def test_normal_3_1(self):
+        class _Event:
+            pass
+
+        class _Events:
+            Mint = _Event()
+
+        class _Contract:
+            events = _Events()
+
+        get_logs_mock = AsyncMock(side_effect=[[{"id": 1}], [{"id": 2}], [{"id": 3}]])
+        _Contract.events.Mint.get_logs = get_logs_mock
+
+        with patch("app.utils.eth_contract_utils.APP_ENV", "local"):
+            logs = await EthAsyncContractUtils.get_event_logs(
+                contract=_Contract,
+                event="Mint",
+                block_from=100,
+                block_to=124,
+            )
+
+        assert logs == [{"id": 1}, {"id": 2}, {"id": 3}]
+        assert get_logs_mock.await_count == 3
+        get_logs_mock.assert_any_await(
+            from_block=100,
+            to_block=109,
+            argument_filters=None,
+        )
+        get_logs_mock.assert_any_await(
+            from_block=110,
+            to_block=119,
+            argument_filters=None,
+        )
+        get_logs_mock.assert_any_await(
+            from_block=120,
+            to_block=124,
+            argument_filters=None,
+        )
+
+    # <Normal_3_2>
+    # Keep a single request outside local/dev
+    async def test_normal_3_2(self):
+        class _Event:
+            pass
+
+        class _Events:
+            Mint = _Event()
+
+        class _Contract:
+            events = _Events()
+
+        get_logs_mock = AsyncMock(return_value=[{"id": 1}])
+        _Contract.events.Mint.get_logs = get_logs_mock
+
+        with patch("app.utils.eth_contract_utils.APP_ENV", "live"):
+            logs = await EthAsyncContractUtils.get_event_logs(
+                contract=_Contract,
+                event="Mint",
+                block_from=100,
+                block_to=124,
+            )
+
+        assert logs == [{"id": 1}]
+        get_logs_mock.assert_awaited_once_with(
+            from_block=100,
+            to_block=124,
+            argument_filters=None,
+        )


### PR DESCRIPTION
This pull request introduces a change to how Ethereum event log requests are handled in local and development environments, splitting them into smaller block chunks to avoid issues with large requests. 

## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
None

## 🔄 Changes

<!-- List the major changes in this PR. -->

**Event Log Request Handling:**

* In `app/utils/eth_contract_utils.py`, event log requests are now split into 10-block chunks when running in local or dev environments, using the new constant `ETH_GET_LOGS_MAX_BLOCKS_PER_REQUEST`. This prevents failures due to large block spans in development setups.

**Testing Enhancements:**

* Added tests in `tests/app/utils/test_eth_asynccontract_utils.py` to verify that event log requests are split in local/dev environments and remain single requests in production.

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
