### PR TITLE
Bump dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,11 @@ COPY uv.lock /app/ibet-Prime/uv.lock
 RUN cd /app/ibet-Prime \
  && uv venv $UV_PROJECT_ENVIRONMENT \
  && uv sync --frozen --no-dev --no-install-project --all-extras \
+ && PYTHON_BIN="$(uv python find $PYTHON_VERSION)" \
+ && PYTHON_ROOT="$(dirname "$(dirname "$PYTHON_BIN")")" \
+ && rm -f "$PYTHON_ROOT"/bin/pip "$PYTHON_ROOT"/bin/pip3 "$PYTHON_ROOT"/bin/pip3.* \
+ && rm -rf "$PYTHON_ROOT"/lib/python*/site-packages/pip "$PYTHON_ROOT"/lib/python*/site-packages/pip-*.dist-info \
+ && rm -rf /home/apl/.cache/uv \
  && rm -f /app/ibet-Prime/pyproject.toml \
  && rm -f /app/ibet-Prime/uv.lock
 
@@ -110,7 +115,10 @@ RUN apt-get update -q \
 
 # copy python, dependencies and uv from builder stage
 USER apl
-COPY --from=builder --chown=apl:apl /home/apl/ /home/apl/
+COPY --from=builder --chown=apl:apl /home/apl/.bash_profile /home/apl/.bash_profile
+COPY --from=builder --chown=apl:apl /home/apl/.bashrc /home/apl/.bashrc
+COPY --from=builder --chown=apl:apl /home/apl/.local/share/uv/python/ /home/apl/.local/share/uv/python/
+COPY --from=builder --chown=apl:apl /home/apl/.venv/ /home/apl/.venv/
 COPY --from=builder --chown=apl:apl /app/ibet-Prime/ /app/ibet-Prime/
 COPY --from=builder --chown=apl:apl /usr/local/bin/uv /usr/local/bin/uv
 COPY --from=builder --chown=apl:apl /usr/local/bin/uvx /usr/local/bin/uvx

--- a/tests/Dockerfile_unittest
+++ b/tests/Dockerfile_unittest
@@ -77,6 +77,11 @@ COPY uv.lock /app/ibet-Prime/uv.lock
 RUN cd /app/ibet-Prime \
  && uv venv $UV_PROJECT_ENVIRONMENT \
  && uv sync --frozen --no-install-project \
+ && PYTHON_BIN="$(uv python find $PYTHON_VERSION)" \
+ && PYTHON_ROOT="$(dirname "$(dirname "$PYTHON_BIN")")" \
+ && rm -f "$PYTHON_ROOT"/bin/pip "$PYTHON_ROOT"/bin/pip3 "$PYTHON_ROOT"/bin/pip3.* \
+ && rm -rf "$PYTHON_ROOT"/lib/python*/site-packages/pip "$PYTHON_ROOT"/lib/python*/site-packages/pip-*.dist-info \
+ && rm -rf /home/apl/.cache/uv \
  && rm -f /app/ibet-Prime/pyproject.toml \
  && rm -f /app/ibet-Prime/uv.lock
 
@@ -118,7 +123,10 @@ RUN chmod -R 755 /app/ibet-Prime/tests/
 
 # copy python and dependencies from builder stage
 USER apl
-COPY --from=builder --chown=apl:apl /home/apl/ /home/apl/
+COPY --from=builder --chown=apl:apl /home/apl/.bash_profile /home/apl/.bash_profile
+COPY --from=builder --chown=apl:apl /home/apl/.bashrc /home/apl/.bashrc
+COPY --from=builder --chown=apl:apl /home/apl/.local/share/uv/python/ /home/apl/.local/share/uv/python/
+COPY --from=builder --chown=apl:apl /home/apl/.venv/ /home/apl/.venv/
 COPY --from=builder --chown=apl:apl /app/ibet-Prime/ /app/ibet-Prime/
 COPY --from=builder --chown=apl:apl /usr/local/bin/uv /usr/local/bin/uv
 COPY --from=builder --chown=apl:apl /usr/local/bin/uvx /usr/local/bin/uvx

