### PR TITLE
Stabilize block_timestamp pagination across transfer history and lock event APIs (26.6)

### DIFF
--- a/app/routers/issuer/bond.py
+++ b/app/routers/issuer/bond.py
@@ -3512,14 +3512,20 @@ async def list_bond_token_lock_unlock_events(
 
     if request_query.sort_order == 0:  # ASC
         stmt = stmt.order_by(sort_attr)
-        if request_query.sort_item == ListAllTokenLockEventsSortItem.block_timestamp.value:
+        if (
+            request_query.sort_item
+            == ListAllTokenLockEventsSortItem.block_timestamp.value
+        ):
             stmt = stmt.order_by(
                 all_lock_event_alias.c.source_event_order,
                 all_lock_event_alias.c.source_event_id,
             )
     else:  # DESC
         stmt = stmt.order_by(desc(sort_attr))
-        if request_query.sort_item == ListAllTokenLockEventsSortItem.block_timestamp.value:
+        if (
+            request_query.sort_item
+            == ListAllTokenLockEventsSortItem.block_timestamp.value
+        ):
             stmt = stmt.order_by(
                 desc(all_lock_event_alias.c.source_event_order),
                 desc(all_lock_event_alias.c.source_event_id),

--- a/app/routers/issuer/bond.py
+++ b/app/routers/issuer/bond.py
@@ -1031,8 +1031,12 @@ async def list_bond_additional_issuance_history(
 
     if request_query.sort_order == 0:  # ASC
         stmt = stmt.order_by(sort_attr)
+        if request_query.sort_item == IssueRedeemSortItem.BLOCK_TIMESTAMP:
+            stmt = stmt.order_by(IDXIssueRedeem.id)
     else:  # DESC
         stmt = stmt.order_by(desc(sort_attr))
+        if request_query.sort_item == IssueRedeemSortItem.BLOCK_TIMESTAMP:
+            stmt = stmt.order_by(desc(IDXIssueRedeem.id))
     if request_query.sort_item != IssueRedeemSortItem.BLOCK_TIMESTAMP:
         # NOTE: Set secondary sort for consistent results
         stmt = stmt.order_by(desc(IDXIssueRedeem.block_timestamp))
@@ -1464,8 +1468,12 @@ async def list_bond_redemption_history(
 
     if get_query.sort_order == 0:  # ASC
         stmt = stmt.order_by(sort_attr)
+        if get_query.sort_item == IssueRedeemSortItem.BLOCK_TIMESTAMP:
+            stmt = stmt.order_by(IDXIssueRedeem.id)
     else:  # DESC
         stmt = stmt.order_by(desc(sort_attr))
+        if get_query.sort_item == IssueRedeemSortItem.BLOCK_TIMESTAMP:
+            stmt = stmt.order_by(desc(IDXIssueRedeem.id))
     if get_query.sort_item != IssueRedeemSortItem.BLOCK_TIMESTAMP:
         # NOTE: Set secondary sort for consistent results
         stmt = stmt.order_by(desc(IDXIssueRedeem.block_timestamp))
@@ -3391,6 +3399,8 @@ async def list_bond_token_lock_unlock_events(
     stmt_lock = (
         select(
             literal(value=LockEventCategory.Lock.value, type_=String).label("category"),
+            literal(0).label("source_event_order"),
+            IDXLock.id.label("source_event_id"),
             IDXLock.is_forced.label("is_forced"),
             IDXLock.transaction_hash.label("transaction_hash"),
             IDXLock.msg_sender.label("msg_sender"),
@@ -3420,6 +3430,8 @@ async def list_bond_token_lock_unlock_events(
             literal(value=LockEventCategory.Unlock.value, type_=String).label(
                 "category"
             ),
+            literal(1).label("source_event_order"),
+            IDXUnlock.id.label("source_event_id"),
             IDXUnlock.is_forced.label("is_forced"),
             IDXUnlock.transaction_hash.label("transaction_hash"),
             IDXUnlock.msg_sender.label("msg_sender"),
@@ -3500,8 +3512,18 @@ async def list_bond_token_lock_unlock_events(
 
     if request_query.sort_order == 0:  # ASC
         stmt = stmt.order_by(sort_attr)
+        if request_query.sort_item == ListAllTokenLockEventsSortItem.block_timestamp.value:
+            stmt = stmt.order_by(
+                all_lock_event_alias.c.source_event_order,
+                all_lock_event_alias.c.source_event_id,
+            )
     else:  # DESC
         stmt = stmt.order_by(desc(sort_attr))
+        if request_query.sort_item == ListAllTokenLockEventsSortItem.block_timestamp.value:
+            stmt = stmt.order_by(
+                desc(all_lock_event_alias.c.source_event_order),
+                desc(all_lock_event_alias.c.source_event_id),
+            )
 
     if request_query.sort_item != ListAllTokenLockEventsSortItem.block_timestamp.value:
         # NOTE: Set secondary sort for consistent results
@@ -3772,8 +3794,12 @@ async def list_bond_token_transfer_history(
 
     if query.sort_order == 0:  # ASC
         stmt = stmt.order_by(sort_attr)
+        if query.sort_item == ListTransferHistorySortItem.BLOCK_TIMESTAMP:
+            stmt = stmt.order_by(IDXTransfer.id)
     else:  # DESC
         stmt = stmt.order_by(desc(sort_attr))
+        if query.sort_item == ListTransferHistorySortItem.BLOCK_TIMESTAMP:
+            stmt = stmt.order_by(desc(IDXTransfer.id))
     if query.sort_item != ListTransferHistorySortItem.BLOCK_TIMESTAMP:
         # NOTE: Set secondary sort for consistent results
         stmt = stmt.order_by(desc(IDXTransfer.block_timestamp))

--- a/app/routers/issuer/position.py
+++ b/app/routers/issuer/position.py
@@ -331,6 +331,8 @@ async def list_account_lock_unlock_events(
     stmt_lock = (
         select(
             literal(value=LockEventCategory.Lock.value, type_=String).label("category"),
+            literal(0).label("source_event_order"),
+            IDXLock.id.label("source_event_id"),
             IDXLock.is_forced.label("is_forced"),
             IDXLock.transaction_hash.label("transaction_hash"),
             IDXLock.msg_sender.label("msg_sender"),
@@ -359,6 +361,8 @@ async def list_account_lock_unlock_events(
             literal(value=LockEventCategory.Unlock.value, type_=String).label(
                 "category"
             ),
+            literal(1).label("source_event_order"),
+            IDXUnlock.id.label("source_event_id"),
             IDXUnlock.is_forced.label("is_forced"),
             IDXUnlock.transaction_hash.label("transaction_hash"),
             IDXUnlock.msg_sender.label("msg_sender"),
@@ -434,8 +438,18 @@ async def list_account_lock_unlock_events(
     sort_attr = cast(Any, column(sort_item.value))
     if request_query.sort_order == 0:  # ASC
         stmt = stmt.order_by(sort_attr)
+        if request_query.sort_item == ListAllLockEventsSortItem.block_timestamp.value:
+            stmt = stmt.order_by(
+                all_lock_event_alias.c.source_event_order,
+                all_lock_event_alias.c.source_event_id,
+            )
     else:  # DESC
         stmt = stmt.order_by(desc(sort_attr))
+        if request_query.sort_item == ListAllLockEventsSortItem.block_timestamp.value:
+            stmt = stmt.order_by(
+                desc(all_lock_event_alias.c.source_event_order),
+                desc(all_lock_event_alias.c.source_event_id),
+            )
 
     if sort_item != ListAllLockEventsSortItem.block_timestamp:
         # NOTE: Set secondary sort for consistent results

--- a/app/routers/issuer/share.py
+++ b/app/routers/issuer/share.py
@@ -991,8 +991,12 @@ async def list_share_additional_issuance_history(
 
     if request_query.sort_order == 0:  # ASC
         stmt = stmt.order_by(sort_attr)
+        if request_query.sort_item == IDXIssueRedeemSortItem.BLOCK_TIMESTAMP:
+            stmt = stmt.order_by(IDXIssueRedeem.id)
     else:  # DESC
         stmt = stmt.order_by(desc(sort_attr))
+        if request_query.sort_item == IDXIssueRedeemSortItem.BLOCK_TIMESTAMP:
+            stmt = stmt.order_by(desc(IDXIssueRedeem.id))
     if request_query.sort_item != IDXIssueRedeemSortItem.BLOCK_TIMESTAMP:
         # NOTE: Set secondary sort for consistent results
         stmt = stmt.order_by(desc(IDXIssueRedeem.block_timestamp))
@@ -1424,8 +1428,12 @@ async def list_share_redeem_history(
 
     if get_query.sort_order == 0:  # ASC
         stmt = stmt.order_by(sort_attr)
+        if get_query.sort_item == IDXIssueRedeemSortItem.BLOCK_TIMESTAMP:
+            stmt = stmt.order_by(IDXIssueRedeem.id)
     else:  # DESC
         stmt = stmt.order_by(desc(sort_attr))
+        if get_query.sort_item == IDXIssueRedeemSortItem.BLOCK_TIMESTAMP:
+            stmt = stmt.order_by(desc(IDXIssueRedeem.id))
     if get_query.sort_item != IDXIssueRedeemSortItem.BLOCK_TIMESTAMP:
         # NOTE: Set secondary sort for consistent results
         stmt = stmt.order_by(desc(IDXIssueRedeem.block_timestamp))
@@ -3324,6 +3332,8 @@ async def list_share_token_lock_unlock_events(
     stmt_lock = (
         select(
             literal(value=LockEventCategory.Lock.value, type_=String).label("category"),
+            literal(0).label("source_event_order"),
+            IDXLock.id.label("source_event_id"),
             IDXLock.is_forced.label("is_forced"),
             IDXLock.transaction_hash.label("transaction_hash"),
             IDXLock.msg_sender.label("msg_sender"),
@@ -3353,6 +3363,8 @@ async def list_share_token_lock_unlock_events(
             literal(value=LockEventCategory.Unlock.value, type_=String).label(
                 "category"
             ),
+            literal(1).label("source_event_order"),
+            IDXUnlock.id.label("source_event_id"),
             IDXUnlock.is_forced.label("is_forced"),
             IDXUnlock.transaction_hash.label("transaction_hash"),
             IDXUnlock.msg_sender.label("msg_sender"),
@@ -3433,8 +3445,18 @@ async def list_share_token_lock_unlock_events(
 
     if sort_order == 0:  # ASC
         stmt = stmt.order_by(sort_attr)
+        if sort_item == ListAllTokenLockEventsSortItem.block_timestamp.value:
+            stmt = stmt.order_by(
+                all_lock_event_alias.c.source_event_order,
+                all_lock_event_alias.c.source_event_id,
+            )
     else:  # DESC
         stmt = stmt.order_by(desc(sort_attr))
+        if sort_item == ListAllTokenLockEventsSortItem.block_timestamp.value:
+            stmt = stmt.order_by(
+                desc(all_lock_event_alias.c.source_event_order),
+                desc(all_lock_event_alias.c.source_event_id),
+            )
 
     if sort_item != ListAllTokenLockEventsSortItem.block_timestamp:
         # NOTE: Set secondary sort for consistent results
@@ -3706,8 +3728,12 @@ async def list_share_token_transfer_history(
 
     if query.sort_order == 0:  # ASC
         stmt = stmt.order_by(sort_attr)
+        if query.sort_item == ListTransferHistorySortItem.BLOCK_TIMESTAMP:
+            stmt = stmt.order_by(IDXTransfer.id)
     else:  # DESC
         stmt = stmt.order_by(desc(sort_attr))
+        if query.sort_item == ListTransferHistorySortItem.BLOCK_TIMESTAMP:
+            stmt = stmt.order_by(desc(IDXTransfer.id))
     if query.sort_item != ListTransferHistorySortItem.BLOCK_TIMESTAMP:
         # NOTE: Set secondary sort for consistent results
         stmt = stmt.order_by(desc(IDXTransfer.block_timestamp))

--- a/app/routers/issuer/token_holders.py
+++ b/app/routers/issuer/token_holders.py
@@ -268,8 +268,10 @@ async def list_all_token_holders_personal_info_history(
     # Sort
     if get_query.sort_order == 0:
         stmt = stmt.order_by(IDXPersonalInfoHistory.block_timestamp)
+        stmt = stmt.order_by(IDXPersonalInfoHistory.id)
     else:
         stmt = stmt.order_by(desc(IDXPersonalInfoHistory.block_timestamp))
+        stmt = stmt.order_by(desc(IDXPersonalInfoHistory.id))
 
     # Pagination
     if get_query.limit is not None:

--- a/tests/app/test_bond_additional_issue_ListBondAdditionalIssuanceHistory.py
+++ b/tests/app/test_bond_additional_issue_ListBondAdditionalIssuanceHistory.py
@@ -347,7 +347,7 @@ class TestListBondAdditionalIssuanceHistory:
     # Normal_5
     # Pagination with same block_timestamp
     @pytest.mark.asyncio
-    async def test_normal_5(self, async_client, async_db):
+    async def test_normal_5(self, async_client: AsyncClient, async_db: AsyncSession):
         # prepare data: Token
         _token = Token()
         _token.type = TokenType.IBET_STRAIGHT_BOND
@@ -371,7 +371,7 @@ class TestListBondAdditionalIssuanceHistory:
 
         await async_db.commit()
 
-        returned_amounts = []
+        returned_amounts: list[int] = []
         for offset in range(0, 3):
             resp = await async_client.get(
                 self.base_url.format(self.test_token_address),

--- a/tests/app/test_bond_additional_issue_ListBondAdditionalIssuanceHistory.py
+++ b/tests/app/test_bond_additional_issue_ListBondAdditionalIssuanceHistory.py
@@ -347,9 +347,7 @@ class TestListBondAdditionalIssuanceHistory:
     # Normal_5
     # Pagination with same block_timestamp
     @pytest.mark.asyncio
-    async def test_normal_5(
-        self, async_client, async_db
-    ):
+    async def test_normal_5(self, async_client, async_db):
         # prepare data: Token
         _token = Token()
         _token.type = TokenType.IBET_STRAIGHT_BOND

--- a/tests/app/test_bond_additional_issue_ListBondAdditionalIssuanceHistory.py
+++ b/tests/app/test_bond_additional_issue_ListBondAdditionalIssuanceHistory.py
@@ -344,6 +344,53 @@ class TestListBondAdditionalIssuanceHistory:
             ],
         }
 
+    # Normal_5
+    # Pagination with same block_timestamp
+    @pytest.mark.asyncio
+    async def test_normal_5(
+        self, async_client, async_db
+    ):
+        # prepare data: Token
+        _token = Token()
+        _token.type = TokenType.IBET_STRAIGHT_BOND
+        _token.tx_hash = self.test_transaction_hash
+        _token.issuer_address = self.test_issuer_address
+        _token.token_address = self.test_token_address
+        _token.abi = {}
+        _token.version = TokenVersion.V_25_09
+        async_db.add(_token)
+
+        for amount in self.test_amount:
+            _record = IDXIssueRedeem()
+            _record.event_type = IDXIssueRedeemEventType.ISSUE
+            _record.transaction_hash = self.test_transaction_hash
+            _record.token_address = self.test_token_address
+            _record.locked_address = self.test_locked_address
+            _record.target_address = self.test_target_address
+            _record.amount = amount
+            _record.block_timestamp = self.test_block_timestamp[0]
+            async_db.add(_record)
+
+        await async_db.commit()
+
+        returned_amounts = []
+        for offset in range(0, 3):
+            resp = await async_client.get(
+                self.base_url.format(self.test_token_address),
+                params={"offset": offset, "limit": 1},
+            )
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["result_set"] == {
+                "count": 3,
+                "offset": offset,
+                "limit": 1,
+                "total": 3,
+            }
+            returned_amounts.append(body["history"][0]["amount"])
+
+        assert returned_amounts == [30, 20, 10]
+
     ###########################################################################
     # Error Case
     ###########################################################################

--- a/tests/app/test_bond_lock_events_ListBondTokenLockUnlockEvents.py
+++ b/tests/app/test_bond_lock_events_ListBondTokenLockUnlockEvents.py
@@ -605,7 +605,10 @@ class TestListBondTokenLockUnlockEvents:
     @mock.patch("app.model.ibet.token.IbetStraightBondContract.get")
     @pytest.mark.asyncio
     async def test_normal_8(
-        self, mock_IbetStraightBondContract_get, async_client, async_db
+        self,
+        mock_IbetStraightBondContract_get: MagicMock,
+        async_client: AsyncClient,
+        async_db: AsyncSession,
     ):
         # prepare data: Token
         _token = Token()
@@ -663,7 +666,7 @@ class TestListBondTokenLockUnlockEvents:
             [self.token_name_1]
         )[0]
 
-        returned_events = []
+        returned_events: list[tuple[str, str]] = []
         for offset in range(0, 3):
             resp = await async_client.get(
                 self.base_url.format(token_address=self.token_address_1),

--- a/tests/app/test_bond_lock_events_ListBondTokenLockUnlockEvents.py
+++ b/tests/app/test_bond_lock_events_ListBondTokenLockUnlockEvents.py
@@ -600,6 +600,96 @@ class TestListBondTokenLockUnlockEvents:
             "events": [self.expected_unlock_1],
         }
 
+    # Normal_8
+    # Pagination with same block_timestamp
+    @mock.patch("app.model.ibet.token.IbetStraightBondContract.get")
+    @pytest.mark.asyncio
+    async def test_normal_8(
+        self, mock_IbetStraightBondContract_get, async_client, async_db
+    ):
+        # prepare data: Token
+        _token = Token()
+        _token.token_address = self.token_address_1
+        _token.issuer_address = self.issuer_address
+        _token.type = TokenType.IBET_STRAIGHT_BOND
+        _token.tx_hash = ""
+        _token.abi = {}
+        _token.version = TokenVersion.V_25_09
+        async_db.add(_token)
+
+        same_timestamp = datetime(2024, 1, 1, tzinfo=UTC).replace(tzinfo=None)
+
+        _lock = IDXLock()
+        _lock.transaction_hash = "tx_hash_1"
+        _lock.msg_sender = self.account_address_1
+        _lock.block_number = 1
+        _lock.token_address = self.token_address_1
+        _lock.lock_address = self.lock_address_1
+        _lock.account_address = self.account_address_1
+        _lock.value = 1
+        _lock.data = {"message": "locked_1"}
+        _lock.block_timestamp = same_timestamp
+        async_db.add(_lock)
+
+        _unlock = IDXUnlock()
+        _unlock.transaction_hash = "tx_hash_2"
+        _unlock.msg_sender = self.lock_address_1
+        _unlock.block_number = 2
+        _unlock.token_address = self.token_address_1
+        _unlock.lock_address = self.lock_address_1
+        _unlock.account_address = self.account_address_1
+        _unlock.recipient_address = self.other_account_address_1
+        _unlock.value = 1
+        _unlock.data = {"message": "unlocked_1"}
+        _unlock.block_timestamp = same_timestamp
+        async_db.add(_unlock)
+
+        _unlock = IDXUnlock()
+        _unlock.transaction_hash = "tx_hash_3"
+        _unlock.msg_sender = self.lock_address_1
+        _unlock.block_number = 3
+        _unlock.token_address = self.token_address_1
+        _unlock.lock_address = self.lock_address_1
+        _unlock.account_address = self.account_address_1
+        _unlock.recipient_address = self.other_account_address_2
+        _unlock.value = 1
+        _unlock.data = {"message": "unlocked_2"}
+        _unlock.block_timestamp = same_timestamp
+        async_db.add(_unlock)
+
+        await async_db.commit()
+
+        mock_IbetStraightBondContract_get.return_value = self.get_contract_mock_data(
+            [self.token_name_1]
+        )[0]
+
+        returned_events = []
+        for offset in range(0, 3):
+            resp = await async_client.get(
+                self.base_url.format(token_address=self.token_address_1),
+                params={"offset": offset, "limit": 1},
+            )
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["result_set"] == {
+                "count": 3,
+                "offset": offset,
+                "limit": 1,
+                "total": 3,
+            }
+            returned_events.append(
+                (
+                    body["events"][0]["category"],
+                    body["events"][0]["transaction_hash"],
+                )
+            )
+
+        assert returned_events == [
+            ("Unlock", "tx_hash_3"),
+            ("Unlock", "tx_hash_2"),
+            ("Lock", "tx_hash_1"),
+        ]
+
     # ###########################################################################
     # # Error Case
     # ###########################################################################

--- a/tests/app/test_bond_redeem_ListBondRedemptionHistory.py
+++ b/tests/app/test_bond_redeem_ListBondRedemptionHistory.py
@@ -344,6 +344,53 @@ class TestListBondRedemptionHistory:
             ],
         }
 
+    # Normal_5
+    # Pagination with same block_timestamp
+    @pytest.mark.asyncio
+    async def test_normal_5(
+        self, async_client, async_db
+    ):
+        # prepare data: Token
+        _token = Token()
+        _token.type = TokenType.IBET_STRAIGHT_BOND
+        _token.tx_hash = self.test_transaction_hash
+        _token.issuer_address = self.test_issuer_address
+        _token.token_address = self.test_token_address
+        _token.abi = {}
+        _token.version = TokenVersion.V_25_09
+        async_db.add(_token)
+
+        for amount in self.test_amount:
+            _record = IDXIssueRedeem()
+            _record.event_type = IDXIssueRedeemEventType.REDEEM
+            _record.transaction_hash = self.test_transaction_hash
+            _record.token_address = self.test_token_address
+            _record.locked_address = self.test_locked_address
+            _record.target_address = self.test_target_address
+            _record.amount = amount
+            _record.block_timestamp = self.test_block_timestamp[0]
+            async_db.add(_record)
+
+        await async_db.commit()
+
+        returned_amounts = []
+        for offset in range(0, 3):
+            resp = await async_client.get(
+                self.base_url.format(self.test_token_address),
+                params={"offset": offset, "limit": 1},
+            )
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["result_set"] == {
+                "count": 3,
+                "offset": offset,
+                "limit": 1,
+                "total": 3,
+            }
+            returned_amounts.append(body["history"][0]["amount"])
+
+        assert returned_amounts == [30, 20, 10]
+
     ###########################################################################
     # Error Case
     ###########################################################################

--- a/tests/app/test_bond_redeem_ListBondRedemptionHistory.py
+++ b/tests/app/test_bond_redeem_ListBondRedemptionHistory.py
@@ -347,9 +347,7 @@ class TestListBondRedemptionHistory:
     # Normal_5
     # Pagination with same block_timestamp
     @pytest.mark.asyncio
-    async def test_normal_5(
-        self, async_client, async_db
-    ):
+    async def test_normal_5(self, async_client, async_db):
         # prepare data: Token
         _token = Token()
         _token.type = TokenType.IBET_STRAIGHT_BOND

--- a/tests/app/test_bond_redeem_ListBondRedemptionHistory.py
+++ b/tests/app/test_bond_redeem_ListBondRedemptionHistory.py
@@ -347,7 +347,7 @@ class TestListBondRedemptionHistory:
     # Normal_5
     # Pagination with same block_timestamp
     @pytest.mark.asyncio
-    async def test_normal_5(self, async_client, async_db):
+    async def test_normal_5(self, async_client: AsyncClient, async_db: AsyncSession):
         # prepare data: Token
         _token = Token()
         _token.type = TokenType.IBET_STRAIGHT_BOND
@@ -371,7 +371,7 @@ class TestListBondRedemptionHistory:
 
         await async_db.commit()
 
-        returned_amounts = []
+        returned_amounts: list[int] = []
         for offset in range(0, 3):
             resp = await async_client.get(
                 self.base_url.format(self.test_token_address),

--- a/tests/app/test_bond_transfers_ListBondTokenTransferHistory.py
+++ b/tests/app/test_bond_transfers_ListBondTokenTransferHistory.py
@@ -144,10 +144,12 @@ class TestAppRoutersBondTransfersGET:
         }
         assert resp.json() == assumed_response
 
-    # <Normal_2>
+    # <Normal_2_1>
     # offset, limit
     @pytest.mark.asyncio
-    async def test_normal_2(self, async_client: AsyncClient, async_db: AsyncSession):
+    async def test_normal_2_1(
+        self, async_client: AsyncClient, async_db: AsyncSession
+    ):
         # prepare data: Token
         _token = Token()
         _token.type = TokenType.IBET_STRAIGHT_BOND
@@ -249,6 +251,54 @@ class TestAppRoutersBondTransfersGET:
             ],
         }
         assert resp.json() == assumed_response
+
+    # <Normal_2_2>
+    # offset, limit with same block_timestamp
+    @pytest.mark.asyncio
+    async def test_normal_2_2(
+        self, async_client, async_db
+    ):
+        # prepare data: Token
+        _token = Token()
+        _token.type = TokenType.IBET_STRAIGHT_BOND
+        _token.tx_hash = self.test_transaction_hash
+        _token.issuer_address = self.test_issuer_address
+        _token.token_address = self.test_token_address
+        _token.abi = {}
+        _token.version = TokenVersion.V_25_09
+        async_db.add(_token)
+
+        for amount in range(0, 3):
+            _idx_transfer = IDXTransfer()
+            _idx_transfer.transaction_hash = self.test_transaction_hash
+            _idx_transfer.token_address = self.test_token_address
+            _idx_transfer.from_address = self.test_from_address_1
+            _idx_transfer.to_address = self.test_to_address_1
+            _idx_transfer.amount = amount
+            _idx_transfer.source_event = IDXTransferSourceEventType.TRANSFER
+            _idx_transfer.data = None
+            _idx_transfer.block_timestamp = self.test_block_timestamp[0]
+            async_db.add(_idx_transfer)
+
+        await async_db.commit()
+
+        returned_amounts = []
+        for offset in range(0, 3):
+            resp = await async_client.get(
+                self.base_url.format(self.test_token_address),
+                params={"offset": offset, "limit": 1},
+            )
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["result_set"] == {
+                "count": 3,
+                "offset": offset,
+                "limit": 1,
+                "total": 3,
+            }
+            returned_amounts.append(body["transfer_history"][0]["amount"])
+
+        assert returned_amounts == [2, 1, 0]
 
     # <Normal_3_1>
     # filter: block_timestamp_from

--- a/tests/app/test_bond_transfers_ListBondTokenTransferHistory.py
+++ b/tests/app/test_bond_transfers_ListBondTokenTransferHistory.py
@@ -147,9 +147,7 @@ class TestAppRoutersBondTransfersGET:
     # <Normal_2_1>
     # offset, limit
     @pytest.mark.asyncio
-    async def test_normal_2_1(
-        self, async_client: AsyncClient, async_db: AsyncSession
-    ):
+    async def test_normal_2_1(self, async_client: AsyncClient, async_db: AsyncSession):
         # prepare data: Token
         _token = Token()
         _token.type = TokenType.IBET_STRAIGHT_BOND
@@ -255,9 +253,7 @@ class TestAppRoutersBondTransfersGET:
     # <Normal_2_2>
     # offset, limit with same block_timestamp
     @pytest.mark.asyncio
-    async def test_normal_2_2(
-        self, async_client, async_db
-    ):
+    async def test_normal_2_2(self, async_client, async_db):
         # prepare data: Token
         _token = Token()
         _token.type = TokenType.IBET_STRAIGHT_BOND

--- a/tests/app/test_bond_transfers_ListBondTokenTransferHistory.py
+++ b/tests/app/test_bond_transfers_ListBondTokenTransferHistory.py
@@ -253,7 +253,7 @@ class TestAppRoutersBondTransfersGET:
     # <Normal_2_2>
     # offset, limit with same block_timestamp
     @pytest.mark.asyncio
-    async def test_normal_2_2(self, async_client, async_db):
+    async def test_normal_2_2(self, async_client: AsyncClient, async_db: AsyncSession):
         # prepare data: Token
         _token = Token()
         _token.type = TokenType.IBET_STRAIGHT_BOND
@@ -278,7 +278,7 @@ class TestAppRoutersBondTransfersGET:
 
         await async_db.commit()
 
-        returned_amounts = []
+        returned_amounts: list[int] = []
         for offset in range(0, 3):
             resp = await async_client.get(
                 self.base_url.format(self.test_token_address),

--- a/tests/app/test_positions_ListAccountLockUnlockEvents.py
+++ b/tests/app/test_positions_ListAccountLockUnlockEvents.py
@@ -1392,6 +1392,104 @@ class TestListAccountLockUnlockEvents:
             ],
         }
 
+    # Normal_8
+    # Pagination with same block_timestamp
+    @mock.patch("app.model.ibet.token.IbetStraightBondContract.get")
+    @pytest.mark.asyncio
+    async def test_normal_8(
+        self, mock_IbetStraightBondContract_get, async_client, async_db
+    ):
+        issuer_address = "0x1234567890123456789012345678900000000100"
+        account_address = "0x1234567890123456789012345678900000000000"
+        other_account_address_1 = "0x1234567890123456789012345678911111111111"
+        other_account_address_2 = "0x1234567890123456789012345678922222222222"
+        lock_address_1 = "0x1234567890123456789012345678900000000001"
+        token_address_1 = "0x1234567890123456789012345678900000000010"
+        token_name_1 = "test_bond_1"
+
+        # prepare data: Token
+        _token = Token()
+        _token.token_address = token_address_1
+        _token.issuer_address = issuer_address
+        _token.type = TokenType.IBET_STRAIGHT_BOND
+        _token.tx_hash = ""
+        _token.abi = {}
+        _token.version = TokenVersion.V_25_09
+        async_db.add(_token)
+
+        same_timestamp = datetime(2024, 1, 1, tzinfo=UTC).replace(tzinfo=None)
+
+        _lock = IDXLock()
+        _lock.transaction_hash = "tx_hash_1"
+        _lock.msg_sender = account_address
+        _lock.block_number = 1
+        _lock.token_address = token_address_1
+        _lock.lock_address = lock_address_1
+        _lock.account_address = account_address
+        _lock.value = 1
+        _lock.data = {"message": "locked_1"}
+        _lock.block_timestamp = same_timestamp
+        async_db.add(_lock)
+
+        _unlock = IDXUnlock()
+        _unlock.transaction_hash = "tx_hash_2"
+        _unlock.msg_sender = lock_address_1
+        _unlock.block_number = 2
+        _unlock.token_address = token_address_1
+        _unlock.lock_address = lock_address_1
+        _unlock.account_address = account_address
+        _unlock.recipient_address = other_account_address_1
+        _unlock.value = 1
+        _unlock.data = {"message": "unlocked_1"}
+        _unlock.block_timestamp = same_timestamp
+        async_db.add(_unlock)
+
+        _unlock = IDXUnlock()
+        _unlock.transaction_hash = "tx_hash_3"
+        _unlock.msg_sender = lock_address_1
+        _unlock.block_number = 3
+        _unlock.token_address = token_address_1
+        _unlock.lock_address = lock_address_1
+        _unlock.account_address = account_address
+        _unlock.recipient_address = other_account_address_2
+        _unlock.value = 1
+        _unlock.data = {"message": "unlocked_2"}
+        _unlock.block_timestamp = same_timestamp
+        async_db.add(_unlock)
+
+        await async_db.commit()
+
+        bond_1 = IbetStraightBondContract()
+        bond_1.name = token_name_1
+        mock_IbetStraightBondContract_get.return_value = bond_1
+
+        returned_events = []
+        for offset in range(0, 3):
+            resp = await async_client.get(
+                self.base_url.format(account_address=account_address),
+                params={"offset": offset, "limit": 1},
+            )
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["result_set"] == {
+                "count": 3,
+                "offset": offset,
+                "limit": 1,
+                "total": 3,
+            }
+            returned_events.append(
+                (
+                    body["events"][0]["category"],
+                    body["events"][0]["transaction_hash"],
+                )
+            )
+
+        assert returned_events == [
+            ("Unlock", "tx_hash_3"),
+            ("Unlock", "tx_hash_2"),
+            ("Lock", "tx_hash_1"),
+        ]
+
     # ###########################################################################
     # # Error Case
     # ###########################################################################

--- a/tests/app/test_positions_ListAccountLockUnlockEvents.py
+++ b/tests/app/test_positions_ListAccountLockUnlockEvents.py
@@ -19,9 +19,11 @@ SPDX-License-Identifier: Apache-2.0
 
 from datetime import UTC, datetime
 from unittest import mock
-from unittest.mock import ANY
+from unittest.mock import ANY, MagicMock
 
 import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.model.db import IDXLock, IDXUnlock, Token, TokenType, TokenVersion
 from app.model.ibet import IbetShareContract, IbetStraightBondContract
@@ -1397,7 +1399,10 @@ class TestListAccountLockUnlockEvents:
     @mock.patch("app.model.ibet.token.IbetStraightBondContract.get")
     @pytest.mark.asyncio
     async def test_normal_8(
-        self, mock_IbetStraightBondContract_get, async_client, async_db
+        self,
+        mock_IbetStraightBondContract_get: MagicMock,
+        async_client: AsyncClient,
+        async_db: AsyncSession,
     ):
         issuer_address = "0x1234567890123456789012345678900000000100"
         account_address = "0x1234567890123456789012345678900000000000"
@@ -1463,7 +1468,7 @@ class TestListAccountLockUnlockEvents:
         bond_1.name = token_name_1
         mock_IbetStraightBondContract_get.return_value = bond_1
 
-        returned_events = []
+        returned_events: list[tuple[str, str]] = []
         for offset in range(0, 3):
             resp = await async_client.get(
                 self.base_url.format(account_address=account_address),

--- a/tests/app/test_share_additional_issue_ListShareAdditionalIssuanceHistory.py
+++ b/tests/app/test_share_additional_issue_ListShareAdditionalIssuanceHistory.py
@@ -347,9 +347,7 @@ class TestListShareAdditionalIssuanceHistory:
     # Normal_5
     # Pagination with same block_timestamp
     @pytest.mark.asyncio
-    async def test_normal_5(
-        self, async_client, async_db
-    ):
+    async def test_normal_5(self, async_client, async_db):
         # prepare data: Token
         _token = Token()
         _token.type = TokenType.IBET_SHARE

--- a/tests/app/test_share_additional_issue_ListShareAdditionalIssuanceHistory.py
+++ b/tests/app/test_share_additional_issue_ListShareAdditionalIssuanceHistory.py
@@ -344,6 +344,58 @@ class TestListShareAdditionalIssuanceHistory:
             ],
         }
 
+    # Normal_5
+    # Pagination with same block_timestamp
+    @pytest.mark.asyncio
+    async def test_normal_5(
+        self, async_client, async_db
+    ):
+        # prepare data: Token
+        _token = Token()
+        _token.type = TokenType.IBET_SHARE
+        _token.tx_hash = self.test_transaction_hash
+        _token.issuer_address = self.test_issuer_address
+        _token.token_address = self.test_token_address
+        _token.abi = {}
+        _token.version = TokenVersion.V_25_09
+        async_db.add(_token)
+
+        for amount in self.test_amount:
+            _record = IDXIssueRedeem()
+            _record.event_type = IDXIssueRedeemEventType.ISSUE
+            _record.transaction_hash = self.test_transaction_hash
+            _record.token_address = self.test_token_address
+            _record.locked_address = self.test_locked_address
+            _record.target_address = self.test_target_address
+            _record.amount = amount
+            _record.block_timestamp = self.test_block_timestamp[0]
+            async_db.add(_record)
+
+        await async_db.commit()
+
+        returned_amounts = []
+        for offset in range(0, 3):
+            resp = await async_client.get(
+                self.base_url.format(self.test_token_address),
+                params={
+                    "sort_item": IDXIssueRedeemSortItem.BLOCK_TIMESTAMP.value,
+                    "sort_order": 0,
+                    "offset": offset,
+                    "limit": 1,
+                },
+            )
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["result_set"] == {
+                "count": 3,
+                "offset": offset,
+                "limit": 1,
+                "total": 3,
+            }
+            returned_amounts.append(body["history"][0]["amount"])
+
+        assert returned_amounts == [10, 20, 30]
+
     ###########################################################################
     # Error Case
     ###########################################################################

--- a/tests/app/test_share_additional_issue_ListShareAdditionalIssuanceHistory.py
+++ b/tests/app/test_share_additional_issue_ListShareAdditionalIssuanceHistory.py
@@ -347,7 +347,7 @@ class TestListShareAdditionalIssuanceHistory:
     # Normal_5
     # Pagination with same block_timestamp
     @pytest.mark.asyncio
-    async def test_normal_5(self, async_client, async_db):
+    async def test_normal_5(self, async_client: AsyncClient, async_db: AsyncSession):
         # prepare data: Token
         _token = Token()
         _token.type = TokenType.IBET_SHARE
@@ -371,7 +371,7 @@ class TestListShareAdditionalIssuanceHistory:
 
         await async_db.commit()
 
-        returned_amounts = []
+        returned_amounts: list[int] = []
         for offset in range(0, 3):
             resp = await async_client.get(
                 self.base_url.format(self.test_token_address),

--- a/tests/app/test_share_lock_events_ListShareTokenLockUnlockEvents.py
+++ b/tests/app/test_share_lock_events_ListShareTokenLockUnlockEvents.py
@@ -602,9 +602,7 @@ class TestListShareTokenLockUnlockEvents:
     # Pagination with same block_timestamp
     @mock.patch("app.model.ibet.token.IbetShareContract.get")
     @pytest.mark.asyncio
-    async def test_normal_8(
-        self, mock_IbetShareContract_get, async_client, async_db
-    ):
+    async def test_normal_8(self, mock_IbetShareContract_get, async_client, async_db):
         # prepare data: Token
         _token = Token()
         _token.token_address = self.token_address_1

--- a/tests/app/test_share_lock_events_ListShareTokenLockUnlockEvents.py
+++ b/tests/app/test_share_lock_events_ListShareTokenLockUnlockEvents.py
@@ -598,6 +598,101 @@ class TestListShareTokenLockUnlockEvents:
             "events": [self.expected_unlock_1],
         }
 
+    # Normal_8
+    # Pagination with same block_timestamp
+    @mock.patch("app.model.ibet.token.IbetShareContract.get")
+    @pytest.mark.asyncio
+    async def test_normal_8(
+        self, mock_IbetShareContract_get, async_client, async_db
+    ):
+        # prepare data: Token
+        _token = Token()
+        _token.token_address = self.token_address_1
+        _token.issuer_address = self.issuer_address
+        _token.type = TokenType.IBET_SHARE
+        _token.tx_hash = ""
+        _token.abi = {}
+        _token.version = TokenVersion.V_25_09
+        async_db.add(_token)
+
+        same_timestamp = datetime(2024, 1, 1, tzinfo=UTC).replace(tzinfo=None)
+
+        _lock = IDXLock()
+        _lock.transaction_hash = "tx_hash_1"
+        _lock.msg_sender = self.account_address_1
+        _lock.block_number = 1
+        _lock.token_address = self.token_address_1
+        _lock.lock_address = self.lock_address_1
+        _lock.account_address = self.account_address_1
+        _lock.value = 1
+        _lock.data = {"message": "locked_1"}
+        _lock.block_timestamp = same_timestamp
+        async_db.add(_lock)
+
+        _unlock = IDXUnlock()
+        _unlock.transaction_hash = "tx_hash_2"
+        _unlock.msg_sender = self.lock_address_1
+        _unlock.block_number = 2
+        _unlock.token_address = self.token_address_1
+        _unlock.lock_address = self.lock_address_1
+        _unlock.account_address = self.account_address_1
+        _unlock.recipient_address = self.other_account_address_1
+        _unlock.value = 1
+        _unlock.data = {"message": "unlocked_1"}
+        _unlock.block_timestamp = same_timestamp
+        async_db.add(_unlock)
+
+        _unlock = IDXUnlock()
+        _unlock.transaction_hash = "tx_hash_3"
+        _unlock.msg_sender = self.lock_address_1
+        _unlock.block_number = 3
+        _unlock.token_address = self.token_address_1
+        _unlock.lock_address = self.lock_address_1
+        _unlock.account_address = self.account_address_1
+        _unlock.recipient_address = self.other_account_address_2
+        _unlock.value = 1
+        _unlock.data = {"message": "unlocked_2"}
+        _unlock.block_timestamp = same_timestamp
+        async_db.add(_unlock)
+
+        await async_db.commit()
+
+        mock_IbetShareContract_get.return_value = self.get_contract_mock_data(
+            [self.token_name_1]
+        )[0]
+
+        returned_events = []
+        for offset in range(0, 3):
+            resp = await async_client.get(
+                self.base_url.format(token_address=self.token_address_1),
+                params={
+                    "sort_item": "block_timestamp",
+                    "sort_order": 0,
+                    "offset": offset,
+                    "limit": 1,
+                },
+            )
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["result_set"] == {
+                "count": 3,
+                "offset": offset,
+                "limit": 1,
+                "total": 3,
+            }
+            returned_events.append(
+                (
+                    body["events"][0]["category"],
+                    body["events"][0]["transaction_hash"],
+                )
+            )
+
+        assert returned_events == [
+            ("Lock", "tx_hash_1"),
+            ("Unlock", "tx_hash_2"),
+            ("Unlock", "tx_hash_3"),
+        ]
+
     # ###########################################################################
     # # Error Case
     # ###########################################################################

--- a/tests/app/test_share_lock_events_ListShareTokenLockUnlockEvents.py
+++ b/tests/app/test_share_lock_events_ListShareTokenLockUnlockEvents.py
@@ -602,7 +602,12 @@ class TestListShareTokenLockUnlockEvents:
     # Pagination with same block_timestamp
     @mock.patch("app.model.ibet.token.IbetShareContract.get")
     @pytest.mark.asyncio
-    async def test_normal_8(self, mock_IbetShareContract_get, async_client, async_db):
+    async def test_normal_8(
+        self,
+        mock_IbetShareContract_get: MagicMock,
+        async_client: AsyncClient,
+        async_db: AsyncSession,
+    ):
         # prepare data: Token
         _token = Token()
         _token.token_address = self.token_address_1
@@ -659,7 +664,7 @@ class TestListShareTokenLockUnlockEvents:
             [self.token_name_1]
         )[0]
 
-        returned_events = []
+        returned_events: list[tuple[str, str]] = []
         for offset in range(0, 3):
             resp = await async_client.get(
                 self.base_url.format(token_address=self.token_address_1),

--- a/tests/app/test_share_redeem_ListShareRedemptionHistory.py
+++ b/tests/app/test_share_redeem_ListShareRedemptionHistory.py
@@ -347,9 +347,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemGET:
     # Normal_5
     # Pagination with same block_timestamp
     @pytest.mark.asyncio
-    async def test_normal_5(
-        self, async_client, async_db
-    ):
+    async def test_normal_5(self, async_client, async_db):
         # prepare data: Token
         _token = Token()
         _token.type = TokenType.IBET_SHARE

--- a/tests/app/test_share_redeem_ListShareRedemptionHistory.py
+++ b/tests/app/test_share_redeem_ListShareRedemptionHistory.py
@@ -347,7 +347,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemGET:
     # Normal_5
     # Pagination with same block_timestamp
     @pytest.mark.asyncio
-    async def test_normal_5(self, async_client, async_db):
+    async def test_normal_5(self, async_client: AsyncClient, async_db: AsyncSession):
         # prepare data: Token
         _token = Token()
         _token.type = TokenType.IBET_SHARE
@@ -371,7 +371,7 @@ class TestAppRoutersShareTokensTokenAddressRedeemGET:
 
         await async_db.commit()
 
-        returned_amounts = []
+        returned_amounts: list[int] = []
         for offset in range(0, 3):
             resp = await async_client.get(
                 self.base_url.format(self.test_token_address),

--- a/tests/app/test_share_redeem_ListShareRedemptionHistory.py
+++ b/tests/app/test_share_redeem_ListShareRedemptionHistory.py
@@ -344,6 +344,58 @@ class TestAppRoutersShareTokensTokenAddressRedeemGET:
             ],
         }
 
+    # Normal_5
+    # Pagination with same block_timestamp
+    @pytest.mark.asyncio
+    async def test_normal_5(
+        self, async_client, async_db
+    ):
+        # prepare data: Token
+        _token = Token()
+        _token.type = TokenType.IBET_SHARE
+        _token.tx_hash = self.test_transaction_hash
+        _token.issuer_address = self.test_issuer_address
+        _token.token_address = self.test_token_address
+        _token.abi = {}
+        _token.version = TokenVersion.V_25_09
+        async_db.add(_token)
+
+        for amount in self.test_amount:
+            _record = IDXIssueRedeem()
+            _record.event_type = IDXIssueRedeemEventType.REDEEM
+            _record.transaction_hash = self.test_transaction_hash
+            _record.token_address = self.test_token_address
+            _record.locked_address = self.test_locked_address
+            _record.target_address = self.test_target_address
+            _record.amount = amount
+            _record.block_timestamp = self.test_block_timestamp[0]
+            async_db.add(_record)
+
+        await async_db.commit()
+
+        returned_amounts = []
+        for offset in range(0, 3):
+            resp = await async_client.get(
+                self.base_url.format(self.test_token_address),
+                params={
+                    "sort_item": IDXIssueRedeemSortItem.BLOCK_TIMESTAMP.value,
+                    "sort_order": 0,
+                    "offset": offset,
+                    "limit": 1,
+                },
+            )
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["result_set"] == {
+                "count": 3,
+                "offset": offset,
+                "limit": 1,
+                "total": 3,
+            }
+            returned_amounts.append(body["history"][0]["amount"])
+
+        assert returned_amounts == [10, 20, 30]
+
     ###########################################################################
     # Error Case
     ###########################################################################

--- a/tests/app/test_share_transfers_ListShareTokenTransferHistory.py
+++ b/tests/app/test_share_transfers_ListShareTokenTransferHistory.py
@@ -147,9 +147,7 @@ class TestListShareTokenTransferHistory:
     # <Normal_2_1>
     # offset, limit
     @pytest.mark.asyncio
-    async def test_normal_2_1(
-        self, async_client: AsyncClient, async_db: AsyncSession
-    ):
+    async def test_normal_2_1(self, async_client: AsyncClient, async_db: AsyncSession):
         # prepare data: Token
         _token = Token()
         _token.type = TokenType.IBET_SHARE
@@ -255,9 +253,7 @@ class TestListShareTokenTransferHistory:
     # <Normal_2_2>
     # offset, limit with same block_timestamp
     @pytest.mark.asyncio
-    async def test_normal_2_2(
-        self, async_client, async_db
-    ):
+    async def test_normal_2_2(self, async_client, async_db):
         # prepare data: Token
         _token = Token()
         _token.type = TokenType.IBET_SHARE

--- a/tests/app/test_share_transfers_ListShareTokenTransferHistory.py
+++ b/tests/app/test_share_transfers_ListShareTokenTransferHistory.py
@@ -144,10 +144,12 @@ class TestListShareTokenTransferHistory:
         }
         assert resp.json() == assumed_response
 
-    # <Normal_2>
+    # <Normal_2_1>
     # offset, limit
     @pytest.mark.asyncio
-    async def test_normal_2(self, async_client: AsyncClient, async_db: AsyncSession):
+    async def test_normal_2_1(
+        self, async_client: AsyncClient, async_db: AsyncSession
+    ):
         # prepare data: Token
         _token = Token()
         _token.type = TokenType.IBET_SHARE
@@ -249,6 +251,59 @@ class TestListShareTokenTransferHistory:
             ],
         }
         assert resp.json() == assumed_response
+
+    # <Normal_2_2>
+    # offset, limit with same block_timestamp
+    @pytest.mark.asyncio
+    async def test_normal_2_2(
+        self, async_client, async_db
+    ):
+        # prepare data: Token
+        _token = Token()
+        _token.type = TokenType.IBET_SHARE
+        _token.tx_hash = self.test_transaction_hash
+        _token.issuer_address = self.test_issuer_address
+        _token.token_address = self.test_token_address
+        _token.abi = {}
+        _token.version = TokenVersion.V_25_09
+        async_db.add(_token)
+
+        for amount in range(0, 3):
+            _idx_transfer = IDXTransfer()
+            _idx_transfer.transaction_hash = self.test_transaction_hash
+            _idx_transfer.token_address = self.test_token_address
+            _idx_transfer.from_address = self.test_from_address_1
+            _idx_transfer.to_address = self.test_to_address_1
+            _idx_transfer.amount = amount
+            _idx_transfer.source_event = IDXTransferSourceEventType.TRANSFER
+            _idx_transfer.data = None
+            _idx_transfer.block_timestamp = self.test_block_timestamp[0]
+            async_db.add(_idx_transfer)
+
+        await async_db.commit()
+
+        returned_amounts = []
+        for offset in range(0, 3):
+            resp = await async_client.get(
+                self.base_url.format(self.test_token_address),
+                params={
+                    "sort_item": "block_timestamp",
+                    "sort_order": 0,
+                    "offset": offset,
+                    "limit": 1,
+                },
+            )
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["result_set"] == {
+                "count": 3,
+                "offset": offset,
+                "limit": 1,
+                "total": 3,
+            }
+            returned_amounts.append(body["transfer_history"][0]["amount"])
+
+        assert returned_amounts == [0, 1, 2]
 
     # <Normal_3_1>
     # filter: block_timestamp_from

--- a/tests/app/test_share_transfers_ListShareTokenTransferHistory.py
+++ b/tests/app/test_share_transfers_ListShareTokenTransferHistory.py
@@ -253,7 +253,7 @@ class TestListShareTokenTransferHistory:
     # <Normal_2_2>
     # offset, limit with same block_timestamp
     @pytest.mark.asyncio
-    async def test_normal_2_2(self, async_client, async_db):
+    async def test_normal_2_2(self, async_client: AsyncClient, async_db: AsyncSession):
         # prepare data: Token
         _token = Token()
         _token.type = TokenType.IBET_SHARE
@@ -278,7 +278,7 @@ class TestListShareTokenTransferHistory:
 
         await async_db.commit()
 
-        returned_amounts = []
+        returned_amounts: list[int] = []
         for offset in range(0, 3):
             resp = await async_client.get(
                 self.base_url.format(self.test_token_address),

--- a/tests/app/test_token_holders_ListTokenHoldersPersonalInfoHistory.py
+++ b/tests/app/test_token_holders_ListTokenHoldersPersonalInfoHistory.py
@@ -1089,12 +1089,8 @@ class TestListTokenHoldersPersonalInfoHistory:
     # <Normal_6>
     # Pagination: same block_timestamp
     @pytest.mark.asyncio
-    async def test_normal_6(
-        self, async_client, async_db
-    ):
-        same_timestamp = datetime(2024, 5, 14, 0, 0, 0, tzinfo=UTC).replace(
-            tzinfo=None
-        )
+    async def test_normal_6(self, async_client, async_db):
+        same_timestamp = datetime(2024, 5, 14, 0, 0, 0, tzinfo=UTC).replace(tzinfo=None)
         created_list = [
             datetime(2024, 5, 14, 0, 0, 2, tzinfo=UTC).replace(tzinfo=None),
             datetime(2024, 5, 14, 0, 0, 0, tzinfo=UTC).replace(tzinfo=None),

--- a/tests/app/test_token_holders_ListTokenHoldersPersonalInfoHistory.py
+++ b/tests/app/test_token_holders_ListTokenHoldersPersonalInfoHistory.py
@@ -1086,6 +1086,63 @@ class TestListTokenHoldersPersonalInfoHistory:
             ],
         }
 
+    # <Normal_6>
+    # Pagination: same block_timestamp
+    @pytest.mark.asyncio
+    async def test_normal_6(
+        self, async_client, async_db
+    ):
+        same_timestamp = datetime(2024, 5, 14, 0, 0, 0, tzinfo=UTC).replace(
+            tzinfo=None
+        )
+        created_list = [
+            datetime(2024, 5, 14, 0, 0, 2, tzinfo=UTC).replace(tzinfo=None),
+            datetime(2024, 5, 14, 0, 0, 0, tzinfo=UTC).replace(tzinfo=None),
+            datetime(2024, 5, 14, 0, 0, 1, tzinfo=UTC).replace(tzinfo=None),
+        ]
+
+        for index in range(0, 3):
+            history = IDXPersonalInfoHistory()
+            history.issuer_address = self.test_issuer_address_1
+            history.account_address = self.test_account_address_1
+            history.event_type = PersonalInfoEventType.REGISTER
+            history.personal_info = {
+                "key_manager": f"key_manager_test{index + 1}",
+                "name": f"name_test{index + 1}",
+                "postal_code": f"postal_code_test{index + 1}",
+                "address": f"address_test{index + 1}",
+                "email": f"email_test{index + 1}",
+                "birth": f"birth_test{index + 1}",
+                "is_corporate": False,
+                "tax_category": 10,
+            }
+            history.block_timestamp = same_timestamp
+            history.created = created_list[index]
+            async_db.add(history)
+
+        await async_db.commit()
+
+        returned_names = []
+        for offset in range(0, 3):
+            resp = await async_client.get(
+                self.url,
+                headers={
+                    "issuer-address": self.test_issuer_address_1,
+                },
+                params={"sort_order": 0, "offset": offset, "limit": 1},
+            )
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["result_set"] == {
+                "count": 3,
+                "limit": 1,
+                "offset": offset,
+                "total": 3,
+            }
+            returned_names.append(body["personal_info"][0]["personal_info"]["name"])
+
+        assert returned_names == ["name_test1", "name_test2", "name_test3"]
+
     ###########################################################################
     # Error Case
     ###########################################################################

--- a/tests/app/test_token_holders_ListTokenHoldersPersonalInfoHistory.py
+++ b/tests/app/test_token_holders_ListTokenHoldersPersonalInfoHistory.py
@@ -1089,7 +1089,7 @@ class TestListTokenHoldersPersonalInfoHistory:
     # <Normal_6>
     # Pagination: same block_timestamp
     @pytest.mark.asyncio
-    async def test_normal_6(self, async_client, async_db):
+    async def test_normal_6(self, async_client: AsyncClient, async_db: AsyncSession):
         same_timestamp = datetime(2024, 5, 14, 0, 0, 0, tzinfo=UTC).replace(tzinfo=None)
         created_list = [
             datetime(2024, 5, 14, 0, 0, 2, tzinfo=UTC).replace(tzinfo=None),
@@ -1118,7 +1118,7 @@ class TestListTokenHoldersPersonalInfoHistory:
 
         await async_db.commit()
 
-        returned_names = []
+        returned_names: list[str] = []
         for offset in range(0, 3):
             resp = await async_client.get(
                 self.url,


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->
This PR fixes unstable pagination when `block_timestamp` is used as the primary sort key.

Some APIs returned non-deterministic ordering when multiple records shared the same `block_timestamp`, which could cause duplicate or missing records across paginated responses. This PR adds stable secondary sort keys to ensure deterministic pagination.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- Cherry pick from https://github.com/BoostryJP/ibet-Prime/pull/1021
- Close #1019 

## 🔄 Changes

<!-- List the major changes in this PR. -->
- Added stable secondary sorting to affected `block_timestamp`-sorted history APIs.
- Added stable secondary sorting to affected lock/unlock event APIs.
- Added regression tests for pagination with duplicated `block_timestamp` values.

## 📌 Checklist

- [x] I have added tests where necessary.
- [ ] I have updated the documentation where necessary.
