### PR TITLE
Defer E2EE RSA config validation until runtime to avoid boot-time failures

### DIFF
--- a/app/utils/e2ee_utils.py
+++ b/app/utils/e2ee_utils.py
@@ -109,6 +109,21 @@ class E2EEUtils:
         )
 
     @staticmethod
+    def __get_rsa_settings() -> tuple[int, str, str]:
+        if E2EE_RSA_RESOURCE_MODE is None:
+            raise ValueError("E2EE_RSA_RESOURCE_MODE is not configured")
+        if E2EE_RSA_RESOURCE is None:
+            raise ValueError("E2EE_RSA_RESOURCE is not configured")
+        if E2EE_RSA_PASSPHRASE is None:
+            raise ValueError("E2EE_RSA_PASSPHRASE is not configured")
+
+        return (
+            E2EE_RSA_RESOURCE_MODE,
+            E2EE_RSA_RESOURCE,
+            E2EE_RSA_PASSPHRASE,
+        )
+
+    @staticmethod
     def __get_crypto_data() -> DictCache:
         if E2EEUtils.cache.get("expiration_datetime") is None:
             cast(Any, E2EEUtils.cache).update(
@@ -129,23 +144,25 @@ class E2EEUtils:
         ).replace(tzinfo=None):
             return E2EEUtils.cache
 
+        rsa_resource_mode, rsa_resource, rsa_passphrase = E2EEUtils.__get_rsa_settings()
+
         # Get Private Key
         private_key: str | None = None
-        if E2EE_RSA_RESOURCE_MODE == 0:
-            with open(E2EE_RSA_RESOURCE, "r") as f:
+        if rsa_resource_mode == 0:
+            with open(rsa_resource, "r") as f:
                 private_key = f.read()
-        elif E2EE_RSA_RESOURCE_MODE == 1:
+        elif rsa_resource_mode == 1:
             secrets_manager: Any = boto3.client(
                 service_name="secretsmanager", region_name=AWS_REGION_NAME
             )
-            result: Any = secrets_manager.get_secret_value(SecretId=E2EE_RSA_RESOURCE)
+            result: Any = secrets_manager.get_secret_value(SecretId=rsa_resource)
             private_key = cast(str | None, result.get("SecretString"))
 
         if private_key is None:
             raise ValueError("RSA private key is not configured")
 
         # Get Public Key
-        rsa_key = RSA.importKey(private_key, passphrase=E2EE_RSA_PASSPHRASE)
+        rsa_key = RSA.importKey(private_key, passphrase=rsa_passphrase)
 
         public_key = rsa_key.publickey().exportKey().decode()
 