--- a/uv.lock
+++ b/uv.lock
@@ -1002,21 +1002,21 @@ wheels = [
 
 [[package]]
 name = "memray"
-version = "1.19.1"
+version = "1.19.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jinja2" },
     { name = "rich" },
     { name = "textual" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/36/18/5df5995a7b142e12ab194f4b2fd1473efd51f4f622dfe47f3c013c3c11f7/memray-1.19.1.tar.gz", hash = "sha256:7fcf306eae2c00144920b01913f42fa7f235af7a80fa3226ab124672a5cb1d8f", size = 2395421, upload-time = "2025-10-16T02:26:51.513Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/db/56ff21f47be261ab781105b233d1851d3f2fcdd4f08ebf689f6d6fd84f0d/memray-1.19.2.tar.gz", hash = "sha256:680cb90ac4564d140673ac9d8b7a7e07a8405bd1fb8f933da22616f93124ca84", size = 2410256, upload-time = "2026-03-13T15:22:31.825Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/5f/a67da1226dc993501253164bd348d553a522e954057fd1042a74d0ee5768/memray-1.19.1-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:56b20156c2754762ccfcfa03fd88ce33ecd712aacd302ef099a871b3197fe4a2", size = 2185883, upload-time = "2025-10-16T02:25:59.046Z" },
-    { url = "https://files.pythonhosted.org/packages/50/94/e48e6999910b542254e5354b07cac6cad6dd1c4d4f1dd8b2cb16c6bdffc6/memray-1.19.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e9d93995a91a8383fda95a1f7a15247aca2abd2f80f7f7c7ff56b3d89a5d7893", size = 2154720, upload-time = "2025-10-16T02:26:00.547Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/dd/5d90c042c0afce46b42de271b6157ca32048522f7ba8097a602593b2292a/memray-1.19.1-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:500956020d245ad3440cc2fae06c1d781f339e30f8d58654bc5ae9f51f999fab", size = 9745457, upload-time = "2025-10-16T02:26:01.761Z" },
-    { url = "https://files.pythonhosted.org/packages/52/40/617b15e62d5de1718e81ee436a1f19d4d40274ead97ac0eda188baebb986/memray-1.19.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9770b6046a8b7d7bb982c2cefb324a60a0ee7cd7c35c58c0df058355a9a54676", size = 10019011, upload-time = "2025-10-16T02:26:03.75Z" },
-    { url = "https://files.pythonhosted.org/packages/47/9c/cdd27e52876244a8350ade32460eb18ae4a5f69656d0f02474f9fbdb1f85/memray-1.19.1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:89593bfec1924aff4571e7bb00066b1cd832a828d701b0380009d790139aa814", size = 9397754, upload-time = "2025-10-16T02:26:05.934Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/74/17352ebd79117d46064016cce8389d88920da1cb99883cb1838f59221176/memray-1.19.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5dd00e0b4f5820f7a793691c0faeb15e4fbb5472198184605c29d0a961355741", size = 12244258, upload-time = "2025-10-16T02:26:07.614Z" },
+    { url = "https://files.pythonhosted.org/packages/34/10/cbf57c122988d6e3bd148aa374e91e0e2f156cc7db1ac6397eb6db3946d1/memray-1.19.2-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:13aa87ad34cc88b3f31f7205e0a4543c391032e8600dc0c0cbf22555ff816d97", size = 2182910, upload-time = "2026-03-13T15:21:11.357Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/0e/7979dfe7e2b034431e44e3bab86356d9bc2c4f3ed0eb1594cb0ceb38c859/memray-1.19.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d6b249618a3e4fa8e10291445a2b2dfaf6f188e7cc1765966aac8fb52cb22066", size = 2161575, upload-time = "2026-03-13T15:21:13.051Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/92/2f0ca3936cdf4c59bc8c59fc8738ce8854ba24fd8519988f2ece0eba10fa/memray-1.19.2-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:34985e5e638ef8d4d54de8173c5e4481c478930f545bd0eb4738a631beb63d04", size = 9732172, upload-time = "2026-03-13T15:21:15.115Z" },
+    { url = "https://files.pythonhosted.org/packages/52/23/de78510b4e3a0668b793d8b5dff03f2af20eef97943ca5b3263effff799c/memray-1.19.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ee0fcfafd1e8535bdc0d0ed75bcdd48d436a6f62d467df91871366cbb3bbaebc", size = 9999447, upload-time = "2026-03-13T15:21:18.099Z" },
+    { url = "https://files.pythonhosted.org/packages/00/0d/b0e50537470f93bddfa2c134177fe9332c20be44a571588866776ff92b82/memray-1.19.2-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:846185c393ff0dc6bca55819b1c83b510b77d8d561b7c0c50f4873f69579e35d", size = 9379158, upload-time = "2026-03-13T15:21:21.003Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/53/78f6de5c7208821b15cfbbb9da44ab4a5a881a7cc5075f9435a1700320e8/memray-1.19.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8cc31327ed71e9f6ef7e9ed558e764f0e9c3f01da13ad8547734eb65fbeade1d", size = 12226753, upload-time = "2026-03-13T15:21:24.041Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 📌 Description

This pull request updates both the main and test Dockerfiles to optimize the runtime image by cleaning up unnecessary files related to pip and cache directories after building with uv.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- None 

## 🔄 Changes

<!-- List the major changes in this PR. -->

* Added a `RUN` command to both `Dockerfile` and `tests/Dockerfile_unittest` that removes the pip package, pip-related metadata, and pip binaries from the uv-managed Python directory.
* Updated memray patch version in `uv.lock`.

## 📌 Checklist

- [ ] I have added tests where necessary.
- [ ] I have updated the documentation where necessary.