--- a/app/utils/e2ee_utils.py
+++ b/app/utils/e2ee_utils.py
@@ -70,12 +70,14 @@ class E2EEUtils:
         :param base64_encrypt_data: Base64-encoded encrypted data
         :return: Decrypted data
         """
+        rsa_settings = E2EEUtils.__get_rsa_settings()
         crypto_data = E2EEUtils.__get_crypto_data()
         private_key = cast(str | None, crypto_data.get("private_key"))
         if private_key is None:
             return base64_encrypt_data
 
-        rsa_key = RSA.importKey(private_key, passphrase=E2EE_RSA_PASSPHRASE)
+        _, _, rsa_passphrase = rsa_settings
+        rsa_key = RSA.importKey(private_key, passphrase=rsa_passphrase)
         cipher = PKCS1_OAEP.new(rsa_key)
 
         try:
@@ -135,6 +137,8 @@ class E2EEUtils:
                 }
             )
 
+        rsa_resource_mode, rsa_resource, rsa_passphrase = E2EEUtils.__get_rsa_settings()
+
         # Use Cache
         expiration_datetime = cast(
             datetime | None, E2EEUtils.cache.get("expiration_datetime")
@@ -143,8 +147,6 @@ class E2EEUtils:
             UTC
         ).replace(tzinfo=None):
             return E2EEUtils.cache
-
-        rsa_resource_mode, rsa_resource, rsa_passphrase = E2EEUtils.__get_rsa_settings()
 
         # Get Private Key
         private_key: str | None = None

--- a/config.py
+++ b/config.py
@@ -266,10 +266,9 @@ else:
     e2ee_rsa_resource_mode = os.environ.get("E2EE_RSA_RESOURCE_MODE")
     e2ee_rsa_resource = os.environ.get("E2EE_RSA_RESOURCE")
     e2ee_rsa_passphrase = os.environ.get("E2EE_RSA_PASSPHRASE")
-    assert e2ee_rsa_resource_mode is not None
-    assert e2ee_rsa_resource is not None
-    assert e2ee_rsa_passphrase is not None
-E2EE_RSA_RESOURCE_MODE = int(e2ee_rsa_resource_mode)
+E2EE_RSA_RESOURCE_MODE = (
+    int(e2ee_rsa_resource_mode) if e2ee_rsa_resource_mode is not None else None
+)
 E2EE_RSA_RESOURCE = e2ee_rsa_resource
 E2EE_RSA_PASSPHRASE = e2ee_rsa_passphrase
 E2EE_REQUEST_ENABLED = False if os.environ.get("E2EE_REQUEST_ENABLED") == "0" else True

--- a/tests/app/utils/test_e2ee_utils.py
+++ b/tests/app/utils/test_e2ee_utils.py
@@ -17,6 +17,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
+import base64
 import importlib
 import sys
 from datetime import datetime
@@ -65,6 +66,54 @@ class TestE2EEUtils:
                 ValueError, match="E2EE_RSA_RESOURCE_MODE is not configured"
             ):
                 E2EEUtils.get_key()
+
+    @mock.patch(
+        "app.utils.e2ee_utils.E2EEUtils.cache",
+        {
+            "private_key": "cached-private-key",
+            "public_key": "cached-public-key",
+            "encrypted_length": 256,
+            "expiration_datetime": datetime.max,
+        },
+    )
+    def test_error_when_rsa_passphrase_is_not_configured_even_if_cache_is_warm(self):
+        with (
+            mock.patch("app.utils.e2ee_utils.E2EE_RSA_RESOURCE_MODE", 0),
+            mock.patch("app.utils.e2ee_utils.E2EE_RSA_RESOURCE", "dummy.pem"),
+            mock.patch("app.utils.e2ee_utils.E2EE_RSA_PASSPHRASE", None),
+        ):
+            with pytest.raises(
+                ValueError, match="E2EE_RSA_PASSPHRASE is not configured"
+            ):
+                E2EEUtils.get_key()
+
+    def test_decrypt_uses_validated_rsa_passphrase(self):
+        crypto_data = {"private_key": "dummy-private-key", "encrypted_length": None}
+        cipher = mock.MagicMock()
+        cipher.decrypt.return_value = b"decrypted"
+        validated_rsa_settings = (0, "dummy.pem", "validated-passphrase")
+        base64_encrypt_data = base64.b64encode(b"encrypted").decode()
+
+        with (
+            mock.patch("app.utils.e2ee_utils.E2EE_RSA_PASSPHRASE", None),
+            mock.patch(
+                "app.utils.e2ee_utils.E2EEUtils._E2EEUtils__get_rsa_settings",
+                return_value=validated_rsa_settings,
+            ),
+            mock.patch(
+                "app.utils.e2ee_utils.E2EEUtils._E2EEUtils__get_crypto_data",
+                return_value=crypto_data,
+            ) as mock_get_crypto_data,
+            mock.patch("app.utils.e2ee_utils.RSA.importKey") as mock_import_key,
+            mock.patch("app.utils.e2ee_utils.PKCS1_OAEP.new", return_value=cipher),
+        ):
+            assert E2EEUtils.decrypt(base64_encrypt_data) == "decrypted"
+
+        mock_get_crypto_data.assert_called_once_with()
+        mock_import_key.assert_called_once_with(
+            "dummy-private-key", passphrase="validated-passphrase"
+        )
+        cipher.decrypt.assert_called_once_with(b"encrypted")
 
 
 def test_config_import_does_not_require_e2ee_env(monkeypatch: pytest.MonkeyPatch):

--- a/tests/app/utils/test_e2ee_utils.py
+++ b/tests/app/utils/test_e2ee_utils.py
@@ -1,0 +1,91 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import importlib
+import sys
+from datetime import datetime
+from unittest import mock
+
+import pytest
+
+from app.utils.e2ee_utils import E2EEUtils
+
+
+class TestE2EEUtils:
+    @mock.patch(
+        "app.utils.e2ee_utils.E2EEUtils.cache",
+        {
+            "private_key": None,
+            "public_key": None,
+            "encrypted_length": None,
+            "expiration_datetime": datetime.min,
+        },
+    )
+    def test_error_when_rsa_resource_is_not_configured(self):
+        with (
+            mock.patch("app.utils.e2ee_utils.E2EE_RSA_RESOURCE_MODE", 0),
+            mock.patch("app.utils.e2ee_utils.E2EE_RSA_RESOURCE", None),
+            mock.patch("app.utils.e2ee_utils.E2EE_RSA_PASSPHRASE", "password"),
+        ):
+            with pytest.raises(ValueError, match="E2EE_RSA_RESOURCE is not configured"):
+                E2EEUtils.get_key()
+
+    @mock.patch(
+        "app.utils.e2ee_utils.E2EEUtils.cache",
+        {
+            "private_key": None,
+            "public_key": None,
+            "encrypted_length": None,
+            "expiration_datetime": datetime.min,
+        },
+    )
+    def test_error_when_rsa_resource_mode_is_invalid(self):
+        with (
+            mock.patch("app.utils.e2ee_utils.E2EE_RSA_RESOURCE_MODE", "invalid"),
+            mock.patch("app.utils.e2ee_utils.E2EE_RSA_RESOURCE", "dummy.pem"),
+            mock.patch("app.utils.e2ee_utils.E2EE_RSA_PASSPHRASE", "password"),
+        ):
+            with pytest.raises(
+                ValueError, match="E2EE_RSA_RESOURCE_MODE must be an integer"
+            ):
+                E2EEUtils.get_key()
+
+
+def test_config_import_does_not_require_e2ee_env(monkeypatch: pytest.MonkeyPatch):
+    with monkeypatch.context() as context:
+        context.setenv("APP_ENV", "dev")
+        context.delenv("E2EE_RSA_RESOURCE_MODE", raising=False)
+        context.delenv("E2EE_RSA_RESOURCE", raising=False)
+        context.delenv("E2EE_RSA_PASSPHRASE", raising=False)
+
+        # Simulate a normal application import path where config is reloaded
+        # without test or migration tooling already imported. This ensures the
+        # test validates that E2EE env vars are not required merely because
+        # pytest/alembic-specific import-time detection is unavailable.
+        context.delitem(sys.modules, "alembic", raising=False)
+        context.delitem(sys.modules, "config", raising=False)
+
+        reloaded_config = importlib.import_module("config")
+
+        assert reloaded_config is not None
+        assert reloaded_config is sys.modules["config"]
+        assert reloaded_config.__name__ == "config"
+        assert reloaded_config.E2EE_RSA_RESOURCE_MODE is None
+        assert reloaded_config.E2EE_RSA_RESOURCE is None
+        assert reloaded_config.E2EE_RSA_PASSPHRASE is None

--- a/tests/app/utils/test_e2ee_utils.py
+++ b/tests/app/utils/test_e2ee_utils.py
@@ -55,14 +55,14 @@ class TestE2EEUtils:
             "expiration_datetime": datetime.min,
         },
     )
-    def test_error_when_rsa_resource_mode_is_invalid(self):
+    def test_error_when_rsa_resource_mode_is_not_configured(self):
         with (
-            mock.patch("app.utils.e2ee_utils.E2EE_RSA_RESOURCE_MODE", "invalid"),
+            mock.patch("app.utils.e2ee_utils.E2EE_RSA_RESOURCE_MODE", None),
             mock.patch("app.utils.e2ee_utils.E2EE_RSA_RESOURCE", "dummy.pem"),
             mock.patch("app.utils.e2ee_utils.E2EE_RSA_PASSPHRASE", "password"),
         ):
             with pytest.raises(
-                ValueError, match="E2EE_RSA_RESOURCE_MODE must be an integer"
+                ValueError, match="E2EE_RSA_RESOURCE_MODE is not configured"
             ):
                 E2EEUtils.get_key()
 
@@ -78,6 +78,7 @@ def test_config_import_does_not_require_e2ee_env(monkeypatch: pytest.MonkeyPatch
         # without test or migration tooling already imported. This ensures the
         # test validates that E2EE env vars are not required merely because
         # pytest/alembic-specific import-time detection is unavailable.
+        context.delitem(sys.modules, "pytest", raising=False)
         context.delitem(sys.modules, "alembic", raising=False)
         context.delitem(sys.modules, "config", raising=False)
 


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->
Prevent boot-time failures when E2EE environment variables are missing by deferring E2EE RSA configuration validation until the settings are actually used.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- Fix #1016 

## 🔄 Changes

<!-- List the major changes in this PR. -->

- Removed import-time assertions for E2EE RSA environment variables in config loading
- Deferred E2EE RSA setting validation to runtime in the E2EE utility layer

## 📌 Checklist

- [x] I have added tests where necessary.
- [ ] I have updated the documentation where necessary.
