### PR TITLE
Make account keyfile/eoa_password non-nullable

### DIFF
--- a/app/model/db/account.py
+++ b/app/model/db/account.py
@@ -37,9 +37,9 @@ class Account(Base):
     # - NOTE: The value will be set in versions after v24.12.
     issuer_public_key: Mapped[str | None] = mapped_column(String(66))
     # ethereum private-key keyfile
-    keyfile: Mapped[dict[str, Any] | None] = mapped_column(JSON)
+    keyfile: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
     # keyfile password (encrypted)
-    eoa_password: Mapped[str | None] = mapped_column(String(2000))
+    eoa_password: Mapped[str] = mapped_column(String(2000), nullable=False)
     # rsa private key
     rsa_private_key: Mapped[str | None] = mapped_column(String(8000))
     # rsa public key
@@ -47,9 +47,9 @@ class Account(Base):
     # rsa passphrase (encrypted)
     rsa_passphrase: Mapped[str | None] = mapped_column(String(2000))
     # rsa status (AccountRsaStatus)
-    rsa_status: Mapped[int | None] = mapped_column(Integer)
+    rsa_status: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     # delete flag
-    is_deleted: Mapped[bool | None] = mapped_column(Boolean, default=False)
+    is_deleted: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
 
 
 class AccountRsaStatus(int, Enum):

--- a/app/model/db/freeze_log_account.py
+++ b/app/model/db/freeze_log_account.py
@@ -33,8 +33,8 @@ class FreezeLogAccount(Base):
     # account address
     account_address: Mapped[str] = mapped_column(String(42), primary_key=True)
     # ethereum keyfile
-    keyfile: Mapped[dict[str, Any] | None] = mapped_column(JSON)
+    keyfile: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
     # ethereum account password(encrypted)
-    eoa_password: Mapped[str | None] = mapped_column(String(2000))
+    eoa_password: Mapped[str] = mapped_column(String(2000), nullable=False)
     # delete flag
-    is_deleted: Mapped[bool | None] = mapped_column(Boolean, default=False)
+    is_deleted: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)

--- a/app/model/ibet/freeze_log.py
+++ b/app/model/ibet/freeze_log.py
@@ -52,10 +52,6 @@ class FreezeLogContract:
         """
 
         try:
-            if self.log_account.eoa_password is None:
-                raise SendTransactionError("log account eoa_password is not configured")
-            if self.log_account.keyfile is None:
-                raise SendTransactionError("log account keyfile is not configured")
             private_key = decode_keyfile_json(
                 raw_keyfile_json=self.log_account.keyfile,
                 password=E2EEUtils.decrypt(self.log_account.eoa_password).encode(
@@ -101,8 +97,6 @@ class FreezeLogContract:
         """
 
         try:
-            assert self.log_account.eoa_password is not None
-            assert self.log_account.keyfile is not None
             private_key = decode_keyfile_json(
                 raw_keyfile_json=self.log_account.keyfile,
                 password=E2EEUtils.decrypt(self.log_account.eoa_password).encode(

--- a/app/model/ibet/personal_info.py
+++ b/app/model/ibet/personal_info.py
@@ -199,8 +199,6 @@ class PersonalInfoContract:
 
         try:
             if self.private_key is None:
-                assert self.issuer.eoa_password is not None
-                assert self.issuer.keyfile is not None
                 self.private_key = decode_keyfile_json(
                     raw_keyfile_json=self.issuer.keyfile,
                     password=E2EEUtils.decrypt(self.issuer.eoa_password).encode(
@@ -267,8 +265,6 @@ class PersonalInfoContract:
 
         try:
             if self.private_key is None:
-                assert self.issuer.eoa_password is not None
-                assert self.issuer.keyfile is not None
                 self.private_key = decode_keyfile_json(
                     raw_keyfile_json=self.issuer.keyfile,
                     password=E2EEUtils.decrypt(self.issuer.eoa_password).encode(

--- a/app/routers/issuer/account.py
+++ b/app/routers/issuer/account.py
@@ -282,7 +282,7 @@ async def change_issuer_eoa_password(
             select(Account).where(Account.issuer_address == issuer_address).limit(1)
         )
     ).first()
-    if _account is None or _account.eoa_password is None or _account.keyfile is None:
+    if _account is None:
         raise HTTPException(status_code=404, detail="issuer does not exist")
 
     # Check Password Policy

--- a/app/routers/issuer/bond.py
+++ b/app/routers/issuer/bond.py
@@ -282,10 +282,9 @@ async def _is_ibet_wst_deploy_in_progress(
 
 
 def _decode_private_key(
-    keyfile_json: dict[str, Any] | None,
+    keyfile_json: dict[str, Any],
     decrypt_password: str,
 ) -> bytes:
-    assert keyfile_json is not None
     return decode_keyfile_json(
         raw_keyfile_json=keyfile_json,
         password=decrypt_password.encode("utf-8"),

--- a/app/routers/issuer/position.py
+++ b/app/routers/issuer/position.py
@@ -601,8 +601,6 @@ async def force_lock(
         raise InvalidParameterError("account_address is not a valid address")
 
     # Get private key
-    if _account.keyfile is None:
-        raise InvalidParameterError("keyfile not found")
     private_key = decode_keyfile_json(
         raw_keyfile_json=_account.keyfile, password=decrypt_password.encode("utf-8")
     )
@@ -698,8 +696,6 @@ async def force_unlock(
         raise InvalidParameterError("account_address is not a valid address")
 
     # Get private key
-    if _account.keyfile is None:
-        raise InvalidParameterError("keyfile not found")
     private_key = decode_keyfile_json(
         raw_keyfile_json=_account.keyfile, password=decrypt_password.encode("utf-8")
     )

--- a/app/routers/issuer/settlement_issuer.py
+++ b/app/routers/issuer/settlement_issuer.py
@@ -305,7 +305,6 @@ async def create_dvp_delivery(
 
     # Get private key
     keyfile_json = _account.keyfile
-    assert keyfile_json is not None
     private_key = decode_keyfile_json(
         raw_keyfile_json=keyfile_json, password=decrypt_password.encode("utf-8")
     )
@@ -564,7 +563,6 @@ async def update_dvp_delivery(
         case "Cancel":
             # Get private key
             keyfile_json = _account.keyfile
-            assert keyfile_json is not None
             private_key = decode_keyfile_json(
                 raw_keyfile_json=keyfile_json, password=decrypt_password.encode("utf-8")
             )

--- a/app/routers/issuer/share.py
+++ b/app/routers/issuer/share.py
@@ -282,10 +282,9 @@ async def _is_ibet_wst_deploy_in_progress(
 
 
 def _decode_private_key(
-    keyfile_json: dict[str, Any] | None,
+    keyfile_json: dict[str, Any],
     decrypt_password: str,
 ) -> bytes:
-    assert keyfile_json is not None
     return decode_keyfile_json(
         raw_keyfile_json=keyfile_json,
         password=decrypt_password.encode("utf-8"),

--- a/app/routers/issuer/token_common.py
+++ b/app/routers/issuer/token_common.py
@@ -189,8 +189,13 @@ async def list_all_issued_tokens(
     else:  # DESC
         stmt = stmt.order_by(desc(sort_attr))
 
-    if str(sort_item) != "created":
-        # NOTE: Set secondary sort for consistent results
+    # NOTE: Set secondary sort for consistent results when the primary sort key ties.
+    if str(sort_item) == "created":
+        if request_query.sort_order == 0:  # ASC
+            stmt = stmt.order_by(asc(Token.token_address))
+        else:  # DESC
+            stmt = stmt.order_by(desc(Token.token_address))
+    else:
         stmt = stmt.order_by(desc(Token.created))
 
     # Pagination
@@ -557,7 +562,7 @@ async def get_ibet_wst_whitelist_with_personal_info(
     "/tokens/{token_address}/ibet_wst/whitelists/add",
     operation_id="AddIbetWSTWhitelist",
     response_model=IbetWSTTransactionResponse,
-    responses=get_routers_responses(400, 404, 422),
+    responses=get_routers_responses(404, 422),
 )
 async def add_ibet_wst_whitelist(
     db: DBAsyncSession,
@@ -601,8 +606,6 @@ async def add_ibet_wst_whitelist(
     )
 
     # Get private key
-    if _account.keyfile is None:
-        raise HTTPException(status_code=400, detail="Keyfile not found")
     private_key = decode_keyfile_json(
         raw_keyfile_json=_account.keyfile, password=decrypt_password.encode("utf-8")
     )
@@ -685,7 +688,7 @@ async def add_ibet_wst_whitelist(
     "/tokens/{token_address}/ibet_wst/whitelists/delete",
     operation_id="DeleteIbetWSTWhitelist",
     response_model=IbetWSTTransactionResponse,
-    responses=get_routers_responses(400, 404, 422),
+    responses=get_routers_responses(404, 422),
 )
 async def delete_ibet_wst_whitelist(
     db: DBAsyncSession,
@@ -728,8 +731,6 @@ async def delete_ibet_wst_whitelist(
     )
 
     # Get private key
-    if _account.keyfile is None:
-        raise HTTPException(status_code=400, detail="Keyfile not found")
     private_key = decode_keyfile_json(
         raw_keyfile_json=_account.keyfile, password=decrypt_password.encode("utf-8")
     )
@@ -810,7 +811,7 @@ async def delete_ibet_wst_whitelist(
     "/tokens/{token_address}/ibet_wst/positions/force_burn",
     operation_id="ForceBurnIbetWSTPosition",
     response_model=IbetWSTTransactionResponse,
-    responses=get_routers_responses(400, 404, 422),
+    responses=get_routers_responses(404, 422),
 )
 async def force_burn_ibet_wst_position(
     db: DBAsyncSession,
@@ -854,8 +855,6 @@ async def force_burn_ibet_wst_position(
     )
 
     # Get private key
-    if issuer_account.keyfile is None:
-        raise HTTPException(status_code=400, detail="Keyfile not found")
     private_key = decode_keyfile_json(
         raw_keyfile_json=issuer_account.keyfile,
         password=decrypt_password.encode("utf-8"),

--- a/app/routers/misc/bc_explorer.py
+++ b/app/routers/misc/bc_explorer.py
@@ -77,7 +77,6 @@ async def service_list_block_data(
             "block_data": [],
         }
 
-    assert idx_block_data_block_number.latest_block_number is not None
     total = idx_block_data_block_number.latest_block_number + 1
 
     stmt = select(IDXBlockData)

--- a/app/routers/misc/freeze_log.py
+++ b/app/routers/misc/freeze_log.py
@@ -196,7 +196,7 @@ async def change_eoa_password(
             .limit(1)
         )
     ).first()
-    if _account is None or _account.eoa_password is None or _account.keyfile is None:
+    if _account is None:
         raise HTTPException(status_code=404, detail="account is not exists")
 
     # Check Old Password
@@ -259,11 +259,7 @@ async def record_new_log(
             .limit(1)
         )
     ).first()
-    if (
-        log_account is None
-        or log_account.eoa_password is None
-        or log_account.keyfile is None
-    ):
+    if log_account is None:
         raise HTTPException(status_code=404, detail="account is not exists")
 
     # Authentication
@@ -317,7 +313,7 @@ async def update_log(
             .limit(1)
         )
     ).first()
-    if log_account is None or log_account.eoa_password is None:
+    if log_account is None:
         raise HTTPException(status_code=404, detail="account is not exists")
 
     # Authentication

--- a/app/utils/check_utils.py
+++ b/app/utils/check_utils.py
@@ -169,7 +169,7 @@ async def check_account_for_auth(
             select(Account).where(Account.issuer_address == issuer_address).limit(1)
         )
     ).first()
-    if account is None or account.eoa_password is None:
+    if account is None:
         raise AuthorizationError
     decrypted_eoa_password = E2EEUtils.decrypt(account.eoa_password)
     return account, decrypted_eoa_password

--- a/batch/processor_batch_issue_redeem.py
+++ b/batch/processor_batch_issue_redeem.py
@@ -126,8 +126,6 @@ class Processor:
                     continue
 
                 try:
-                    assert issuer_account.keyfile is not None
-                    assert issuer_account.eoa_password is not None
                     issuer_pk = decode_keyfile_json(
                         raw_keyfile_json=issuer_account.keyfile,
                         password=E2EEUtils.decrypt(issuer_account.eoa_password).encode(

--- a/batch/processor_bulk_transfer.py
+++ b/batch/processor_bulk_transfer.py
@@ -129,8 +129,6 @@ class Processor:
                         await self.__release_processing_issuer(_upload.upload_id)
                         continue
 
-                    assert _account.keyfile is not None
-                    assert _account.eoa_password is not None
                     keyfile_json = _account.keyfile
                     decrypt_password = E2EEUtils.decrypt(_account.eoa_password)
                     private_key = decode_keyfile_json(

--- a/batch/processor_dvp_async_tx.py
+++ b/batch/processor_dvp_async_tx.py
@@ -357,8 +357,6 @@ class Processor:
             raise AccountNotFound
 
         try:
-            assert issuer_account.keyfile is not None
-            assert issuer_account.eoa_password is not None
             issuer_pk = decode_keyfile_json(
                 raw_keyfile_json=issuer_account.keyfile,
                 password=E2EEUtils.decrypt(issuer_account.eoa_password).encode("utf-8"),

--- a/batch/processor_scheduled_events.py
+++ b/batch/processor_scheduled_events.py
@@ -185,8 +185,7 @@ class Processor:
                     )
                     await db_session.commit()
                     continue
-                assert _account.keyfile is not None
-                assert _account.eoa_password is not None
+
                 keyfile_json = _account.keyfile
                 decrypt_password = E2EEUtils.decrypt(_account.eoa_password)
                 private_key = decode_keyfile_json(

--- a/batch/processor_update_token.py
+++ b/batch/processor_update_token.py
@@ -126,8 +126,6 @@ class Processor:
                         await db_session.commit()
                         continue
 
-                    assert _account.keyfile is not None
-                    assert _account.eoa_password is not None
                     keyfile_json = _account.keyfile
                     decrypt_password = E2EEUtils.decrypt(_account.eoa_password)
                     private_key = decode_keyfile_json(

--- a/batch/processor_wst_ava_bridge_to_ibet.py
+++ b/batch/processor_wst_ava_bridge_to_ibet.py
@@ -96,11 +96,6 @@ class AvaWSTBridgeToIbetProcessor:
                     )
                     continue
 
-                if issuer.keyfile is None or issuer.eoa_password is None:
-                    LOG.warning(
-                        f"Issuer key data is missing for transaction: id={pending_tx.tx_id}"
-                    )
-                    continue
                 issuer_pk = decode_keyfile_json(
                     raw_keyfile_json=issuer.keyfile,
                     password=E2EEUtils.decrypt(issuer.eoa_password).encode("utf-8"),

--- a/batch/processor_wst_ava_monitor_bridge_events.py
+++ b/batch/processor_wst_ava_monitor_bridge_events.py
@@ -421,11 +421,7 @@ class AvaWSTBridgeMonitoringProcessor:
                         f"Cannot find issuer for IbetWST address: {wst_address}"
                     )
                     continue
-                if issuer.keyfile is None or issuer.eoa_password is None:
-                    LOG.warning(
-                        f"Issuer key data is missing for IbetWST address: {wst_address}"
-                    )
-                    continue
+
                 issuer_pk = decode_keyfile_json(
                     raw_keyfile_json=issuer.keyfile,
                     password=E2EEUtils.decrypt(issuer.eoa_password).encode("utf-8"),

--- a/batch/processor_wst_ava_send_tx.py
+++ b/batch/processor_wst_ava_send_tx.py
@@ -224,8 +224,6 @@ async def get_tx_sender_account(
             )
         ).first()
         if tx_sender_account is not None:
-            assert tx_sender_account.keyfile is not None
-            assert tx_sender_account.eoa_password is not None
             private_key = decode_keyfile_json(
                 raw_keyfile_json=tx_sender_account.keyfile,
                 password=E2EEUtils.decrypt(tx_sender_account.eoa_password).encode(

--- a/batch/processor_wst_eth_bridge_to_ibet.py
+++ b/batch/processor_wst_eth_bridge_to_ibet.py
@@ -95,11 +95,6 @@ class EthWSTBridgeToIbetProcessor:
                     )
                     continue
 
-                if issuer.keyfile is None or issuer.eoa_password is None:
-                    LOG.warning(
-                        f"Issuer key data is missing for transaction: id={pending_tx.tx_id}"
-                    )
-                    continue
                 issuer_pk = decode_keyfile_json(
                     raw_keyfile_json=issuer.keyfile,
                     password=E2EEUtils.decrypt(issuer.eoa_password).encode("utf-8"),

--- a/batch/processor_wst_eth_monitor_bridge_events.py
+++ b/batch/processor_wst_eth_monitor_bridge_events.py
@@ -427,11 +427,7 @@ class EthWSTBridgeMonitoringProcessor:
                         f"Cannot find issuer for IbetWST address: {wst_address}"
                     )
                     continue
-                if issuer.keyfile is None or issuer.eoa_password is None:
-                    LOG.warning(
-                        f"Issuer key data is missing for IbetWST address: {wst_address}"
-                    )
-                    continue
+
                 issuer_pk = decode_keyfile_json(
                     raw_keyfile_json=issuer.keyfile,
                     password=E2EEUtils.decrypt(issuer.eoa_password).encode("utf-8"),

--- a/batch/processor_wst_eth_send_tx.py
+++ b/batch/processor_wst_eth_send_tx.py
@@ -224,8 +224,6 @@ async def get_tx_sender_account(
             )
         ).first()
         if tx_sender_account is not None:
-            assert tx_sender_account.keyfile is not None
-            assert tx_sender_account.eoa_password is not None
             private_key = decode_keyfile_json(
                 raw_keyfile_json=tx_sender_account.keyfile,
                 password=E2EEUtils.decrypt(tx_sender_account.eoa_password).encode(

--- a/docs/ibet_prime.yaml
+++ b/docs/ibet_prime.yaml
@@ -8728,13 +8728,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/IbetWSTTransactionResponse'
-        '400':
-          description: Invalid Parameter Error / Send Transaction Error / 
-            Contract Revert Error etc
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error400Model'
         '404':
           description: Not Found Error
           content:
@@ -8807,13 +8800,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/IbetWSTTransactionResponse'
-        '400':
-          description: Invalid Parameter Error / Send Transaction Error / 
-            Contract Revert Error etc
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error400Model'
         '404':
           description: Not Found Error
           content:
@@ -8886,13 +8872,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/IbetWSTTransactionResponse'
-        '400':
-          description: Invalid Parameter Error / Send Transaction Error / 
-            Contract Revert Error etc
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error400Model'
         '404':
           description: Not Found Error
           content:
@@ -13793,44 +13772,6 @@ components:
         - detail
       title: ERC20InsufficientAllowanceErrorResponse
       description: Insufficient allowance for ERC20 token transfer
-    Error400MetaModel:
-      properties:
-        code:
-          type: integer
-          title: Code
-          examples:
-            - 0
-            - 1
-            - 2
-            - 100001
-        title:
-          type: string
-          title: Title
-          examples:
-            - InvalidParameterError
-            - SendTransactionError
-            - ContractRevertError
-      type: object
-      required:
-        - code
-        - title
-      title: Error400MetaModel
-    Error400Model:
-      properties:
-        meta:
-          $ref: '#/components/schemas/Error400MetaModel'
-        detail:
-          type: string
-          title: Detail
-          examples:
-            - this token is temporarily unavailable
-            - failed to register token address token list
-            - The address has already been registered.
-      type: object
-      required:
-        - meta
-        - detail
-      title: Error400Model
     Error401MetaModel:
       properties:
         code:

--- a/migrations/versions/7b965ee0f8f1_v26_6_0_feature_1001.py
+++ b/migrations/versions/7b965ee0f8f1_v26_6_0_feature_1001.py
@@ -1,0 +1,123 @@
+"""v26_6_0_feature_1001
+
+Revision ID: 7b965ee0f8f1
+Revises: 301b31d8c870
+Create Date: 2026-04-09 20:50:41.056799
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from app.database import get_db_schema
+
+# revision identifiers, used by Alembic.
+revision = "7b965ee0f8f1"
+down_revision = "301b31d8c870"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column(
+        "account",
+        "keyfile",
+        existing_type=postgresql.JSON(astext_type=sa.Text()),
+        nullable=False,
+        schema=get_db_schema(),
+    )
+    op.alter_column(
+        "account",
+        "eoa_password",
+        existing_type=sa.VARCHAR(length=2000),
+        nullable=False,
+        schema=get_db_schema(),
+    )
+    op.alter_column(
+        "account",
+        "rsa_status",
+        existing_type=sa.INTEGER(),
+        nullable=False,
+        schema=get_db_schema(),
+    )
+    op.alter_column(
+        "account",
+        "is_deleted",
+        existing_type=sa.BOOLEAN(),
+        nullable=False,
+        schema=get_db_schema(),
+    )
+    op.alter_column(
+        "freeze_log_account",
+        "keyfile",
+        existing_type=postgresql.JSON(astext_type=sa.Text()),
+        nullable=False,
+        schema=get_db_schema(),
+    )
+    op.alter_column(
+        "freeze_log_account",
+        "eoa_password",
+        existing_type=sa.VARCHAR(length=2000),
+        nullable=False,
+        schema=get_db_schema(),
+    )
+    op.alter_column(
+        "freeze_log_account",
+        "is_deleted",
+        existing_type=sa.BOOLEAN(),
+        nullable=False,
+        schema=get_db_schema(),
+    )
+
+
+def downgrade():
+    op.alter_column(
+        "freeze_log_account",
+        "is_deleted",
+        existing_type=sa.BOOLEAN(),
+        nullable=True,
+        schema=get_db_schema(),
+    )
+    op.alter_column(
+        "freeze_log_account",
+        "eoa_password",
+        existing_type=sa.VARCHAR(length=2000),
+        nullable=True,
+        schema=get_db_schema(),
+    )
+    op.alter_column(
+        "freeze_log_account",
+        "keyfile",
+        existing_type=postgresql.JSON(astext_type=sa.Text()),
+        nullable=True,
+        schema=get_db_schema(),
+    )
+    op.alter_column(
+        "account",
+        "is_deleted",
+        existing_type=sa.BOOLEAN(),
+        nullable=True,
+        schema=get_db_schema(),
+    )
+    op.alter_column(
+        "account",
+        "rsa_status",
+        existing_type=sa.INTEGER(),
+        nullable=True,
+        schema=get_db_schema(),
+    )
+    op.alter_column(
+        "account",
+        "eoa_password",
+        existing_type=sa.VARCHAR(length=2000),
+        nullable=True,
+        schema=get_db_schema(),
+    )
+    op.alter_column(
+        "account",
+        "keyfile",
+        existing_type=postgresql.JSON(astext_type=sa.Text()),
+        nullable=True,
+        schema=get_db_schema(),
+    )

--- a/tests/app/model/ibet/test_PersonalInfo.py
+++ b/tests/app/model/ibet/test_PersonalInfo.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -46,15 +48,17 @@ web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
 
 async def initialize(issuer: UnitTestAccount, async_db: AsyncSession):
+    eoa_password = "password"
+
     _account = Account()
     _account.issuer_address = issuer["address"]
     _account.keyfile = issuer["keyfile_json"]
-    eoa_password = "password"
     _account.eoa_password = E2EEUtils.encrypt(eoa_password)
     _account.rsa_private_key = issuer["rsa_private_key"]
     _account.rsa_public_key = issuer["rsa_public_key"]
-    rsa_password = "password"
-    _account.rsa_passphrase = E2EEUtils.encrypt(rsa_password)
+    _account.rsa_passphrase = E2EEUtils.encrypt("password")
+    _account.rsa_status = AccountRsaStatus.UNSET.value
+    _account.is_deleted = False
     async_db.add(_account)
     await async_db.commit()
 

--- a/tests/app/test_accounts_ChangeIssuerEOAPassword.py
+++ b/tests/app/test_accounts_ChangeIssuerEOAPassword.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -23,7 +25,7 @@ from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.model.db import Account, AccountRsaStatus
+from app.model.db import Account
 from app.model.ibet import IbetStraightBondContract
 from app.utils.e2ee_utils import E2EEUtils
 from config import EOA_PASSWORD_PATTERN_MSG
@@ -49,6 +51,7 @@ class TestChangeIssuerEOAPassword:
 
         # prepare data
         account = Account()
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _old_keyfile
         account.eoa_password = E2EEUtils.encrypt(_old_password)
@@ -72,8 +75,6 @@ class TestChangeIssuerEOAPassword:
         _account = (await async_db.scalars(select(Account).limit(1))).first()
         assert _account is not None
         _account_keyfile = _account.keyfile
-        assert _account_keyfile is not None
-        assert _account.eoa_password is not None
         _account_eoa_password = E2EEUtils.decrypt(_account.eoa_password)
         assert _account_keyfile != _old_keyfile
         assert _account_eoa_password == _new_password
@@ -240,6 +241,7 @@ class TestChangeIssuerEOAPassword:
 
         # prepare data
         account = Account()
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _old_keyfile
         account.eoa_password = E2EEUtils.encrypt(_old_password)
@@ -276,6 +278,7 @@ class TestChangeIssuerEOAPassword:
 
         # prepare data
         account = Account()
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _old_keyfile
         account.eoa_password = E2EEUtils.encrypt(_old_password)

--- a/tests/app/test_accounts_ChangeIssuerRSAPassphrase.py
+++ b/tests/app/test_accounts_ChangeIssuerRSAPassphrase.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -24,7 +26,7 @@ from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.model.db import Account, AccountRsaStatus
+from app.model.db import Account
 from app.utils.e2ee_utils import E2EEUtils
 from config import PERSONAL_INFO_RSA_PASSPHRASE_PATTERN_MSG
 from tests.account_config import default_eth_account
@@ -53,6 +55,9 @@ class TestChangeIssuerRSAPassphrase:
 
         # prepare data
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.rsa_private_key = _old_rsa_private_key
         account.rsa_public_key = _rsa_public_key
@@ -237,6 +242,9 @@ class TestChangeIssuerRSAPassphrase:
 
         # prepare data
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.rsa_private_key = _old_rsa_private_key
         account.rsa_public_key = _rsa_public_key
@@ -275,6 +283,9 @@ class TestChangeIssuerRSAPassphrase:
 
         # prepare data
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.rsa_private_key = _old_rsa_private_key
         account.rsa_public_key = _rsa_public_key

--- a/tests/app/test_accounts_CreateChildAccount.py
+++ b/tests/app/test_accounts_CreateChildAccount.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -37,7 +39,9 @@ from app.model.db import (
     PersonalInfoDataSource,
     PersonalInfoEventType,
 )
+from app.utils.e2ee_utils import E2EEUtils
 from config import ASYNC_DATABASE_URL
+from tests.account_config import default_eth_account
 
 
 class TestCreateChildAccount:
@@ -87,6 +91,10 @@ class TestCreateChildAccount:
         _account = Account()
         _account.issuer_address = self.issuer_address
         _account.issuer_public_key = self.issuer_pub_key
+        _account.keyfile = default_eth_account("user1")["keyfile_json"]
+        _account.eoa_password = E2EEUtils.encrypt("password")
+        _account.rsa_status = AccountRsaStatus.UNSET.value
+        _account.is_deleted = False
         async_db.add(_account)
 
         _child_index = ChildAccountIndex()
@@ -191,6 +199,10 @@ class TestCreateChildAccount:
         _account = Account()
         _account.issuer_address = self.issuer_address
         _account.issuer_public_key = self.issuer_pub_key
+        _account.keyfile = default_eth_account("user1")["keyfile_json"]
+        _account.eoa_password = E2EEUtils.encrypt("password")
+        _account.rsa_status = AccountRsaStatus.UNSET.value
+        _account.is_deleted = False
         async_db.add(_account)
 
         _child_index = ChildAccountIndex()
@@ -337,6 +349,10 @@ class TestCreateChildAccount:
         _account = Account()
         _account.issuer_address = self.issuer_address
         _account.issuer_public_key = None  # public-key is not set
+        _account.keyfile = default_eth_account("user1")["keyfile_json"]
+        _account.eoa_password = E2EEUtils.encrypt("password")
+        _account.rsa_status = AccountRsaStatus.UNSET.value
+        _account.is_deleted = False
         async_db.add(_account)
         await async_db.commit()
 
@@ -372,6 +388,10 @@ class TestCreateChildAccount:
         _account = Account()
         _account.issuer_address = self.issuer_address
         _account.issuer_public_key = self.issuer_pub_key
+        _account.keyfile = default_eth_account("user1")["keyfile_json"]
+        _account.eoa_password = E2EEUtils.encrypt("password")
+        _account.rsa_status = AccountRsaStatus.UNSET.value
+        _account.is_deleted = False
         async_db.add(_account)
 
         _child_index = ChildAccountIndex()
@@ -432,6 +452,10 @@ class TestCreateChildAccount:
         _account = Account()
         _account.issuer_address = self.issuer_address
         _account.issuer_public_key = self.issuer_pub_key
+        _account.keyfile = default_eth_account("user1")["keyfile_json"]
+        _account.eoa_password = E2EEUtils.encrypt("password")
+        _account.rsa_status = AccountRsaStatus.UNSET.value
+        _account.is_deleted = False
         async_db.add(_account)
 
         _child_index = ChildAccountIndex()

--- a/tests/app/test_accounts_CreateChildAccountInBatch.py
+++ b/tests/app/test_accounts_CreateChildAccountInBatch.py
@@ -1,3 +1,7 @@
+from app.model.db import AccountRsaStatus
+from app.utils.e2ee_utils import E2EEUtils
+from tests.account_config import default_eth_account
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -57,6 +61,10 @@ class TestCreateChildAccountInBatch:
     async def test_normal_1_1(self, async_client: AsyncClient, async_db: AsyncSession):
         # Prepare data
         _account = Account()
+        _account.keyfile = default_eth_account("user1")["keyfile_json"]
+        _account.eoa_password = E2EEUtils.encrypt("password")
+        _account.rsa_status = AccountRsaStatus.UNSET.value
+        _account.is_deleted = False
         _account.issuer_address = self.issuer_address
         _account.issuer_public_key = self.issuer_pub_key
         async_db.add(_account)
@@ -124,6 +132,10 @@ class TestCreateChildAccountInBatch:
     async def test_normal_1_2(self, async_client: AsyncClient, async_db: AsyncSession):
         # Prepare data
         _account = Account()
+        _account.keyfile = default_eth_account("user1")["keyfile_json"]
+        _account.eoa_password = E2EEUtils.encrypt("password")
+        _account.rsa_status = AccountRsaStatus.UNSET.value
+        _account.is_deleted = False
         _account.issuer_address = self.issuer_address
         _account.issuer_public_key = self.issuer_pub_key
         async_db.add(_account)
@@ -239,6 +251,10 @@ class TestCreateChildAccountInBatch:
     async def test_error_3(self, async_client: AsyncClient, async_db: AsyncSession):
         # Prepare data
         _account = Account()
+        _account.keyfile = default_eth_account("user1")["keyfile_json"]
+        _account.eoa_password = E2EEUtils.encrypt("password")
+        _account.rsa_status = AccountRsaStatus.UNSET.value
+        _account.is_deleted = False
         _account.issuer_address = self.issuer_address
         _account.issuer_public_key = None  # public-key is not set
         async_db.add(_account)
@@ -276,6 +292,10 @@ class TestCreateChildAccountInBatch:
     async def test_error_4(self, async_client: AsyncClient, async_db: AsyncSession):
         # Prepare data
         _account = Account()
+        _account.keyfile = default_eth_account("user1")["keyfile_json"]
+        _account.eoa_password = E2EEUtils.encrypt("password")
+        _account.rsa_status = AccountRsaStatus.UNSET.value
+        _account.is_deleted = False
         _account.issuer_address = self.issuer_address
         _account.issuer_public_key = self.issuer_pub_key
         async_db.add(_account)
@@ -338,6 +358,10 @@ class TestCreateChildAccountInBatch:
     async def test_error_5(self, async_client: AsyncClient, async_db: AsyncSession):
         # Prepare data
         _account = Account()
+        _account.keyfile = default_eth_account("user1")["keyfile_json"]
+        _account.eoa_password = E2EEUtils.encrypt("password")
+        _account.rsa_status = AccountRsaStatus.UNSET.value
+        _account.is_deleted = False
         _account.issuer_address = self.issuer_address
         _account.issuer_public_key = self.issuer_pub_key
         async_db.add(_account)

--- a/tests/app/test_accounts_CreateIssuerKey.py
+++ b/tests/app/test_accounts_CreateIssuerKey.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -25,7 +27,7 @@ from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.model.db import Account, AccountRsaStatus, ChildAccountIndex, TransactionLock
+from app.model.db import Account, ChildAccountIndex, TransactionLock
 from app.utils.e2ee_utils import E2EEUtils
 from config import EOA_PASSWORD_PATTERN_MSG
 

--- a/tests/app/test_accounts_CreateIssuerRSAKey.py
+++ b/tests/app/test_accounts_CreateIssuerRSAKey.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -22,7 +24,7 @@ from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.model.db import Account, AccountRsaKeyTemporary, AccountRsaStatus
+from app.model.db import Account, AccountRsaKeyTemporary
 from app.utils.e2ee_utils import E2EEUtils
 from config import (
     PERSONAL_INFO_RSA_DEFAULT_PASSPHRASE,
@@ -50,6 +52,7 @@ class TestCreateIssuerRSAKey:
         _user_1 = default_eth_account("user1")
 
         _account_before = Account()
+        _account_before.is_deleted = False
         _account_before.issuer_address = _user_1["address"]
         _account_before.keyfile = _user_1["keyfile_json"]
         eoa_password = E2EEUtils.encrypt("password")
@@ -93,6 +96,7 @@ class TestCreateIssuerRSAKey:
         _user_2 = default_eth_account("user2")
 
         _account_before = Account()
+        _account_before.is_deleted = False
         _account_before.issuer_address = _user_1["address"]
         _account_before.keyfile = _user_1["keyfile_json"]
         eoa_password = E2EEUtils.encrypt("password")
@@ -154,6 +158,7 @@ class TestCreateIssuerRSAKey:
         _user_1 = default_eth_account("user1")
 
         _account_before = Account()
+        _account_before.is_deleted = False
         _account_before.issuer_address = _user_1["address"]
         _account_before.keyfile = _user_1["keyfile_json"]
         eoa_password = E2EEUtils.encrypt("password")
@@ -250,6 +255,7 @@ class TestCreateIssuerRSAKey:
         _user_1 = default_eth_account("user1")
 
         _account = Account()
+        _account.is_deleted = False
         _account.issuer_address = _user_1["address"]
         _account.keyfile = _user_1["keyfile_json"]
         _account.eoa_password = E2EEUtils.encrypt("password")
@@ -282,6 +288,7 @@ class TestCreateIssuerRSAKey:
         _user_1 = default_eth_account("user1")
 
         _account = Account()
+        _account.is_deleted = False
         _account.issuer_address = _user_1["address"]
         _account.keyfile = _user_1["keyfile_json"]
         _account.eoa_password = E2EEUtils.encrypt("password")
@@ -310,6 +317,7 @@ class TestCreateIssuerRSAKey:
         _user_1 = default_eth_account("user1")
 
         _account = Account()
+        _account.is_deleted = False
         _account.issuer_address = _user_1["address"]
         _account.keyfile = _user_1["keyfile_json"]
         _account.eoa_password = E2EEUtils.encrypt("password")
@@ -341,6 +349,7 @@ class TestCreateIssuerRSAKey:
         _user_1 = default_eth_account("user1")
 
         _account = Account()
+        _account.is_deleted = False
         _account.issuer_address = _user_1["address"]
         _account.keyfile = _user_1["keyfile_json"]
         _account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/app/test_accounts_DeleteChildAccount.py
+++ b/tests/app/test_accounts_DeleteChildAccount.py
@@ -1,3 +1,7 @@
+from app.model.db import AccountRsaStatus
+from app.utils.e2ee_utils import E2EEUtils
+from tests.account_config import default_eth_account
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -41,6 +45,10 @@ class TestDeleteChildAccount:
     async def test_normal_1(self, async_client: AsyncClient, async_db: AsyncSession):
         # Prepare data
         _account = Account()
+        _account.keyfile = default_eth_account("user1")["keyfile_json"]
+        _account.eoa_password = E2EEUtils.encrypt("password")
+        _account.rsa_status = AccountRsaStatus.UNSET.value
+        _account.is_deleted = False
         _account.issuer_address = self.issuer_address
         async_db.add(_account)
 
@@ -103,6 +111,10 @@ class TestDeleteChildAccount:
     async def test_error_2(self, async_client: AsyncClient, async_db: AsyncSession):
         # Prepare data
         _account = Account()
+        _account.keyfile = default_eth_account("user1")["keyfile_json"]
+        _account.eoa_password = E2EEUtils.encrypt("password")
+        _account.rsa_status = AccountRsaStatus.UNSET.value
+        _account.is_deleted = False
         _account.issuer_address = self.issuer_address
         async_db.add(_account)
         await async_db.commit()

--- a/tests/app/test_accounts_DeleteIssuer.py
+++ b/tests/app/test_accounts_DeleteIssuer.py
@@ -1,3 +1,6 @@
+from app.model.db import AccountRsaStatus
+from app.utils.e2ee_utils import E2EEUtils
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -22,7 +25,7 @@ from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.model.db import Account, AccountRsaStatus
+from app.model.db import Account
 from tests.account_config import default_eth_account
 
 
@@ -43,6 +46,7 @@ class TestDeleteIssuer:
 
         # prepare data
         account = Account()
+        account.eoa_password = E2EEUtils.encrypt("password")
         account.issuer_address = _admin_address
         account.keyfile = _admin_keyfile
         account.rsa_status = AccountRsaStatus.UNSET.value

--- a/tests/app/test_accounts_DeleteIssuerAuthToken.py
+++ b/tests/app/test_accounts_DeleteIssuerAuthToken.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -49,6 +51,8 @@ class TestDeleteIssuerAuthToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = test_account["address"]
         account.keyfile = test_account["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt(self.eoa_password)
@@ -89,6 +93,8 @@ class TestDeleteIssuerAuthToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = test_account["address"]
         account.keyfile = test_account["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt(self.eoa_password)
@@ -133,6 +139,8 @@ class TestDeleteIssuerAuthToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = test_account["address"]
         account.keyfile = test_account["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt(self.eoa_password)
@@ -185,6 +193,8 @@ class TestDeleteIssuerAuthToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = test_account["address"]
         account.keyfile = test_account["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt(self.eoa_password)
@@ -237,6 +247,8 @@ class TestDeleteIssuerAuthToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = test_account["address"]
         account.keyfile = test_account["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt(self.eoa_password)
@@ -281,6 +293,8 @@ class TestDeleteIssuerAuthToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = test_account["address"]
         account.keyfile = test_account["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt(self.eoa_password)
@@ -327,6 +341,8 @@ class TestDeleteIssuerAuthToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = test_account["address"]
         account.keyfile = test_account["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt(self.eoa_password)

--- a/tests/app/test_accounts_GenerateIssuerAuthToken.py
+++ b/tests/app/test_accounts_GenerateIssuerAuthToken.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -55,6 +57,8 @@ class TestGenerateIssuerAuthToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = test_account["address"]
         account.keyfile = test_account["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt(self.eoa_password)
@@ -104,6 +108,8 @@ class TestGenerateIssuerAuthToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = test_account["address"]
         account.keyfile = test_account["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt(self.eoa_password)
@@ -168,6 +174,8 @@ class TestGenerateIssuerAuthToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = test_account["address"]
         account.keyfile = test_account["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt(self.eoa_password)
@@ -218,6 +226,8 @@ class TestGenerateIssuerAuthToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = test_account["address"]
         account.keyfile = test_account["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt(self.eoa_password)
@@ -269,6 +279,8 @@ class TestGenerateIssuerAuthToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = test_account["address"]
         account.keyfile = test_account["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt(self.eoa_password)
@@ -321,6 +333,8 @@ class TestGenerateIssuerAuthToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = test_account["address"]
         account.keyfile = test_account["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt(self.eoa_password)
@@ -375,6 +389,8 @@ class TestGenerateIssuerAuthToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = test_account["address"]
         account.keyfile = test_account["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt(self.eoa_password)
@@ -428,6 +444,8 @@ class TestGenerateIssuerAuthToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = test_account["address"]
         account.keyfile = test_account["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt(self.eoa_password)
@@ -480,6 +498,8 @@ class TestGenerateIssuerAuthToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = test_account["address"]
         account.keyfile = test_account["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt(self.eoa_password)
@@ -527,6 +547,8 @@ class TestGenerateIssuerAuthToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = test_account["address"]
         account.keyfile = test_account["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt(self.eoa_password)
@@ -570,6 +592,8 @@ class TestGenerateIssuerAuthToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = test_account["address"]
         account.keyfile = test_account["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt(self.eoa_password)

--- a/tests/app/test_accounts_ListAllChildAccount.py
+++ b/tests/app/test_accounts_ListAllChildAccount.py
@@ -1,3 +1,7 @@
+from app.model.db import AccountRsaStatus
+from app.utils.e2ee_utils import E2EEUtils
+from tests.account_config import default_eth_account
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -53,6 +57,10 @@ class TestListAllChildAccount:
     async def test_normal_1_1(self, async_client: AsyncClient, async_db: AsyncSession):
         # Prepare data
         _account = Account()
+        _account.keyfile = default_eth_account("user1")["keyfile_json"]
+        _account.eoa_password = E2EEUtils.encrypt("password")
+        _account.rsa_status = AccountRsaStatus.UNSET.value
+        _account.is_deleted = False
         _account.issuer_address = self.issuer_address
         async_db.add(_account)
 
@@ -126,6 +134,10 @@ class TestListAllChildAccount:
     async def test_normal_1_2(self, async_client: AsyncClient, async_db: AsyncSession):
         # Prepare data
         _account = Account()
+        _account.keyfile = default_eth_account("user1")["keyfile_json"]
+        _account.eoa_password = E2EEUtils.encrypt("password")
+        _account.rsa_status = AccountRsaStatus.UNSET.value
+        _account.is_deleted = False
         _account.issuer_address = self.issuer_address
         async_db.add(_account)
 
@@ -226,6 +238,10 @@ class TestListAllChildAccount:
     async def test_normal_2_1(self, async_client: AsyncClient, async_db: AsyncSession):
         # Prepare data
         _account = Account()
+        _account.keyfile = default_eth_account("user1")["keyfile_json"]
+        _account.eoa_password = E2EEUtils.encrypt("password")
+        _account.rsa_status = AccountRsaStatus.UNSET.value
+        _account.is_deleted = False
         _account.issuer_address = self.issuer_address
         async_db.add(_account)
 
@@ -293,6 +309,10 @@ class TestListAllChildAccount:
     async def test_normal_2_2(self, async_client: AsyncClient, async_db: AsyncSession):
         # Prepare data
         _account = Account()
+        _account.keyfile = default_eth_account("user1")["keyfile_json"]
+        _account.eoa_password = E2EEUtils.encrypt("password")
+        _account.rsa_status = AccountRsaStatus.UNSET.value
+        _account.is_deleted = False
         _account.issuer_address = self.issuer_address
         async_db.add(_account)
 
@@ -358,6 +378,10 @@ class TestListAllChildAccount:
     async def test_normal_2_3(self, async_client: AsyncClient, async_db: AsyncSession):
         # Prepare data
         _account = Account()
+        _account.keyfile = default_eth_account("user1")["keyfile_json"]
+        _account.eoa_password = E2EEUtils.encrypt("password")
+        _account.rsa_status = AccountRsaStatus.UNSET.value
+        _account.is_deleted = False
         _account.issuer_address = self.issuer_address
         async_db.add(_account)
 
@@ -444,6 +468,10 @@ class TestListAllChildAccount:
     async def test_normal_2_4(self, async_client: AsyncClient, async_db: AsyncSession):
         # Prepare data
         _account = Account()
+        _account.keyfile = default_eth_account("user1")["keyfile_json"]
+        _account.eoa_password = E2EEUtils.encrypt("password")
+        _account.rsa_status = AccountRsaStatus.UNSET.value
+        _account.is_deleted = False
         _account.issuer_address = self.issuer_address
         async_db.add(_account)
 
@@ -530,6 +558,10 @@ class TestListAllChildAccount:
     async def test_normal_2_5(self, async_client: AsyncClient, async_db: AsyncSession):
         # Prepare data
         _account = Account()
+        _account.keyfile = default_eth_account("user1")["keyfile_json"]
+        _account.eoa_password = E2EEUtils.encrypt("password")
+        _account.rsa_status = AccountRsaStatus.UNSET.value
+        _account.is_deleted = False
         _account.issuer_address = self.issuer_address
         async_db.add(_account)
 
@@ -616,6 +648,10 @@ class TestListAllChildAccount:
     async def test_normal_2_6(self, async_client: AsyncClient, async_db: AsyncSession):
         # Prepare data
         _account = Account()
+        _account.keyfile = default_eth_account("user1")["keyfile_json"]
+        _account.eoa_password = E2EEUtils.encrypt("password")
+        _account.rsa_status = AccountRsaStatus.UNSET.value
+        _account.is_deleted = False
         _account.issuer_address = self.issuer_address
         async_db.add(_account)
 
@@ -702,6 +738,10 @@ class TestListAllChildAccount:
     async def test_normal_3_1(self, async_client: AsyncClient, async_db: AsyncSession):
         # Prepare data
         _account = Account()
+        _account.keyfile = default_eth_account("user1")["keyfile_json"]
+        _account.eoa_password = E2EEUtils.encrypt("password")
+        _account.rsa_status = AccountRsaStatus.UNSET.value
+        _account.is_deleted = False
         _account.issuer_address = self.issuer_address
         async_db.add(_account)
 
@@ -774,6 +814,10 @@ class TestListAllChildAccount:
     async def test_normal_3_2(self, async_client: AsyncClient, async_db: AsyncSession):
         # Prepare data
         _account = Account()
+        _account.keyfile = default_eth_account("user1")["keyfile_json"]
+        _account.eoa_password = E2EEUtils.encrypt("password")
+        _account.rsa_status = AccountRsaStatus.UNSET.value
+        _account.is_deleted = False
         _account.issuer_address = self.issuer_address
         async_db.add(_account)
 
@@ -847,6 +891,10 @@ class TestListAllChildAccount:
     async def test_normal_3_3(self, async_client: AsyncClient, async_db: AsyncSession):
         # Prepare data
         _account = Account()
+        _account.keyfile = default_eth_account("user1")["keyfile_json"]
+        _account.eoa_password = E2EEUtils.encrypt("password")
+        _account.rsa_status = AccountRsaStatus.UNSET.value
+        _account.is_deleted = False
         _account.issuer_address = self.issuer_address
         async_db.add(_account)
 
@@ -953,6 +1001,10 @@ class TestListAllChildAccount:
     async def test_normal_3_4(self, async_client: AsyncClient, async_db: AsyncSession):
         # Prepare data
         _account = Account()
+        _account.keyfile = default_eth_account("user1")["keyfile_json"]
+        _account.eoa_password = E2EEUtils.encrypt("password")
+        _account.rsa_status = AccountRsaStatus.UNSET.value
+        _account.is_deleted = False
         _account.issuer_address = self.issuer_address
         async_db.add(_account)
 
@@ -1059,6 +1111,10 @@ class TestListAllChildAccount:
     async def test_normal_3_5(self, async_client: AsyncClient, async_db: AsyncSession):
         # Prepare data
         _account = Account()
+        _account.keyfile = default_eth_account("user1")["keyfile_json"]
+        _account.eoa_password = E2EEUtils.encrypt("password")
+        _account.rsa_status = AccountRsaStatus.UNSET.value
+        _account.is_deleted = False
         _account.issuer_address = self.issuer_address
         async_db.add(_account)
 
@@ -1164,6 +1220,10 @@ class TestListAllChildAccount:
     async def test_normal_4(self, async_client: AsyncClient, async_db: AsyncSession):
         # Prepare data
         _account = Account()
+        _account.keyfile = default_eth_account("user1")["keyfile_json"]
+        _account.eoa_password = E2EEUtils.encrypt("password")
+        _account.rsa_status = AccountRsaStatus.UNSET.value
+        _account.is_deleted = False
         _account.issuer_address = self.issuer_address
         async_db.add(_account)
 

--- a/tests/app/test_accounts_ListAllIssuers.py
+++ b/tests/app/test_accounts_ListAllIssuers.py
@@ -1,3 +1,6 @@
+from app.model.db import AccountRsaStatus
+from app.utils.e2ee_utils import E2EEUtils
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -21,7 +24,7 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.model.db import Account, AccountRsaStatus
+from app.model.db import Account
 from tests.account_config import default_eth_account
 
 
@@ -43,6 +46,8 @@ class TestListAllIssuers:
 
         # prepare data
         account = Account()
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.is_deleted = False
         account.issuer_address = _admin_address
         account.keyfile = _admin_keyfile
         account.rsa_status = AccountRsaStatus.UNSET.value
@@ -72,6 +77,8 @@ class TestListAllIssuers:
 
         # prepare data
         account = Account()
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.is_deleted = False
         account.issuer_address = _admin_address
         account.keyfile = _admin_keyfile
         account.rsa_public_key = _admin_rsa_public_key

--- a/tests/app/test_accounts_RetrieveChildAccount.py
+++ b/tests/app/test_accounts_RetrieveChildAccount.py
@@ -1,3 +1,7 @@
+from app.model.db import AccountRsaStatus
+from app.utils.e2ee_utils import E2EEUtils
+from tests.account_config import default_eth_account
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -41,6 +45,10 @@ class TestRetrieveChildAccount:
     async def test_normal_1_1(self, async_client: AsyncClient, async_db: AsyncSession):
         # Prepare data
         _account = Account()
+        _account.keyfile = default_eth_account("user1")["keyfile_json"]
+        _account.eoa_password = E2EEUtils.encrypt("password")
+        _account.rsa_status = AccountRsaStatus.UNSET.value
+        _account.is_deleted = False
         _account.issuer_address = self.issuer_address
         async_db.add(_account)
 
@@ -73,6 +81,10 @@ class TestRetrieveChildAccount:
     async def test_normal_1_2(self, async_client: AsyncClient, async_db: AsyncSession):
         # Prepare data
         _account = Account()
+        _account.keyfile = default_eth_account("user1")["keyfile_json"]
+        _account.eoa_password = E2EEUtils.encrypt("password")
+        _account.rsa_status = AccountRsaStatus.UNSET.value
+        _account.is_deleted = False
         _account.issuer_address = self.issuer_address
         async_db.add(_account)
 
@@ -147,6 +159,10 @@ class TestRetrieveChildAccount:
     async def test_error_2(self, async_client: AsyncClient, async_db: AsyncSession):
         # Prepare data
         _account = Account()
+        _account.keyfile = default_eth_account("user1")["keyfile_json"]
+        _account.eoa_password = E2EEUtils.encrypt("password")
+        _account.rsa_status = AccountRsaStatus.UNSET.value
+        _account.is_deleted = False
         _account.issuer_address = self.issuer_address
         async_db.add(_account)
         await async_db.commit()

--- a/tests/app/test_accounts_RetrieveIssuer.py
+++ b/tests/app/test_accounts_RetrieveIssuer.py
@@ -1,3 +1,6 @@
+from app.model.db import AccountRsaStatus
+from app.utils.e2ee_utils import E2EEUtils
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -21,7 +24,7 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.model.db import Account, AccountRsaStatus
+from app.model.db import Account
 from tests.account_config import default_eth_account
 
 
@@ -43,6 +46,8 @@ class TestRetrieveIssuer:
 
         # prepare data
         account = Account()
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.is_deleted = False
         account.issuer_address = _admin_address
         account.keyfile = _admin_keyfile
         account.rsa_status = AccountRsaStatus.UNSET.value
@@ -70,6 +75,8 @@ class TestRetrieveIssuer:
 
         # prepare data
         account = Account()
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.is_deleted = False
         account.issuer_address = _admin_address
         account.keyfile = _admin_keyfile
         account.rsa_public_key = _admin_rsa_public_key

--- a/tests/app/test_accounts_UpdateChildAccount.py
+++ b/tests/app/test_accounts_UpdateChildAccount.py
@@ -1,3 +1,7 @@
+from app.model.db import AccountRsaStatus
+from app.utils.e2ee_utils import E2EEUtils
+from tests.account_config import default_eth_account
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -51,6 +55,10 @@ class TestUpdateChildAccount:
     async def test_normal_1(self, async_client: AsyncClient, async_db: AsyncSession):
         # Prepare data
         _account = Account()
+        _account.keyfile = default_eth_account("user1")["keyfile_json"]
+        _account.eoa_password = E2EEUtils.encrypt("password")
+        _account.rsa_status = AccountRsaStatus.UNSET.value
+        _account.is_deleted = False
         _account.issuer_address = self.issuer_address
         async_db.add(_account)
 
@@ -199,6 +207,10 @@ class TestUpdateChildAccount:
     async def test_error_3(self, async_client: AsyncClient, async_db: AsyncSession):
         # Prepare data
         _account = Account()
+        _account.keyfile = default_eth_account("user1")["keyfile_json"]
+        _account.eoa_password = E2EEUtils.encrypt("password")
+        _account.rsa_status = AccountRsaStatus.UNSET.value
+        _account.is_deleted = False
         _account.issuer_address = self.issuer_address
         async_db.add(_account)
         await async_db.commit()
@@ -232,6 +244,10 @@ class TestUpdateChildAccount:
     async def test_error_4(self, async_client: AsyncClient, async_db: AsyncSession):
         # Prepare data
         _account = Account()
+        _account.keyfile = default_eth_account("user1")["keyfile_json"]
+        _account.eoa_password = E2EEUtils.encrypt("password")
+        _account.rsa_status = AccountRsaStatus.UNSET.value
+        _account.is_deleted = False
         _account.issuer_address = self.issuer_address
         async_db.add(_account)
 

--- a/tests/app/test_bond_additional_issue_IssueAdditionalBond.py
+++ b/tests/app/test_bond_additional_issue_IssueAdditionalBond.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -63,6 +65,8 @@ class TestIssueAdditionalBond:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -123,6 +127,8 @@ class TestIssueAdditionalBond:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -391,6 +397,8 @@ class TestIssueAdditionalBond:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -470,6 +478,8 @@ class TestIssueAdditionalBond:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -505,6 +515,8 @@ class TestIssueAdditionalBond:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -540,6 +552,8 @@ class TestIssueAdditionalBond:
 
         # prepare data¬
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -592,6 +606,8 @@ class TestIssueAdditionalBond:
 
         # prepare data¬
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/app/test_bond_additional_issue_IssueAdditionalBondsInBatch.py
+++ b/tests/app/test_bond_additional_issue_IssueAdditionalBondsInBatch.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -65,6 +67,8 @@ class TestIssueAdditionalBondsInBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -134,6 +138,8 @@ class TestIssueAdditionalBondsInBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -211,6 +217,8 @@ class TestIssueAdditionalBondsInBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -264,6 +272,8 @@ class TestIssueAdditionalBondsInBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -320,6 +330,8 @@ class TestIssueAdditionalBondsInBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -376,6 +388,8 @@ class TestIssueAdditionalBondsInBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -432,6 +446,8 @@ class TestIssueAdditionalBondsInBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -482,6 +498,8 @@ class TestIssueAdditionalBondsInBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -532,6 +550,8 @@ class TestIssueAdditionalBondsInBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -580,6 +600,8 @@ class TestIssueAdditionalBondsInBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = "different_issuer_address"  # different
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -628,6 +650,8 @@ class TestIssueAdditionalBondsInBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("wrong_password")  # wrong password
@@ -677,6 +701,8 @@ class TestIssueAdditionalBondsInBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -717,6 +743,8 @@ class TestIssueAdditionalBondsInBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/app/test_bond_additional_issue_RetrieveBatchAdditionalBondIssueStatus.py
+++ b/tests/app/test_bond_additional_issue_RetrieveBatchAdditionalBondIssueStatus.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -73,6 +75,8 @@ class TestRetrieveBatchAdditionalBondIssueStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -162,6 +166,8 @@ class TestRetrieveBatchAdditionalBondIssueStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -251,6 +257,8 @@ class TestRetrieveBatchAdditionalBondIssueStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -366,6 +374,8 @@ class TestRetrieveBatchAdditionalBondIssueStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/app/test_bond_bulk_transfer_BulkTransferBondTokenOwnership.py
+++ b/tests/app/test_bond_bulk_transfer_BulkTransferBondTokenOwnership.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -73,6 +75,8 @@ class TestAppRoutersBondBulkTransferPOST:
     async def test_normal_1(self, async_client: AsyncClient, async_db: AsyncSession):
         # prepare data : Account(Issuer)
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.admin_address
         account.keyfile = self.admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -161,6 +165,8 @@ class TestAppRoutersBondBulkTransferPOST:
     async def test_normal_2(self, async_client: AsyncClient, async_db: AsyncSession):
         # prepare data : Account(Issuer)
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.admin_address
         account.keyfile = self.admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -462,6 +468,8 @@ class TestAppRoutersBondBulkTransferPOST:
     async def test_error_2(self, async_client: AsyncClient, async_db: AsyncSession):
         # prepare data : Account(Issuer)
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.admin_address
         account.keyfile = self.admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -540,6 +548,8 @@ class TestAppRoutersBondBulkTransferPOST:
     async def test_error_3_2(self, async_client: AsyncClient, async_db: AsyncSession):
         # prepare data : Account(Issuer)
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.admin_address
         account.keyfile = self.admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -579,6 +589,8 @@ class TestAppRoutersBondBulkTransferPOST:
     async def test_error_4(self, async_client: AsyncClient, async_db: AsyncSession):
         # prepare data : Account(Issuer)
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.admin_address
         account.keyfile = self.admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -618,6 +630,8 @@ class TestAppRoutersBondBulkTransferPOST:
     async def test_error_5(self, async_client: AsyncClient, async_db: AsyncSession):
         # prepare data : Account(Issuer)
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.admin_address
         account.keyfile = self.admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -668,6 +682,8 @@ class TestAppRoutersBondBulkTransferPOST:
     async def test_error_6(self, async_client: AsyncClient, async_db: AsyncSession):
         # prepare data : Account(Issuer)
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.from_address
         account.keyfile = self.admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/app/test_bond_bulk_transfer_ListBondTokenBulkTransfers.py
+++ b/tests/app/test_bond_bulk_transfer_ListBondTokenBulkTransfers.py
@@ -1,3 +1,6 @@
+from app.model.db import AccountRsaStatus
+from app.utils.e2ee_utils import E2EEUtils
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -84,6 +87,9 @@ class TestListBondTokenBulkTransfers:
         # prepare data : Account(Issuer)
         for _issuer in self.upload_issuer_list:
             account = Account()
+            account.eoa_password = E2EEUtils.encrypt("password")
+            account.rsa_status = AccountRsaStatus.UNSET.value
+            account.is_deleted = False
             account.issuer_address = _issuer["address"]
             account.keyfile = _issuer["keyfile"]
             async_db.add(account)
@@ -190,6 +196,9 @@ class TestListBondTokenBulkTransfers:
         # prepare data : Account(Issuer)
         for _issuer in self.upload_issuer_list:
             account = Account()
+            account.eoa_password = E2EEUtils.encrypt("password")
+            account.rsa_status = AccountRsaStatus.UNSET.value
+            account.is_deleted = False
             account.issuer_address = _issuer["address"]
             account.keyfile = _issuer["keyfile"]
             async_db.add(account)
@@ -297,6 +306,9 @@ class TestListBondTokenBulkTransfers:
         # prepare data : Account(Issuer)
         for _issuer in self.upload_issuer_list:
             account = Account()
+            account.eoa_password = E2EEUtils.encrypt("password")
+            account.rsa_status = AccountRsaStatus.UNSET.value
+            account.is_deleted = False
             account.issuer_address = _issuer["address"]
             account.keyfile = _issuer["keyfile"]
             async_db.add(account)

--- a/tests/app/test_bond_bulk_transfer_RetrieveBondTokenBulkTransfer.py
+++ b/tests/app/test_bond_bulk_transfer_RetrieveBondTokenBulkTransfer.py
@@ -1,3 +1,6 @@
+from app.model.db import AccountRsaStatus
+from app.utils.e2ee_utils import E2EEUtils
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -78,6 +81,9 @@ class TestRetrieveBondTokenBulkTransfer:
         # prepare data : Account(Issuer)
         for _issuer in self.upload_issuer_list:
             account = Account()
+            account.eoa_password = E2EEUtils.encrypt("password")
+            account.rsa_status = AccountRsaStatus.UNSET.value
+            account.is_deleted = False
             account.issuer_address = _issuer["address"]
             account.keyfile = _issuer["keyfile"]
             async_db.add(account)
@@ -141,6 +147,9 @@ class TestRetrieveBondTokenBulkTransfer:
         # prepare data : Account(Issuer)
         for _issuer in self.upload_issuer_list:
             account = Account()
+            account.eoa_password = E2EEUtils.encrypt("password")
+            account.rsa_status = AccountRsaStatus.UNSET.value
+            account.is_deleted = False
             account.issuer_address = _issuer["address"]
             account.keyfile = _issuer["keyfile"]
             async_db.add(account)
@@ -365,6 +374,9 @@ class TestRetrieveBondTokenBulkTransfer:
         # prepare data : Account(Issuer)
         for _issuer in self.upload_issuer_list:
             account = Account()
+            account.eoa_password = E2EEUtils.encrypt("password")
+            account.rsa_status = AccountRsaStatus.UNSET.value
+            account.is_deleted = False
             account.issuer_address = _issuer["address"]
             account.keyfile = _issuer["keyfile"]
             async_db.add(account)
@@ -471,6 +483,9 @@ class TestRetrieveBondTokenBulkTransfer:
         # prepare data : Account(Issuer)
         for _issuer in self.upload_issuer_list:
             account = Account()
+            account.eoa_password = E2EEUtils.encrypt("password")
+            account.rsa_status = AccountRsaStatus.UNSET.value
+            account.is_deleted = False
             account.issuer_address = _issuer["address"]
             account.keyfile = _issuer["keyfile"]
             async_db.add(account)

--- a/tests/app/test_bond_holders_CountBondTokenHolders.py
+++ b/tests/app/test_bond_holders_CountBondTokenHolders.py
@@ -1,3 +1,6 @@
+from app.model.db import AccountRsaStatus
+from app.utils.e2ee_utils import E2EEUtils
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -52,6 +55,10 @@ class TestCountBondTokenHolders:
 
         # prepare data
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -88,6 +95,10 @@ class TestCountBondTokenHolders:
 
         # prepare data
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -133,6 +144,10 @@ class TestCountBondTokenHolders:
 
         # prepare data
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -196,6 +211,10 @@ class TestCountBondTokenHolders:
 
         # prepare data
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -251,6 +270,10 @@ class TestCountBondTokenHolders:
 
         # prepare data
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -392,6 +415,10 @@ class TestCountBondTokenHolders:
 
         # prepare data
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -421,6 +448,10 @@ class TestCountBondTokenHolders:
 
         # prepare data
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 

--- a/tests/app/test_bond_holders_ListAllBondTokenHolders.py
+++ b/tests/app/test_bond_holders_ListAllBondTokenHolders.py
@@ -1,3 +1,6 @@
+from app.model.db import AccountRsaStatus
+from app.utils.e2ee_utils import E2EEUtils
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -56,6 +59,10 @@ class TestListAllBondTokenHolders:
 
         # prepare data
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -95,6 +102,10 @@ class TestListAllBondTokenHolders:
 
         # prepare data: Account
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -223,6 +234,10 @@ class TestListAllBondTokenHolders:
 
         # prepare data: Account
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -363,6 +378,10 @@ class TestListAllBondTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -632,6 +651,10 @@ class TestListAllBondTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -756,6 +779,10 @@ class TestListAllBondTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -910,6 +937,10 @@ class TestListAllBondTokenHolders:
 
         # prepare data
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -1096,6 +1127,10 @@ class TestListAllBondTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -1301,6 +1336,10 @@ class TestListAllBondTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -1533,6 +1572,10 @@ class TestListAllBondTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -1765,6 +1808,10 @@ class TestListAllBondTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -1970,6 +2017,10 @@ class TestListAllBondTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -2202,6 +2253,10 @@ class TestListAllBondTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -2434,6 +2489,10 @@ class TestListAllBondTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -2639,6 +2698,10 @@ class TestListAllBondTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -2872,6 +2935,10 @@ class TestListAllBondTokenHolders:
         _account_address_4 = "0x1CBd3b2770909D4e10f157cABC84C7264073C9Ec"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -3150,6 +3217,10 @@ class TestListAllBondTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -3358,6 +3429,10 @@ class TestListAllBondTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -3593,6 +3668,10 @@ class TestListAllBondTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -3799,6 +3878,10 @@ class TestListAllBondTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -4002,6 +4085,10 @@ class TestListAllBondTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -4232,6 +4319,10 @@ class TestListAllBondTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -4435,6 +4526,10 @@ class TestListAllBondTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -4695,6 +4790,10 @@ class TestListAllBondTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -4955,6 +5054,10 @@ class TestListAllBondTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -5215,6 +5318,10 @@ class TestListAllBondTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -5475,6 +5582,10 @@ class TestListAllBondTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -5735,6 +5846,10 @@ class TestListAllBondTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -5996,6 +6111,10 @@ class TestListAllBondTokenHolders:
         _account_address_4 = "0x917eFFaC072dcda308e2337636f562D0A96F42eA"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -6296,6 +6415,10 @@ class TestListAllBondTokenHolders:
         _account_address_4 = "0x917eFFaC072dcda308e2337636f562D0A96F42eA"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -6595,6 +6718,10 @@ class TestListAllBondTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -6825,6 +6952,10 @@ class TestListAllBondTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -7048,6 +7179,10 @@ class TestListAllBondTokenHolders:
 
         # prepare data
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -7076,6 +7211,10 @@ class TestListAllBondTokenHolders:
 
         # prepare data
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 

--- a/tests/app/test_bond_holders_RegisterBondTokenHolderExtraInfo.py
+++ b/tests/app/test_bond_holders_RegisterBondTokenHolderExtraInfo.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -57,6 +59,8 @@ class TestRegisterBondTokenHolderExtraInfo:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -125,6 +129,8 @@ class TestRegisterBondTokenHolderExtraInfo:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -198,6 +204,8 @@ class TestRegisterBondTokenHolderExtraInfo:
         await async_db.commit()
 
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -523,6 +531,8 @@ class TestRegisterBondTokenHolderExtraInfo:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -568,6 +578,8 @@ class TestRegisterBondTokenHolderExtraInfo:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -614,6 +626,8 @@ class TestRegisterBondTokenHolderExtraInfo:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/app/test_bond_holders_RetrieveBondTokenHolder.py
+++ b/tests/app/test_bond_holders_RetrieveBondTokenHolder.py
@@ -1,3 +1,6 @@
+from app.model.db import AccountRsaStatus
+from app.utils.e2ee_utils import E2EEUtils
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -58,6 +61,10 @@ class TestRetrieveBondTokenHolder:
 
         # prepare data
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -138,6 +145,10 @@ class TestRetrieveBondTokenHolder:
 
         # prepare data: Account
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -229,6 +240,10 @@ class TestRetrieveBondTokenHolder:
 
         # prepare data: Account
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -340,6 +355,10 @@ class TestRetrieveBondTokenHolder:
 
         # prepare data
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -411,6 +430,10 @@ class TestRetrieveBondTokenHolder:
 
         # prepare data
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -497,6 +520,10 @@ class TestRetrieveBondTokenHolder:
 
         # prepare data
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -632,6 +659,10 @@ class TestRetrieveBondTokenHolder:
 
         # prepare data
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -661,6 +692,10 @@ class TestRetrieveBondTokenHolder:
 
         # prepare data
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 

--- a/tests/app/test_bond_personal_info_InitiateBondTokenBatchPersonalInfoRegistration.py
+++ b/tests/app/test_bond_personal_info_InitiateBondTokenBatchPersonalInfoRegistration.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -64,6 +66,8 @@ class TestInitiateBondTokenBatchPersonalInfoRegistration:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -138,6 +142,8 @@ class TestInitiateBondTokenBatchPersonalInfoRegistration:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -636,6 +642,8 @@ class TestInitiateBondTokenBatchPersonalInfoRegistration:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -689,6 +697,8 @@ class TestInitiateBondTokenBatchPersonalInfoRegistration:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -742,6 +752,8 @@ class TestInitiateBondTokenBatchPersonalInfoRegistration:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -805,6 +817,8 @@ class TestInitiateBondTokenBatchPersonalInfoRegistration:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -858,6 +872,8 @@ class TestInitiateBondTokenBatchPersonalInfoRegistration:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/app/test_bond_personal_info_RegisterBondTokenHolderPersonalInfo.py
+++ b/tests/app/test_bond_personal_info_RegisterBondTokenHolderPersonalInfo.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -65,6 +67,8 @@ class TestRegisterBondTokenHolderPersonalInfo:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -158,6 +162,8 @@ class TestRegisterBondTokenHolderPersonalInfo:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -288,6 +294,8 @@ class TestRegisterBondTokenHolderPersonalInfo:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -374,6 +382,8 @@ class TestRegisterBondTokenHolderPersonalInfo:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -467,6 +477,8 @@ class TestRegisterBondTokenHolderPersonalInfo:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -894,6 +906,8 @@ class TestRegisterBondTokenHolderPersonalInfo:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -945,6 +959,8 @@ class TestRegisterBondTokenHolderPersonalInfo:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -996,6 +1012,8 @@ class TestRegisterBondTokenHolderPersonalInfo:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1056,6 +1074,8 @@ class TestRegisterBondTokenHolderPersonalInfo:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1138,6 +1158,8 @@ class TestRegisterBondTokenHolderPersonalInfo:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/app/test_bond_personal_info_RetrieveBondTokenPersonalInfoBatchRegistrationStatus.py
+++ b/tests/app/test_bond_personal_info_RetrieveBondTokenPersonalInfoBatchRegistrationStatus.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -96,6 +98,8 @@ class TestAppRoutersBondTokensTokenAddressPersonalInfoBatchBatchIdGET:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/app/test_bond_redeem_RedeemBond.py
+++ b/tests/app/test_bond_redeem_RedeemBond.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -63,6 +65,8 @@ class TestRedeemBond:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -120,6 +124,8 @@ class TestRedeemBond:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -385,6 +391,8 @@ class TestRedeemBond:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -464,6 +472,8 @@ class TestRedeemBond:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -499,6 +509,8 @@ class TestRedeemBond:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -534,6 +546,8 @@ class TestRedeemBond:
 
         # prepare data¬
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -584,6 +598,8 @@ class TestRedeemBond:
 
         # prepare data¬
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/app/test_bond_redeem_RedeemBondsInBatch.py
+++ b/tests/app/test_bond_redeem_RedeemBondsInBatch.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -60,6 +62,8 @@ class TestRedeemBondsInBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -127,6 +131,8 @@ class TestRedeemBondsInBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -204,6 +210,8 @@ class TestRedeemBondsInBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -257,6 +265,8 @@ class TestRedeemBondsInBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -313,6 +323,8 @@ class TestRedeemBondsInBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -369,6 +381,8 @@ class TestRedeemBondsInBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -425,6 +439,8 @@ class TestRedeemBondsInBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -475,6 +491,8 @@ class TestRedeemBondsInBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -525,6 +543,8 @@ class TestRedeemBondsInBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -573,6 +593,8 @@ class TestRedeemBondsInBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = "different_issuer_address"  # different
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -621,6 +643,8 @@ class TestRedeemBondsInBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("wrong_password")  # wrong password
@@ -670,6 +694,8 @@ class TestRedeemBondsInBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -710,6 +736,8 @@ class TestRedeemBondsInBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/app/test_bond_redeem_RetrieveBatchBondRedemptionStatus.py
+++ b/tests/app/test_bond_redeem_RetrieveBatchBondRedemptionStatus.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -73,6 +75,8 @@ class TestRetrieveBatchBondRedemptionStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -162,6 +166,8 @@ class TestRetrieveBatchBondRedemptionStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -251,6 +257,8 @@ class TestRetrieveBatchBondRedemptionStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -366,6 +374,8 @@ class TestRetrieveBatchBondRedemptionStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/app/test_bond_scheduled_events_DeleteScheduledBondTokenUpdateEvent.py
+++ b/tests/app/test_bond_scheduled_events_DeleteScheduledBondTokenUpdateEvent.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -53,6 +55,8 @@ class TestDeleteScheduledBondTokenUpdateEvent:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -140,6 +144,8 @@ class TestDeleteScheduledBondTokenUpdateEvent:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -293,6 +299,8 @@ class TestDeleteScheduledBondTokenUpdateEvent:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -326,6 +334,8 @@ class TestDeleteScheduledBondTokenUpdateEvent:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/app/test_bond_scheduled_events_ScheduleBondTokenUpdateEvent.py
+++ b/tests/app/test_bond_scheduled_events_ScheduleBondTokenUpdateEvent.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -58,6 +60,8 @@ class TestScheduleBondTokenUpdateEvent:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -151,6 +155,8 @@ class TestScheduleBondTokenUpdateEvent:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -372,6 +378,8 @@ class TestScheduleBondTokenUpdateEvent:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -425,6 +433,8 @@ class TestScheduleBondTokenUpdateEvent:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -520,6 +530,8 @@ class TestScheduleBondTokenUpdateEvent:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -590,6 +602,8 @@ class TestScheduleBondTokenUpdateEvent:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -666,6 +680,8 @@ class TestScheduleBondTokenUpdateEvent:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/app/test_bond_scheduled_events_ScheduleBondTokenUpdateEventsInBatch.py
+++ b/tests/app/test_bond_scheduled_events_ScheduleBondTokenUpdateEventsInBatch.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -59,6 +61,8 @@ class TestScheduleBondTokenUpdateEventsInBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -378,6 +382,8 @@ class TestScheduleBondTokenUpdateEventsInBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -430,6 +436,8 @@ class TestScheduleBondTokenUpdateEventsInBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -473,6 +481,8 @@ class TestScheduleBondTokenUpdateEventsInBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -527,6 +537,8 @@ class TestScheduleBondTokenUpdateEventsInBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -600,6 +612,8 @@ class TestScheduleBondTokenUpdateEventsInBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/app/test_bond_tokens_IssueBondToken.py
+++ b/tests/app/test_bond_tokens_IssueBondToken.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -73,6 +75,8 @@ class TestIssueBondToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = test_account["address"]
         account.keyfile = test_account["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -220,6 +224,8 @@ class TestIssueBondToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = test_account["address"]
         account.keyfile = test_account["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -366,6 +372,8 @@ class TestIssueBondToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = test_account["address"]
         account.keyfile = test_account["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -523,6 +531,8 @@ class TestIssueBondToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = test_account["address"]
         account.keyfile = test_account["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -687,6 +697,8 @@ class TestIssueBondToken:
         test_account = default_eth_account("user1")
 
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = test_account["address"]
         account.keyfile = test_account["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -981,6 +993,8 @@ class TestIssueBondToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = test_account_1["address"]
         account.keyfile = test_account_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1404,6 +1418,8 @@ class TestIssueBondToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = test_account_1["address"]
         account.keyfile = test_account_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1448,6 +1464,8 @@ class TestIssueBondToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = test_account_1["address"]
         account.keyfile = test_account_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1494,6 +1512,8 @@ class TestIssueBondToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = test_account_1["address"]
         account.keyfile = test_account_2["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1546,6 +1566,8 @@ class TestIssueBondToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = test_account["address"]
         account.keyfile = test_account["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/app/test_bond_tokens_ListBondOperationLogHistory.py
+++ b/tests/app/test_bond_tokens_ListBondOperationLogHistory.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -270,6 +272,8 @@ class TestListBondOperationLogHistory:
 
         # prepare data: Token
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -331,6 +335,8 @@ class TestListBondOperationLogHistory:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -430,6 +436,8 @@ class TestListBondOperationLogHistory:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -527,6 +535,8 @@ class TestListBondOperationLogHistory:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -613,6 +623,8 @@ class TestListBondOperationLogHistory:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -728,6 +740,8 @@ class TestListBondOperationLogHistory:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -835,6 +849,8 @@ class TestListBondOperationLogHistory:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -938,6 +954,8 @@ class TestListBondOperationLogHistory:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1042,6 +1060,8 @@ class TestListBondOperationLogHistory:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1130,6 +1150,8 @@ class TestListBondOperationLogHistory:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/app/test_bond_tokens_UpdateBondToken.py
+++ b/tests/app/test_bond_tokens_UpdateBondToken.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -116,6 +118,8 @@ class TestUpdateBondToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -286,6 +290,8 @@ class TestUpdateBondToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -431,6 +437,8 @@ class TestUpdateBondToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -574,6 +582,8 @@ class TestUpdateBondToken:
         _token_address = token_contract.address
 
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -651,6 +661,8 @@ class TestUpdateBondToken:
         _token_address = token_contract.address
 
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -728,6 +740,8 @@ class TestUpdateBondToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -794,6 +808,8 @@ class TestUpdateBondToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1686,6 +1702,8 @@ class TestUpdateBondToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1729,6 +1747,8 @@ class TestUpdateBondToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1768,6 +1788,8 @@ class TestUpdateBondToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1818,6 +1840,8 @@ class TestUpdateBondToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1863,6 +1887,8 @@ class TestUpdateBondToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1930,6 +1956,8 @@ class TestUpdateBondToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1975,6 +2003,8 @@ class TestUpdateBondToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -2031,6 +2061,8 @@ class TestUpdateBondToken:
         _token_address = token_contract.address
 
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/app/test_bond_transfer_approvals_UpdateBondTokenTransferApprovalStatus.py
+++ b/tests/app/test_bond_transfer_approvals_UpdateBondTokenTransferApprovalStatus.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -85,6 +87,8 @@ class TestUpdateBondTokenTransferApprovalStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -223,6 +227,8 @@ class TestUpdateBondTokenTransferApprovalStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -362,6 +368,8 @@ class TestUpdateBondTokenTransferApprovalStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -499,6 +507,8 @@ class TestUpdateBondTokenTransferApprovalStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -775,6 +785,8 @@ class TestUpdateBondTokenTransferApprovalStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -811,6 +823,8 @@ class TestUpdateBondTokenTransferApprovalStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -847,6 +861,8 @@ class TestUpdateBondTokenTransferApprovalStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -892,6 +908,8 @@ class TestUpdateBondTokenTransferApprovalStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -938,6 +956,8 @@ class TestUpdateBondTokenTransferApprovalStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1004,6 +1024,8 @@ class TestUpdateBondTokenTransferApprovalStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1070,6 +1092,8 @@ class TestUpdateBondTokenTransferApprovalStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1134,6 +1158,8 @@ class TestUpdateBondTokenTransferApprovalStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1198,6 +1224,8 @@ class TestUpdateBondTokenTransferApprovalStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1275,6 +1303,8 @@ class TestUpdateBondTokenTransferApprovalStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1372,6 +1402,8 @@ class TestUpdateBondTokenTransferApprovalStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1486,6 +1518,8 @@ class TestUpdateBondTokenTransferApprovalStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1583,6 +1617,8 @@ class TestUpdateBondTokenTransferApprovalStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1691,6 +1727,8 @@ class TestUpdateBondTokenTransferApprovalStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1787,6 +1825,8 @@ class TestUpdateBondTokenTransferApprovalStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1888,6 +1928,8 @@ class TestUpdateBondTokenTransferApprovalStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1957,6 +1999,8 @@ class TestUpdateBondTokenTransferApprovalStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/app/test_bond_transfers_TransferBondTokenOwnership.py
+++ b/tests/app/test_bond_transfers_TransferBondTokenOwnership.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -71,6 +73,8 @@ class TestTransferBondTokenOwnership:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _admin_address
         account.keyfile = _admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -145,6 +149,8 @@ class TestTransferBondTokenOwnership:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _admin_address
         account.keyfile = _admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -455,6 +461,8 @@ class TestTransferBondTokenOwnership:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _admin_address
         account.keyfile = _admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -503,6 +511,8 @@ class TestTransferBondTokenOwnership:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _admin_address
         account.keyfile = _admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -551,6 +561,8 @@ class TestTransferBondTokenOwnership:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _admin_address
         account.keyfile = _admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -613,6 +625,8 @@ class TestTransferBondTokenOwnership:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _admin_address
         account.keyfile = _admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/app/test_ledger_RetrieveLedgerHistory.py
+++ b/tests/app/test_ledger_RetrieveLedgerHistory.py
@@ -1,3 +1,6 @@
+from app.model.db import AccountRsaStatus
+from app.utils.e2ee_utils import E2EEUtils
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -72,6 +75,10 @@ class TestRetrieveLedgerHistory:
         async_db.add(_token)
 
         _issuer_account = Account()
+        _issuer_account.keyfile = default_eth_account("user1")["keyfile_json"]
+        _issuer_account.eoa_password = E2EEUtils.encrypt("password")
+        _issuer_account.rsa_status = AccountRsaStatus.UNSET.value
+        _issuer_account.is_deleted = False
         _issuer_account.issuer_address = issuer_address
         async_db.add(_issuer_account)
 
@@ -328,6 +335,10 @@ class TestRetrieveLedgerHistory:
         async_db.add(_token)
 
         _issuer_account = Account()
+        _issuer_account.keyfile = default_eth_account("user1")["keyfile_json"]
+        _issuer_account.eoa_password = E2EEUtils.encrypt("password")
+        _issuer_account.rsa_status = AccountRsaStatus.UNSET.value
+        _issuer_account.is_deleted = False
         _issuer_account.issuer_address = issuer_address
         async_db.add(_issuer_account)
 
@@ -583,6 +594,10 @@ class TestRetrieveLedgerHistory:
         async_db.add(_token)
 
         _issuer_account = Account()
+        _issuer_account.keyfile = default_eth_account("user1")["keyfile_json"]
+        _issuer_account.eoa_password = E2EEUtils.encrypt("password")
+        _issuer_account.rsa_status = AccountRsaStatus.UNSET.value
+        _issuer_account.is_deleted = False
         _issuer_account.issuer_address = issuer_address
         async_db.add(_issuer_account)
 
@@ -869,6 +884,10 @@ class TestRetrieveLedgerHistory:
         async_db.add(_token)
 
         _issuer_account = Account()
+        _issuer_account.keyfile = default_eth_account("user1")["keyfile_json"]
+        _issuer_account.eoa_password = E2EEUtils.encrypt("password")
+        _issuer_account.rsa_status = AccountRsaStatus.UNSET.value
+        _issuer_account.is_deleted = False
         _issuer_account.issuer_address = issuer_address
         async_db.add(_issuer_account)
 
@@ -1192,6 +1211,10 @@ class TestRetrieveLedgerHistory:
         async_db.add(_token)
 
         _issuer_account = Account()
+        _issuer_account.keyfile = default_eth_account("user1")["keyfile_json"]
+        _issuer_account.eoa_password = E2EEUtils.encrypt("password")
+        _issuer_account.rsa_status = AccountRsaStatus.UNSET.value
+        _issuer_account.is_deleted = False
         _issuer_account.issuer_address = issuer_address
         async_db.add(_issuer_account)
 
@@ -1510,6 +1533,10 @@ class TestRetrieveLedgerHistory:
         async_db.add(_token)
 
         _issuer_account = Account()
+        _issuer_account.keyfile = default_eth_account("user1")["keyfile_json"]
+        _issuer_account.eoa_password = E2EEUtils.encrypt("password")
+        _issuer_account.rsa_status = AccountRsaStatus.UNSET.value
+        _issuer_account.is_deleted = False
         _issuer_account.issuer_address = issuer_address
         async_db.add(_issuer_account)
 
@@ -1898,6 +1925,10 @@ class TestRetrieveLedgerHistory:
         async_db.add(_token)
 
         _issuer_account = Account()
+        _issuer_account.keyfile = default_eth_account("user1")["keyfile_json"]
+        _issuer_account.eoa_password = E2EEUtils.encrypt("password")
+        _issuer_account.rsa_status = AccountRsaStatus.UNSET.value
+        _issuer_account.is_deleted = False
         _issuer_account.issuer_address = issuer_address
         async_db.add(_issuer_account)
 

--- a/tests/app/test_positions_ForceLock.py
+++ b/tests/app/test_positions_ForceLock.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -64,6 +66,8 @@ class TestForceLock:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _admin_address
         account.keyfile = _admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -136,6 +140,8 @@ class TestForceLock:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _admin_address
         account.keyfile = _admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -208,6 +214,8 @@ class TestForceLock:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _admin_address
         account.keyfile = _admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -492,6 +500,8 @@ class TestForceLock:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _admin_address
         account.keyfile = _admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -587,6 +597,8 @@ class TestForceLock:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _admin_address
         account.keyfile = _admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -633,6 +645,8 @@ class TestForceLock:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _admin_address
         account.keyfile = _admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -688,6 +702,8 @@ class TestForceLock:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _admin_address
         account.keyfile = _admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -734,6 +750,8 @@ class TestForceLock:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _admin_address
         account.keyfile = _admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -789,6 +807,8 @@ class TestForceLock:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _admin_address
         account.keyfile = _admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -847,6 +867,8 @@ class TestForceLock:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _admin_address
         account.keyfile = _admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -905,6 +927,8 @@ class TestForceLock:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _admin_address
         account.keyfile = _admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/app/test_positions_ForceUnlock.py
+++ b/tests/app/test_positions_ForceUnlock.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -79,6 +81,8 @@ class TestForceUnlock:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _admin_address
         account.keyfile = _admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -154,6 +158,8 @@ class TestForceUnlock:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _admin_address
         account.keyfile = _admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -229,6 +235,8 @@ class TestForceUnlock:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _admin_address
         account.keyfile = _admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -307,6 +315,8 @@ class TestForceUnlock:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _admin_address
         account.keyfile = _admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -629,6 +639,8 @@ class TestForceUnlock:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _admin_address
         account.keyfile = _admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -728,6 +740,8 @@ class TestForceUnlock:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _admin_address
         account.keyfile = _admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -776,6 +790,8 @@ class TestForceUnlock:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _admin_address
         account.keyfile = _admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -833,6 +849,8 @@ class TestForceUnlock:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _admin_address
         account.keyfile = _admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -881,6 +899,8 @@ class TestForceUnlock:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _admin_address
         account.keyfile = _admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -940,6 +960,8 @@ class TestForceUnlock:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _admin_address
         account.keyfile = _admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1014,6 +1036,8 @@ class TestForceUnlock:
         _ava_ibet_wst_address = "0x2234567890abcdef1234567890abcdef12345678"
 
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _admin_address
         account.keyfile = _admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1089,6 +1113,8 @@ class TestForceUnlock:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _admin_address
         account.keyfile = _admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1149,6 +1175,8 @@ class TestForceUnlock:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _admin_address
         account.keyfile = _admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/app/test_settlement_agent_UpdateDVPAgentDelivery.py
+++ b/tests/app/test_settlement_agent_UpdateDVPAgentDelivery.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -109,6 +111,8 @@ class TestUpdateDVPDelivery:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -222,6 +226,8 @@ class TestUpdateDVPDelivery:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -339,6 +345,8 @@ class TestUpdateDVPDelivery:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -445,6 +453,8 @@ class TestUpdateDVPDelivery:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -501,6 +511,8 @@ class TestUpdateDVPDelivery:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -566,6 +578,8 @@ class TestUpdateDVPDelivery:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -635,6 +649,8 @@ class TestUpdateDVPDelivery:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -689,6 +705,8 @@ class TestUpdateDVPDelivery:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -770,6 +788,8 @@ class TestUpdateDVPDelivery:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/app/test_settlement_issuer_CreateDVPDelivery.py
+++ b/tests/app/test_settlement_issuer_CreateDVPDelivery.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -117,6 +119,8 @@ class TestCreateDVPDelivery:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -216,6 +220,8 @@ class TestCreateDVPDelivery:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -328,6 +334,8 @@ class TestCreateDVPDelivery:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -687,6 +695,8 @@ class TestCreateDVPDelivery:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -793,6 +803,8 @@ class TestCreateDVPDelivery:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -851,6 +863,8 @@ class TestCreateDVPDelivery:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/app/test_settlement_issuer_UpdateDVPDelivery.py
+++ b/tests/app/test_settlement_issuer_UpdateDVPDelivery.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -117,6 +119,8 @@ class TestUpdateDVPDelivery:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -234,6 +238,8 @@ class TestUpdateDVPDelivery:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -433,6 +439,8 @@ class TestUpdateDVPDelivery:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -531,6 +539,8 @@ class TestUpdateDVPDelivery:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -576,6 +586,8 @@ class TestUpdateDVPDelivery:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/app/test_share_additional_issue_IssueAdditionalShare.py
+++ b/tests/app/test_share_additional_issue_IssueAdditionalShare.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -63,6 +65,8 @@ class TestIssueAdditionalShare:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -123,6 +127,8 @@ class TestIssueAdditionalShare:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -399,6 +405,8 @@ class TestIssueAdditionalShare:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -434,6 +442,8 @@ class TestIssueAdditionalShare:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -469,6 +479,8 @@ class TestIssueAdditionalShare:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -519,6 +531,8 @@ class TestIssueAdditionalShare:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/app/test_share_additional_issue_IssueAdditionalSharesInBatch.py
+++ b/tests/app/test_share_additional_issue_IssueAdditionalSharesInBatch.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -65,6 +67,8 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueBatchPOST:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -134,6 +138,8 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueBatchPOST:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -211,6 +217,8 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueBatchPOST:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -264,6 +272,8 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueBatchPOST:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -320,6 +330,8 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueBatchPOST:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -376,6 +388,8 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueBatchPOST:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -432,6 +446,8 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueBatchPOST:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -482,6 +498,8 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueBatchPOST:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -532,6 +550,8 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueBatchPOST:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -580,6 +600,8 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueBatchPOST:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = "different_issuer_address"  # different
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -628,6 +650,8 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueBatchPOST:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("wrong_password")  # wrong password
@@ -677,6 +701,8 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueBatchPOST:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -717,6 +743,8 @@ class TestAppRoutersShareTokensTokenAddressAdditionalIssueBatchPOST:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/app/test_share_additional_issue_RetrieveBatchAdditionalShareIssueStatus.py
+++ b/tests/app/test_share_additional_issue_RetrieveBatchAdditionalShareIssueStatus.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -73,6 +75,8 @@ class TestRetrieveBatchAdditionalShareIssueStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -162,6 +166,8 @@ class TestRetrieveBatchAdditionalShareIssueStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -251,6 +257,8 @@ class TestRetrieveBatchAdditionalShareIssueStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -366,6 +374,8 @@ class TestRetrieveBatchAdditionalShareIssueStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/app/test_share_bulk_transfer_BulkTransferShareTokenOwnership.py
+++ b/tests/app/test_share_bulk_transfer_BulkTransferShareTokenOwnership.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -73,6 +75,8 @@ class TestBulkTransferShareTokenOwnership:
     async def test_normal_1(self, async_client: AsyncClient, async_db: AsyncSession):
         # prepare data : Account(Issuer)
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.admin_address
         account.keyfile = self.admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -161,6 +165,8 @@ class TestBulkTransferShareTokenOwnership:
     async def test_normal_2(self, async_client: AsyncClient, async_db: AsyncSession):
         # prepare data : Account(Issuer)
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.admin_address
         account.keyfile = self.admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -463,6 +469,8 @@ class TestBulkTransferShareTokenOwnership:
     async def test_error_2(self, async_client: AsyncClient, async_db: AsyncSession):
         # prepare data : Account(Issuer)
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.admin_address
         account.keyfile = self.admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -541,6 +549,8 @@ class TestBulkTransferShareTokenOwnership:
     async def test_error_3_2(self, async_client: AsyncClient, async_db: AsyncSession):
         # prepare data : Account(Issuer)
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.admin_address
         account.keyfile = self.admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -580,6 +590,8 @@ class TestBulkTransferShareTokenOwnership:
     async def test_error_4(self, async_client: AsyncClient, async_db: AsyncSession):
         # prepare data : Account(Issuer)
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.admin_address
         account.keyfile = self.admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -619,6 +631,8 @@ class TestBulkTransferShareTokenOwnership:
     async def test_error_5(self, async_client: AsyncClient, async_db: AsyncSession):
         # prepare data : Account(Issuer)
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.admin_address
         account.keyfile = self.admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -669,6 +683,8 @@ class TestBulkTransferShareTokenOwnership:
     async def test_error_6(self, async_client: AsyncClient, async_db: AsyncSession):
         # prepare data : Account(Issuer)
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.from_address
         account.keyfile = self.admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/app/test_share_bulk_transfer_ListShareTokenBulkTransfers.py
+++ b/tests/app/test_share_bulk_transfer_ListShareTokenBulkTransfers.py
@@ -1,3 +1,6 @@
+from app.model.db import AccountRsaStatus
+from app.utils.e2ee_utils import E2EEUtils
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -84,6 +87,9 @@ class TestListShareTokenBulkTransfers:
         # prepare data : Account(Issuer)
         for _issuer in self.upload_issuer_list:
             account = Account()
+            account.eoa_password = E2EEUtils.encrypt("password")
+            account.rsa_status = AccountRsaStatus.UNSET.value
+            account.is_deleted = False
             account.issuer_address = _issuer["address"]
             account.keyfile = _issuer["keyfile"]
             async_db.add(account)
@@ -190,6 +196,9 @@ class TestListShareTokenBulkTransfers:
         # prepare data : Account(Issuer)
         for _issuer in self.upload_issuer_list:
             account = Account()
+            account.eoa_password = E2EEUtils.encrypt("password")
+            account.rsa_status = AccountRsaStatus.UNSET.value
+            account.is_deleted = False
             account.issuer_address = _issuer["address"]
             account.keyfile = _issuer["keyfile"]
             async_db.add(account)
@@ -297,6 +306,9 @@ class TestListShareTokenBulkTransfers:
         # prepare data : Account(Issuer)
         for _issuer in self.upload_issuer_list:
             account = Account()
+            account.eoa_password = E2EEUtils.encrypt("password")
+            account.rsa_status = AccountRsaStatus.UNSET.value
+            account.is_deleted = False
             account.issuer_address = _issuer["address"]
             account.keyfile = _issuer["keyfile"]
             async_db.add(account)

--- a/tests/app/test_share_bulk_transfer_RetrieveShareTokenBulkTransfer.py
+++ b/tests/app/test_share_bulk_transfer_RetrieveShareTokenBulkTransfer.py
@@ -1,3 +1,6 @@
+from app.model.db import AccountRsaStatus
+from app.utils.e2ee_utils import E2EEUtils
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -78,6 +81,9 @@ class TestAppRoutersShareBulkTransferGET:
         # prepare data : Account(Issuer)
         for _issuer in self.upload_issuer_list:
             account = Account()
+            account.eoa_password = E2EEUtils.encrypt("password")
+            account.rsa_status = AccountRsaStatus.UNSET.value
+            account.is_deleted = False
             account.issuer_address = _issuer["address"]
             account.keyfile = _issuer["keyfile"]
             async_db.add(account)
@@ -141,6 +147,9 @@ class TestAppRoutersShareBulkTransferGET:
         # prepare data : Account(Issuer)
         for _issuer in self.upload_issuer_list:
             account = Account()
+            account.eoa_password = E2EEUtils.encrypt("password")
+            account.rsa_status = AccountRsaStatus.UNSET.value
+            account.is_deleted = False
             account.issuer_address = _issuer["address"]
             account.keyfile = _issuer["keyfile"]
             async_db.add(account)
@@ -365,6 +374,9 @@ class TestAppRoutersShareBulkTransferGET:
         # prepare data : Account(Issuer)
         for _issuer in self.upload_issuer_list:
             account = Account()
+            account.eoa_password = E2EEUtils.encrypt("password")
+            account.rsa_status = AccountRsaStatus.UNSET.value
+            account.is_deleted = False
             account.issuer_address = _issuer["address"]
             account.keyfile = _issuer["keyfile"]
             async_db.add(account)
@@ -471,6 +483,9 @@ class TestAppRoutersShareBulkTransferGET:
         # prepare data : Account(Issuer)
         for _issuer in self.upload_issuer_list:
             account = Account()
+            account.eoa_password = E2EEUtils.encrypt("password")
+            account.rsa_status = AccountRsaStatus.UNSET.value
+            account.is_deleted = False
             account.issuer_address = _issuer["address"]
             account.keyfile = _issuer["keyfile"]
             async_db.add(account)

--- a/tests/app/test_share_holders_CountShareTokenHolders.py
+++ b/tests/app/test_share_holders_CountShareTokenHolders.py
@@ -1,3 +1,6 @@
+from app.model.db import AccountRsaStatus
+from app.utils.e2ee_utils import E2EEUtils
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -52,6 +55,10 @@ class TestCountShareTokenHolders:
 
         # prepare data
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -88,6 +95,10 @@ class TestCountShareTokenHolders:
 
         # prepare data
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -133,6 +144,10 @@ class TestCountShareTokenHolders:
 
         # prepare data
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -196,6 +211,10 @@ class TestCountShareTokenHolders:
 
         # prepare data
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -251,6 +270,10 @@ class TestCountShareTokenHolders:
 
         # prepare data
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -392,6 +415,10 @@ class TestCountShareTokenHolders:
 
         # prepare data
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -421,6 +448,10 @@ class TestCountShareTokenHolders:
 
         # prepare data
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 

--- a/tests/app/test_share_holders_ListAllShareTokenHolders.py
+++ b/tests/app/test_share_holders_ListAllShareTokenHolders.py
@@ -1,3 +1,6 @@
+from app.model.db import AccountRsaStatus
+from app.utils.e2ee_utils import E2EEUtils
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -56,6 +59,10 @@ class TestListAllShareTokenHolders:
 
         # prepare data
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -95,6 +102,10 @@ class TestListAllShareTokenHolders:
 
         # prepare data: Account
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -223,6 +234,10 @@ class TestListAllShareTokenHolders:
 
         # prepare data: Account
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -363,6 +378,10 @@ class TestListAllShareTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -632,6 +651,10 @@ class TestListAllShareTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -756,6 +779,10 @@ class TestListAllShareTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -925,6 +952,10 @@ class TestListAllShareTokenHolders:
 
         # prepare data
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -1111,6 +1142,10 @@ class TestListAllShareTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -1316,6 +1351,10 @@ class TestListAllShareTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -1548,6 +1587,10 @@ class TestListAllShareTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -1780,6 +1823,10 @@ class TestListAllShareTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -1985,6 +2032,10 @@ class TestListAllShareTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -2217,6 +2268,10 @@ class TestListAllShareTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -2449,6 +2504,10 @@ class TestListAllShareTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -2654,6 +2713,10 @@ class TestListAllShareTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -2887,6 +2950,10 @@ class TestListAllShareTokenHolders:
         _account_address_4 = "0x1CBd3b2770909D4e10f157cABC84C7264073C9Ec"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -3157,6 +3224,10 @@ class TestListAllShareTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -3365,6 +3436,10 @@ class TestListAllShareTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -3600,6 +3675,10 @@ class TestListAllShareTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -3833,6 +3912,10 @@ class TestListAllShareTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -4036,6 +4119,10 @@ class TestListAllShareTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -4266,6 +4353,10 @@ class TestListAllShareTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -4469,6 +4560,10 @@ class TestListAllShareTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -4729,6 +4824,10 @@ class TestListAllShareTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -4989,6 +5088,10 @@ class TestListAllShareTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -5249,6 +5352,10 @@ class TestListAllShareTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -5509,6 +5616,10 @@ class TestListAllShareTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -5769,6 +5880,10 @@ class TestListAllShareTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -6030,6 +6145,10 @@ class TestListAllShareTokenHolders:
         _account_address_4 = "0x917eFFaC072dcda308e2337636f562D0A96F42eA"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -6330,6 +6449,10 @@ class TestListAllShareTokenHolders:
         _account_address_4 = "0x917eFFaC072dcda308e2337636f562D0A96F42eA"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -6629,6 +6752,10 @@ class TestListAllShareTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -6859,6 +6986,10 @@ class TestListAllShareTokenHolders:
         _account_address_3 = "0x8277D905F37F8a9717F5718d0daC21495dFE74bf"
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -7082,6 +7213,10 @@ class TestListAllShareTokenHolders:
 
         # prepare data
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -7120,6 +7255,10 @@ class TestListAllShareTokenHolders:
 
         # prepare data
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 

--- a/tests/app/test_share_holders_RegisterShareTokenHolderExtraInfo.py
+++ b/tests/app/test_share_holders_RegisterShareTokenHolderExtraInfo.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -57,6 +59,8 @@ class TestRegisterShareTokenHolderExtraInfo:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -125,6 +129,8 @@ class TestRegisterShareTokenHolderExtraInfo:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -198,6 +204,8 @@ class TestRegisterShareTokenHolderExtraInfo:
         await async_db.commit()
 
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -523,6 +531,8 @@ class TestRegisterShareTokenHolderExtraInfo:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -568,6 +578,8 @@ class TestRegisterShareTokenHolderExtraInfo:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -614,6 +626,8 @@ class TestRegisterShareTokenHolderExtraInfo:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/app/test_share_holders_RetrieveShareTokenHolder.py
+++ b/tests/app/test_share_holders_RetrieveShareTokenHolder.py
@@ -1,3 +1,6 @@
+from app.model.db import AccountRsaStatus
+from app.utils.e2ee_utils import E2EEUtils
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -58,6 +61,10 @@ class TestRetrieveShareTokenHolder:
 
         # prepare data
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -138,6 +145,10 @@ class TestRetrieveShareTokenHolder:
 
         # prepare data: Account
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -229,6 +240,10 @@ class TestRetrieveShareTokenHolder:
 
         # prepare data: Account
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -340,6 +355,10 @@ class TestRetrieveShareTokenHolder:
 
         # prepare data
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -411,6 +430,10 @@ class TestRetrieveShareTokenHolder:
 
         # prepare data
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -498,6 +521,10 @@ class TestRetrieveShareTokenHolder:
 
         # prepare data
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -633,6 +660,10 @@ class TestRetrieveShareTokenHolder:
 
         # prepare data
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 
@@ -662,6 +693,10 @@ class TestRetrieveShareTokenHolder:
 
         # prepare data
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         async_db.add(account)
 

--- a/tests/app/test_share_personal_info_InitiateShareTokenBatchPersonalInfoRegistration.py
+++ b/tests/app/test_share_personal_info_InitiateShareTokenBatchPersonalInfoRegistration.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -64,6 +66,8 @@ class TestInitiateShareTokenBatchPersonalInfoRegistration:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -138,6 +142,8 @@ class TestInitiateShareTokenBatchPersonalInfoRegistration:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -569,6 +575,8 @@ class TestInitiateShareTokenBatchPersonalInfoRegistration:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -622,6 +630,8 @@ class TestInitiateShareTokenBatchPersonalInfoRegistration:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -675,6 +685,8 @@ class TestInitiateShareTokenBatchPersonalInfoRegistration:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -738,6 +750,8 @@ class TestInitiateShareTokenBatchPersonalInfoRegistration:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -791,6 +805,8 @@ class TestInitiateShareTokenBatchPersonalInfoRegistration:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/app/test_share_personal_info_RegisterShareTokenHolderPersonalInfo.py
+++ b/tests/app/test_share_personal_info_RegisterShareTokenHolderPersonalInfo.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -65,6 +67,8 @@ class TestRegisterShareTokenHolderPersonalInfo:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -158,6 +162,8 @@ class TestRegisterShareTokenHolderPersonalInfo:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -288,6 +294,8 @@ class TestRegisterShareTokenHolderPersonalInfo:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -374,6 +382,8 @@ class TestRegisterShareTokenHolderPersonalInfo:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -467,6 +477,8 @@ class TestRegisterShareTokenHolderPersonalInfo:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -894,6 +906,8 @@ class TestRegisterShareTokenHolderPersonalInfo:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -945,6 +959,8 @@ class TestRegisterShareTokenHolderPersonalInfo:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -996,6 +1012,8 @@ class TestRegisterShareTokenHolderPersonalInfo:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1056,6 +1074,8 @@ class TestRegisterShareTokenHolderPersonalInfo:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1138,6 +1158,8 @@ class TestRegisterShareTokenHolderPersonalInfo:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/app/test_share_personal_info_RetrieveShareTokenPersonalInfoBatchRegistrationStatus.py
+++ b/tests/app/test_share_personal_info_RetrieveShareTokenPersonalInfoBatchRegistrationStatus.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -95,6 +97,8 @@ class TestAppRoutersShareTokensTokenAddressPersonalInfoBatchBatchIdGET:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/app/test_share_redeem_RedeemShare.py
+++ b/tests/app/test_share_redeem_RedeemShare.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -63,6 +65,8 @@ class TestAppRoutersShareTokensTokenAddressRedeemPOST:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -120,6 +124,8 @@ class TestAppRoutersShareTokensTokenAddressRedeemPOST:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -393,6 +399,8 @@ class TestAppRoutersShareTokensTokenAddressRedeemPOST:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -428,6 +436,8 @@ class TestAppRoutersShareTokensTokenAddressRedeemPOST:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -463,6 +473,8 @@ class TestAppRoutersShareTokensTokenAddressRedeemPOST:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -513,6 +525,8 @@ class TestAppRoutersShareTokensTokenAddressRedeemPOST:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/app/test_share_redeem_RedeemSharesInBatch.py
+++ b/tests/app/test_share_redeem_RedeemSharesInBatch.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -65,6 +67,8 @@ class TestRedeemSharesInBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -134,6 +138,8 @@ class TestRedeemSharesInBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -211,6 +217,8 @@ class TestRedeemSharesInBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -264,6 +272,8 @@ class TestRedeemSharesInBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -320,6 +330,8 @@ class TestRedeemSharesInBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -376,6 +388,8 @@ class TestRedeemSharesInBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -432,6 +446,8 @@ class TestRedeemSharesInBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -482,6 +498,8 @@ class TestRedeemSharesInBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -532,6 +550,8 @@ class TestRedeemSharesInBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -580,6 +600,8 @@ class TestRedeemSharesInBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = "different_issuer_address"  # different
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -628,6 +650,8 @@ class TestRedeemSharesInBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("wrong_password")  # wrong password
@@ -677,6 +701,8 @@ class TestRedeemSharesInBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -717,6 +743,8 @@ class TestRedeemSharesInBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/app/test_share_redeem_RetrieveBatchShareRedemptionStatus.py
+++ b/tests/app/test_share_redeem_RetrieveBatchShareRedemptionStatus.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -73,6 +75,8 @@ class TestRetrieveBatchShareRedemptionStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -162,6 +166,8 @@ class TestRetrieveBatchShareRedemptionStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -251,6 +257,8 @@ class TestRetrieveBatchShareRedemptionStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -366,6 +374,8 @@ class TestRetrieveBatchShareRedemptionStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/app/test_share_scheduled_events_DeleteScheduledShareTokenUpdateEvent.py
+++ b/tests/app/test_share_scheduled_events_DeleteScheduledShareTokenUpdateEvent.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -53,6 +55,8 @@ class TestDeleteScheduledShareTokenUpdateEvent:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -138,6 +142,8 @@ class TestDeleteScheduledShareTokenUpdateEvent:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -289,6 +295,8 @@ class TestDeleteScheduledShareTokenUpdateEvent:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -322,6 +330,8 @@ class TestDeleteScheduledShareTokenUpdateEvent:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/app/test_share_scheduled_events_ScheduleShareTokenUpdateEvent.py
+++ b/tests/app/test_share_scheduled_events_ScheduleShareTokenUpdateEvent.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -57,6 +59,8 @@ class TestScheduleShareTokenUpdateEvent:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -145,6 +149,8 @@ class TestScheduleShareTokenUpdateEvent:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -355,6 +361,8 @@ class TestScheduleShareTokenUpdateEvent:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -408,6 +416,8 @@ class TestScheduleShareTokenUpdateEvent:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -504,6 +514,8 @@ class TestScheduleShareTokenUpdateEvent:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -559,6 +571,8 @@ class TestScheduleShareTokenUpdateEvent:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/app/test_share_scheduled_events_ScheduleShareTokenUpdateEventsInBatch.py
+++ b/tests/app/test_share_scheduled_events_ScheduleShareTokenUpdateEventsInBatch.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -59,6 +61,8 @@ class TestScheduleShareTokenUpdateEventsBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -368,6 +372,8 @@ class TestScheduleShareTokenUpdateEventsBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -420,6 +426,8 @@ class TestScheduleShareTokenUpdateEventsBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -463,6 +471,8 @@ class TestScheduleShareTokenUpdateEventsBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -530,6 +540,8 @@ class TestScheduleShareTokenUpdateEventsBatch:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/app/test_share_tokens_IssueShareToken.py
+++ b/tests/app/test_share_tokens_IssueShareToken.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -73,6 +75,8 @@ class TestIssueShareToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = test_account["address"]
         account.keyfile = test_account["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -226,6 +230,8 @@ class TestIssueShareToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = test_account["address"]
         account.keyfile = test_account["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -363,6 +369,8 @@ class TestIssueShareToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = test_account["address"]
         account.keyfile = test_account["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -502,6 +510,8 @@ class TestIssueShareToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = test_account["address"]
         account.keyfile = test_account["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -660,6 +670,8 @@ class TestIssueShareToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = test_account["address"]
         account.keyfile = test_account["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -743,6 +755,8 @@ class TestIssueShareToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = test_account["address"]
         account.keyfile = test_account["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -830,6 +844,8 @@ class TestIssueShareToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = test_account["address"]
         account.keyfile = test_account["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -999,6 +1015,8 @@ class TestIssueShareToken:
         test_account = default_eth_account("user1")
 
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = test_account["address"]
         account.keyfile = test_account["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1208,6 +1226,8 @@ class TestIssueShareToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = test_account_1["address"]
         account.keyfile = test_account_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1563,6 +1583,8 @@ class TestIssueShareToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = test_account_1["address"]
         account.keyfile = test_account_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1606,6 +1628,8 @@ class TestIssueShareToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = test_account_1["address"]
         account.keyfile = test_account_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1651,6 +1675,8 @@ class TestIssueShareToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = test_account_1["address"]
         account.keyfile = test_account_2["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1703,6 +1729,8 @@ class TestIssueShareToken:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = test_account_1["address"]
         account.keyfile = test_account_2["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/app/test_share_tokens_ListShareOperationLogHistory.py
+++ b/tests/app/test_share_tokens_ListShareOperationLogHistory.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -231,6 +233,8 @@ class TestAppRoutersShareTokensTokenAddressHistoryGET:
 
         # prepare data: Token
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -292,6 +296,8 @@ class TestAppRoutersShareTokensTokenAddressHistoryGET:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -403,6 +409,8 @@ class TestAppRoutersShareTokensTokenAddressHistoryGET:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -512,6 +520,8 @@ class TestAppRoutersShareTokensTokenAddressHistoryGET:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -605,6 +615,8 @@ class TestAppRoutersShareTokensTokenAddressHistoryGET:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -719,6 +731,8 @@ class TestAppRoutersShareTokensTokenAddressHistoryGET:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -826,6 +840,8 @@ class TestAppRoutersShareTokensTokenAddressHistoryGET:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -941,6 +957,8 @@ class TestAppRoutersShareTokensTokenAddressHistoryGET:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1057,6 +1075,8 @@ class TestAppRoutersShareTokensTokenAddressHistoryGET:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1153,6 +1173,8 @@ class TestAppRoutersShareTokensTokenAddressHistoryGET:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/app/test_share_tokens_UpdateShareToken.py
+++ b/tests/app/test_share_tokens_UpdateShareToken.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -114,6 +116,8 @@ class TestAppRoutersShareTokensTokenAddressPOST:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -267,6 +271,8 @@ class TestAppRoutersShareTokensTokenAddressPOST:
         _token_address = token_contract.address
 
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -345,6 +351,8 @@ class TestAppRoutersShareTokensTokenAddressPOST:
         _token_address = token_contract.address
 
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -423,6 +431,8 @@ class TestAppRoutersShareTokensTokenAddressPOST:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -489,6 +499,8 @@ class TestAppRoutersShareTokensTokenAddressPOST:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -625,6 +637,8 @@ class TestAppRoutersShareTokensTokenAddressPOST:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -731,6 +745,8 @@ class TestAppRoutersShareTokensTokenAddressPOST:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1315,6 +1331,8 @@ class TestAppRoutersShareTokensTokenAddressPOST:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1360,6 +1378,8 @@ class TestAppRoutersShareTokensTokenAddressPOST:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1399,6 +1419,8 @@ class TestAppRoutersShareTokensTokenAddressPOST:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1449,6 +1471,8 @@ class TestAppRoutersShareTokensTokenAddressPOST:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1494,6 +1518,8 @@ class TestAppRoutersShareTokensTokenAddressPOST:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1542,6 +1568,8 @@ class TestAppRoutersShareTokensTokenAddressPOST:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1632,6 +1660,8 @@ class TestAppRoutersShareTokensTokenAddressPOST:
         _token_address = token_contract.address
 
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/app/test_share_transfer_approvals_UpdateShareTokenTransferApprovalStatus.py
+++ b/tests/app/test_share_transfer_approvals_UpdateShareTokenTransferApprovalStatus.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -85,6 +87,8 @@ class TestUpdateShareTokenTransferApprovalStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -222,6 +226,8 @@ class TestUpdateShareTokenTransferApprovalStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -360,6 +366,8 @@ class TestUpdateShareTokenTransferApprovalStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -496,6 +504,8 @@ class TestUpdateShareTokenTransferApprovalStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -771,6 +781,8 @@ class TestUpdateShareTokenTransferApprovalStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -807,6 +819,8 @@ class TestUpdateShareTokenTransferApprovalStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -843,6 +857,8 @@ class TestUpdateShareTokenTransferApprovalStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -888,6 +904,8 @@ class TestUpdateShareTokenTransferApprovalStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -934,6 +952,8 @@ class TestUpdateShareTokenTransferApprovalStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1000,6 +1020,8 @@ class TestUpdateShareTokenTransferApprovalStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1066,6 +1088,8 @@ class TestUpdateShareTokenTransferApprovalStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1130,6 +1154,8 @@ class TestUpdateShareTokenTransferApprovalStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1194,6 +1220,8 @@ class TestUpdateShareTokenTransferApprovalStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1271,6 +1299,8 @@ class TestUpdateShareTokenTransferApprovalStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1367,6 +1397,8 @@ class TestUpdateShareTokenTransferApprovalStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1481,6 +1513,8 @@ class TestUpdateShareTokenTransferApprovalStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1578,6 +1612,8 @@ class TestUpdateShareTokenTransferApprovalStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1686,6 +1722,8 @@ class TestUpdateShareTokenTransferApprovalStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1782,6 +1820,8 @@ class TestUpdateShareTokenTransferApprovalStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1883,6 +1923,8 @@ class TestUpdateShareTokenTransferApprovalStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1952,6 +1994,8 @@ class TestUpdateShareTokenTransferApprovalStatus:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/app/test_share_transfers_TransferShareTokenOwnership.py
+++ b/tests/app/test_share_transfers_TransferShareTokenOwnership.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -71,6 +73,8 @@ class TestTransferShareTokenOwnership:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _admin_address
         account.keyfile = _admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -145,6 +149,8 @@ class TestTransferShareTokenOwnership:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _admin_address
         account.keyfile = _admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -469,6 +475,8 @@ class TestTransferShareTokenOwnership:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _admin_address
         account.keyfile = _admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -517,6 +525,8 @@ class TestTransferShareTokenOwnership:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _admin_address
         account.keyfile = _admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -565,6 +575,8 @@ class TestTransferShareTokenOwnership:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _admin_address
         account.keyfile = _admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -627,6 +639,8 @@ class TestTransferShareTokenOwnership:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _admin_address
         account.keyfile = _admin_keyfile
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/app/test_token_common_AddIbetWSTWhitelist.py
+++ b/tests/app/test_token_common_AddIbetWSTWhitelist.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -67,6 +69,8 @@ class TestAddIbetWSTWhitelist:
     async def test_normal_1(self, async_db: AsyncSession, async_client: AsyncClient):
         # Prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -134,6 +138,8 @@ class TestAddIbetWSTWhitelist:
     async def test_normal_2(self, async_db: AsyncSession, async_client: AsyncClient):
         # Prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -284,6 +290,8 @@ class TestAddIbetWSTWhitelist:
     async def test_error_3(self, async_db: AsyncSession, async_client: AsyncClient):
         # Prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -328,6 +336,8 @@ class TestAddIbetWSTWhitelist:
     async def test_error_4(self, async_db: AsyncSession, async_client: AsyncClient):
         # Prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/app/test_token_common_DeleteIbetWSTWhitelist.py
+++ b/tests/app/test_token_common_DeleteIbetWSTWhitelist.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -66,6 +68,8 @@ class TestAddIbetWSTWhitelist:
     async def test_normal_1(self, async_db: AsyncSession, async_client: AsyncClient):
         # Prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -127,6 +131,8 @@ class TestAddIbetWSTWhitelist:
     async def test_normal_2(self, async_db: AsyncSession, async_client: AsyncClient):
         # Prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -251,6 +257,8 @@ class TestAddIbetWSTWhitelist:
     async def test_error_3(self, async_db: AsyncSession, async_client: AsyncClient):
         # Prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -291,6 +299,8 @@ class TestAddIbetWSTWhitelist:
     async def test_error_4(self, async_db: AsyncSession, async_client: AsyncClient):
         # Prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/app/test_token_common_ForceBurnIbetWSTPosition.py
+++ b/tests/app/test_token_common_ForceBurnIbetWSTPosition.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -66,6 +68,8 @@ class TestAddIbetWSTWhitelist:
     async def test_normal_1(self, async_db: AsyncSession, async_client: AsyncClient):
         # Prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -131,6 +135,8 @@ class TestAddIbetWSTWhitelist:
     async def test_normal_2(self, async_db: AsyncSession, async_client: AsyncClient):
         # Prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -274,6 +280,8 @@ class TestAddIbetWSTWhitelist:
     async def test_error_3(self, async_db: AsyncSession, async_client: AsyncClient):
         # Prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -317,6 +325,8 @@ class TestAddIbetWSTWhitelist:
     async def test_error_4(self, async_db: AsyncSession, async_client: AsyncClient):
         # Prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/app/utils/test_check_utils.py
+++ b/tests/app/utils/test_check_utils.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -49,6 +51,8 @@ class TestCheckAuth:
 
         # prepare data
         _account = Account()
+        _account.rsa_status = AccountRsaStatus.UNSET.value
+        _account.is_deleted = False
         _account.issuer_address = test_account["address"]
         _account.keyfile = test_account["keyfile_json"]
         _account.eoa_password = E2EEUtils.encrypt(self.eoa_password)
@@ -75,6 +79,8 @@ class TestCheckAuth:
 
         # prepare data
         _account = Account()
+        _account.rsa_status = AccountRsaStatus.UNSET.value
+        _account.is_deleted = False
         _account.issuer_address = test_account["address"]
         _account.keyfile = test_account["keyfile_json"]
         _account.eoa_password = E2EEUtils.encrypt(self.eoa_password)
@@ -101,6 +107,8 @@ class TestCheckAuth:
 
         # prepare data
         _account = Account()
+        _account.rsa_status = AccountRsaStatus.UNSET.value
+        _account.is_deleted = False
         _account.issuer_address = test_account["address"]
         _account.keyfile = test_account["keyfile_json"]
         _account.eoa_password = E2EEUtils.encrypt(self.eoa_password)
@@ -136,6 +144,8 @@ class TestCheckAuth:
 
         # prepare data
         _account = Account()
+        _account.rsa_status = AccountRsaStatus.UNSET.value
+        _account.is_deleted = False
         _account.issuer_address = test_account["address"]
         _account.keyfile = test_account["keyfile_json"]
         _account.eoa_password = E2EEUtils.encrypt(self.eoa_password)
@@ -193,6 +203,8 @@ class TestCheckAuth:
 
         # prepare data
         _account = Account()
+        _account.rsa_status = AccountRsaStatus.UNSET.value
+        _account.is_deleted = False
         _account.issuer_address = test_account["address"]
         _account.keyfile = test_account["keyfile_json"]
         _account.eoa_password = E2EEUtils.encrypt(self.eoa_password)
@@ -218,6 +230,8 @@ class TestCheckAuth:
 
         # prepare data
         _account = Account()
+        _account.rsa_status = AccountRsaStatus.UNSET.value
+        _account.is_deleted = False
         _account.issuer_address = test_account["address"]
         _account.keyfile = test_account["keyfile_json"]
         _account.eoa_password = E2EEUtils.encrypt(self.eoa_password)
@@ -247,6 +261,8 @@ class TestCheckAuth:
 
         # prepare data
         _account = Account()
+        _account.rsa_status = AccountRsaStatus.UNSET.value
+        _account.is_deleted = False
         _account.issuer_address = test_account["address"]
         _account.keyfile = test_account["keyfile_json"]
         _account.eoa_password = E2EEUtils.encrypt(self.eoa_password)
@@ -273,6 +289,8 @@ class TestCheckAuth:
 
         # prepare data
         _account = Account()
+        _account.rsa_status = AccountRsaStatus.UNSET.value
+        _account.is_deleted = False
         _account.issuer_address = test_account["address"]
         _account.keyfile = test_account["keyfile_json"]
         _account.eoa_password = E2EEUtils.encrypt(self.eoa_password)
@@ -299,6 +317,8 @@ class TestCheckAuth:
 
         # prepare data
         _account = Account()
+        _account.rsa_status = AccountRsaStatus.UNSET.value
+        _account.is_deleted = False
         _account.issuer_address = test_account["address"]
         _account.keyfile = test_account["keyfile_json"]
         _account.eoa_password = E2EEUtils.encrypt(self.eoa_password)
@@ -333,6 +353,8 @@ class TestCheckAuth:
 
         # prepare data
         _account = Account()
+        _account.rsa_status = AccountRsaStatus.UNSET.value
+        _account.is_deleted = False
         _account.issuer_address = test_account["address"]
         _account.keyfile = test_account["keyfile_json"]
         _account.eoa_password = E2EEUtils.encrypt(self.eoa_password)

--- a/tests/batch/test_indexer_dvp_delivery.py
+++ b/tests/batch/test_indexer_dvp_delivery.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -216,6 +218,9 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.rsa_private_key = user_1["rsa_private_key"]
         account.rsa_public_key = user_1["rsa_public_key"]
@@ -268,6 +273,9 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.rsa_private_key = user_1["rsa_private_key"]
         account.rsa_public_key = user_1["rsa_public_key"]
@@ -338,6 +346,9 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.rsa_private_key = user_1["rsa_private_key"]
         account.rsa_public_key = user_1["rsa_public_key"]
@@ -436,6 +447,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -599,6 +612,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -766,6 +781,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -940,6 +957,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1130,6 +1149,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1309,6 +1330,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1487,6 +1510,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1693,12 +1718,16 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
         async_db.add(account)
 
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = user_address_1
         account.keyfile = user_2["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1924,6 +1953,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -2116,6 +2147,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -2323,6 +2356,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -2390,6 +2425,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -2473,6 +2510,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/batch/test_indexer_issue_redeem.py
+++ b/tests/batch/test_indexer_issue_redeem.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -277,6 +279,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -359,6 +363,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -441,6 +447,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -523,6 +531,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -604,6 +614,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -730,6 +742,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -810,6 +824,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/batch/test_indexer_personal_info.py
+++ b/tests/batch/test_indexer_personal_info.py
@@ -153,6 +153,9 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.rsa_private_key = user_1["rsa_private_key"]
         account.rsa_public_key = user_1["rsa_public_key"]
@@ -218,6 +221,9 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.rsa_private_key = issuer_rsa_private_key
         account.rsa_public_key = issuer_rsa_public_key
@@ -307,6 +313,9 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.rsa_private_key = issuer_rsa_private_key
         account.rsa_public_key = issuer_rsa_public_key
@@ -428,6 +437,9 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.rsa_private_key = issuer_rsa_private_key
         account.rsa_public_key = issuer_rsa_public_key
@@ -597,6 +609,9 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.rsa_private_key = issuer_rsa_private_key
         account.rsa_public_key = issuer_rsa_public_key
@@ -821,6 +836,9 @@ class TestProcessor:
 
         # Prepare data : Account(Issuer1)
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.is_deleted = False
         account.issuer_address = issuer_address_1
         account.rsa_private_key = issuer_rsa_private_key_1
         account.rsa_public_key = issuer_rsa_public_key_1
@@ -830,6 +848,9 @@ class TestProcessor:
 
         # Prepare data : Account(Issuer2)
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.is_deleted = False
         account.issuer_address = issuer_address_2
         account.rsa_private_key = issuer_rsa_private_key_2
         account.rsa_public_key = issuer_rsa_public_key_2
@@ -1046,6 +1067,9 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.rsa_private_key = issuer_rsa_private_key
         account.rsa_public_key = issuer_rsa_public_key
@@ -1177,6 +1201,9 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.rsa_private_key = issuer_rsa_private_key
         account.rsa_public_key = issuer_rsa_public_key

--- a/tests/batch/test_indexer_position_bond.py
+++ b/tests/batch/test_indexer_position_bond.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -247,6 +249,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -346,6 +350,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -468,6 +474,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -589,6 +597,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -700,6 +710,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -873,6 +885,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1100,6 +1114,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1257,6 +1273,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1479,6 +1497,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1705,6 +1725,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1814,6 +1836,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1933,6 +1957,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -2085,6 +2111,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -2245,6 +2273,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -2420,6 +2450,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -2593,6 +2625,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -2769,6 +2803,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -2945,6 +2981,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -3130,6 +3168,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -3305,6 +3345,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -3479,6 +3521,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -3652,6 +3696,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -3818,6 +3864,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -3991,6 +4039,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -4166,6 +4216,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -4346,6 +4398,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -4519,6 +4573,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -4769,6 +4825,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -4950,6 +5008,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -5175,6 +5235,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -5359,6 +5421,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -5527,6 +5591,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -5789,6 +5855,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -5888,6 +5956,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -5949,6 +6019,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/batch/test_indexer_position_share.py
+++ b/tests/batch/test_indexer_position_share.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -218,6 +220,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -280,6 +284,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -378,6 +384,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -499,6 +507,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -620,6 +630,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -731,6 +743,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -901,6 +915,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1128,6 +1144,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1285,6 +1303,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1507,6 +1527,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1733,6 +1755,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1843,6 +1867,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1962,6 +1988,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -2114,6 +2142,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -2277,6 +2307,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -2452,6 +2484,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -2625,6 +2659,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -2801,6 +2837,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -2977,6 +3015,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -3162,6 +3202,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -3338,6 +3380,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -3509,6 +3553,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -3683,6 +3729,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -3850,6 +3898,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -4024,6 +4074,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -4200,6 +4252,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -4381,6 +4435,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -4555,6 +4611,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -4805,6 +4863,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -4987,6 +5047,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -5212,6 +5274,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -5400,6 +5464,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -5572,6 +5638,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -5842,6 +5910,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -5941,6 +6011,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -6004,6 +6076,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/batch/test_indexer_token_cache.py
+++ b/tests/batch/test_indexer_token_cache.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -218,6 +220,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -372,6 +376,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/batch/test_indexer_transfer.py
+++ b/tests/batch/test_indexer_transfer.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -317,6 +319,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -614,6 +618,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -744,6 +750,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -940,6 +948,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1336,6 +1346,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1485,6 +1497,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1669,6 +1683,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1751,6 +1767,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/batch/test_indexer_transfer_approval.py
+++ b/tests/batch/test_indexer_transfer_approval.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -316,6 +318,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -457,6 +461,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -601,6 +607,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -744,6 +752,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -893,6 +903,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1047,6 +1059,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1222,6 +1236,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1383,6 +1399,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1574,6 +1592,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1658,6 +1678,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/batch/test_indexer_wst_ava_trades.py
+++ b/tests/batch/test_indexer_wst_ava_trades.py
@@ -1,3 +1,7 @@
+from app.model.db import AccountRsaStatus
+from app.utils.e2ee_utils import E2EEUtils
+from tests.account_config import default_eth_account
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -104,6 +108,9 @@ class TestProcessor:
         async_db.add(token)
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
         account.issuer_address = self.issuer_address_1
         account.is_deleted = False
         async_db.add(account)
@@ -154,6 +161,9 @@ class TestProcessor:
         async_db.add(token)
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
         account.issuer_address = self.issuer_address_1
         account.is_deleted = True  # Account is deleted
         async_db.add(account)
@@ -230,6 +240,9 @@ class TestProcessor:
         async_db.add(token)
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
         account.issuer_address = self.issuer_address_1
         account.is_deleted = False
         async_db.add(account)
@@ -326,6 +339,9 @@ class TestProcessor:
         async_db.add(token)
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
         account.issuer_address = self.issuer_address_1
         account.is_deleted = False
         async_db.add(account)
@@ -421,6 +437,9 @@ class TestProcessor:
         async_db.add(token)
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
         account.issuer_address = self.issuer_address_1
         account.is_deleted = False
         async_db.add(account)
@@ -516,6 +535,9 @@ class TestProcessor:
         async_db.add(token)
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
         account.issuer_address = self.issuer_address_1
         account.is_deleted = False
         async_db.add(account)
@@ -611,6 +633,9 @@ class TestProcessor:
         async_db.add(token)
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
         account.issuer_address = self.issuer_address_1
         account.is_deleted = False
         async_db.add(account)

--- a/tests/batch/test_indexer_wst_eth_trades.py
+++ b/tests/batch/test_indexer_wst_eth_trades.py
@@ -1,3 +1,7 @@
+from app.model.db import AccountRsaStatus
+from app.utils.e2ee_utils import E2EEUtils
+from tests.account_config import default_eth_account
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -104,6 +108,9 @@ class TestProcessor:
         async_db.add(token)
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
         account.issuer_address = self.issuer_address_1
         account.is_deleted = False
         async_db.add(account)
@@ -154,6 +161,9 @@ class TestProcessor:
         async_db.add(token)
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
         account.issuer_address = self.issuer_address_1
         account.is_deleted = True  # Account is deleted
         async_db.add(account)
@@ -230,6 +240,9 @@ class TestProcessor:
         async_db.add(token)
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
         account.issuer_address = self.issuer_address_1
         account.is_deleted = False
         async_db.add(account)
@@ -326,6 +339,9 @@ class TestProcessor:
         async_db.add(token)
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
         account.issuer_address = self.issuer_address_1
         account.is_deleted = False
         async_db.add(account)
@@ -421,6 +437,9 @@ class TestProcessor:
         async_db.add(token)
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
         account.issuer_address = self.issuer_address_1
         account.is_deleted = False
         async_db.add(account)
@@ -516,6 +535,9 @@ class TestProcessor:
         async_db.add(token)
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
         account.issuer_address = self.issuer_address_1
         account.is_deleted = False
         async_db.add(account)
@@ -611,6 +633,9 @@ class TestProcessor:
         async_db.add(token)
 
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
         account.issuer_address = self.issuer_address_1
         account.is_deleted = False
         async_db.add(account)

--- a/tests/batch/test_processor_batch_create_child_account.py
+++ b/tests/batch/test_processor_batch_create_child_account.py
@@ -1,3 +1,7 @@
+from app.model.db import AccountRsaStatus
+from app.utils.e2ee_utils import E2EEUtils
+from tests.account_config import default_eth_account
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -101,6 +105,10 @@ class TestProcessor:
             async_db.add(_tmp_data)
 
         _account = Account()
+        _account.keyfile = default_eth_account("user1")["keyfile_json"]
+        _account.eoa_password = E2EEUtils.encrypt("password")
+        _account.rsa_status = AccountRsaStatus.UNSET.value
+        _account.is_deleted = False
         _account.issuer_address = self.issuer_address
         _account.issuer_public_key = self.issuer_pub_key
         async_db.add(_account)
@@ -259,6 +267,10 @@ class TestProcessor:
         async_db.add(_tmp_data)
 
         _account = Account()
+        _account.keyfile = default_eth_account("user1")["keyfile_json"]
+        _account.eoa_password = E2EEUtils.encrypt("password")
+        _account.rsa_status = AccountRsaStatus.UNSET.value
+        _account.is_deleted = False
         _account.issuer_address = self.issuer_address
         _account.issuer_public_key = None
         async_db.add(_account)

--- a/tests/batch/test_processor_batch_issue_redeem.py
+++ b/tests/batch/test_processor_batch_issue_redeem.py
@@ -93,6 +93,7 @@ class TestProcessor:
 
         # Prepare data
         _account = Account()
+        _account.is_deleted = False
         _account.issuer_address = issuer_address
         _account.keyfile = issuer_keyfile
         _account.eoa_password = issuer_eoa_password
@@ -228,6 +229,7 @@ class TestProcessor:
 
         # Prepare data
         _account = Account()
+        _account.is_deleted = False
         _account.issuer_address = issuer_address
         _account.keyfile = issuer_keyfile
         _account.eoa_password = issuer_eoa_password
@@ -363,6 +365,7 @@ class TestProcessor:
 
         # Prepare data
         _account = Account()
+        _account.is_deleted = False
         _account.issuer_address = issuer_address
         _account.keyfile = issuer_keyfile
         _account.eoa_password = issuer_eoa_password
@@ -498,6 +501,7 @@ class TestProcessor:
 
         # Prepare data
         _account = Account()
+        _account.is_deleted = False
         _account.issuer_address = issuer_address
         _account.keyfile = issuer_keyfile
         _account.eoa_password = issuer_eoa_password
@@ -734,6 +738,7 @@ class TestProcessor:
 
         # Prepare data
         _account = Account()
+        _account.is_deleted = False
         _account.issuer_address = issuer_address
         _account.keyfile = issuer_keyfile
         _account.eoa_password = issuer_eoa_password
@@ -845,6 +850,7 @@ class TestProcessor:
 
         # Prepare data
         _account = Account()
+        _account.is_deleted = False
         _account.issuer_address = issuer_address
         _account.keyfile = issuer_keyfile
         _account.eoa_password = issuer_eoa_password
@@ -963,6 +969,7 @@ class TestProcessor:
 
         # Prepare data
         _account = Account()
+        _account.is_deleted = False
         _account.issuer_address = issuer_address
         _account.keyfile = issuer_keyfile
         _account.eoa_password = issuer_eoa_password

--- a/tests/batch/test_processor_batch_issue_redeem_v2406.py
+++ b/tests/batch/test_processor_batch_issue_redeem_v2406.py
@@ -91,6 +91,7 @@ class TestProcessor:
 
         # Prepare data
         _account = Account()
+        _account.is_deleted = False
         _account.issuer_address = issuer_address
         _account.keyfile = issuer_keyfile
         _account.eoa_password = issuer_eoa_password
@@ -204,6 +205,7 @@ class TestProcessor:
 
         # Prepare data
         _account = Account()
+        _account.is_deleted = False
         _account.issuer_address = issuer_address
         _account.keyfile = issuer_keyfile
         _account.eoa_password = issuer_eoa_password
@@ -317,6 +319,7 @@ class TestProcessor:
 
         # Prepare data
         _account = Account()
+        _account.is_deleted = False
         _account.issuer_address = issuer_address
         _account.keyfile = issuer_keyfile
         _account.eoa_password = issuer_eoa_password
@@ -430,6 +433,7 @@ class TestProcessor:
 
         # Prepare data
         _account = Account()
+        _account.is_deleted = False
         _account.issuer_address = issuer_address
         _account.keyfile = issuer_keyfile
         _account.eoa_password = issuer_eoa_password
@@ -635,6 +639,7 @@ class TestProcessor:
 
         # Prepare data
         _account = Account()
+        _account.is_deleted = False
         _account.issuer_address = issuer_address
         _account.keyfile = issuer_keyfile
         _account.eoa_password = issuer_eoa_password
@@ -737,6 +742,7 @@ class TestProcessor:
 
         # Prepare data
         _account = Account()
+        _account.is_deleted = False
         _account.issuer_address = issuer_address
         _account.keyfile = issuer_keyfile
         _account.eoa_password = issuer_eoa_password
@@ -846,6 +852,7 @@ class TestProcessor:
 
         # Prepare data
         _account = Account()
+        _account.is_deleted = False
         _account.issuer_address = issuer_address
         _account.keyfile = issuer_keyfile
         _account.eoa_password = issuer_eoa_password

--- a/tests/batch/test_processor_bulk_transfer.py
+++ b/tests/batch/test_processor_bulk_transfer.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -96,6 +98,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _account["address"]
         account.eoa_password = E2EEUtils.encrypt("password")
         account.keyfile = _account["keyfile"]
@@ -176,6 +180,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _account["address"]
         account.eoa_password = E2EEUtils.encrypt("password")
         account.keyfile = _account["keyfile"]
@@ -256,6 +262,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _account["address"]
         account.eoa_password = E2EEUtils.encrypt("password")
         account.keyfile = _account["keyfile"]
@@ -359,6 +367,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _account["address"]
         account.eoa_password = E2EEUtils.encrypt("password")
         account.keyfile = _account["keyfile"]
@@ -463,6 +473,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _account["address"]
         account.eoa_password = E2EEUtils.encrypt("password")
         account.keyfile = _account["keyfile"]
@@ -608,6 +620,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _account["address"]
         account.eoa_password = E2EEUtils.encrypt("password")
         account.keyfile = _account["keyfile"]
@@ -795,6 +809,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _account["address"]
         account.eoa_password = E2EEUtils.encrypt("password_ng")
         account.keyfile = _account["keyfile"]
@@ -852,6 +868,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _account["address"]
         account.eoa_password = E2EEUtils.encrypt("password")
         account.keyfile = _account["keyfile"]
@@ -945,6 +963,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _account["address"]
         account.eoa_password = E2EEUtils.encrypt("password")
         account.keyfile = _account["keyfile"]
@@ -1043,6 +1063,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _account["address"]
         account.eoa_password = E2EEUtils.encrypt("password")
         account.keyfile = _account["keyfile"]
@@ -1119,6 +1141,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _account["address"]
         account.eoa_password = E2EEUtils.encrypt("password")
         account.keyfile = _account["keyfile"]
@@ -1194,6 +1218,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _account["address"]
         account.eoa_password = E2EEUtils.encrypt("password")
         account.keyfile = _account["keyfile"]

--- a/tests/batch/test_processor_create_utxo.py
+++ b/tests/batch/test_processor_create_utxo.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -196,6 +198,8 @@ class TestProcessor:
         async_db.add(_token_2)
 
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -346,6 +350,8 @@ class TestProcessor:
         async_db.add(_token_1)
 
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -420,6 +426,8 @@ class TestProcessor:
         async_db.add(_utxo_block_number)
 
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -537,6 +545,8 @@ class TestProcessor:
         async_db.add(_token_1)
 
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -636,6 +646,8 @@ class TestProcessor:
         async_db.add(_token_1)
 
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -846,6 +858,8 @@ class TestProcessor:
         )
 
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -936,6 +950,8 @@ class TestProcessor:
         async_db.add(_token_2)
 
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1027,6 +1043,8 @@ class TestProcessor:
         async_db.add(_token_2)
 
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1188,6 +1206,8 @@ class TestProcessor:
         async_db.add(_token_2)
 
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1381,6 +1401,8 @@ class TestProcessor:
         async_db.add(_token_2)
 
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1546,6 +1568,8 @@ class TestProcessor:
         async_db.add(_token_1)
 
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1713,6 +1737,8 @@ class TestProcessor:
         async_db.add(_token_2)
 
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1901,6 +1927,8 @@ class TestProcessor:
         async_db.add(_token_2)
 
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -2063,6 +2091,8 @@ class TestProcessor:
         async_db.add(token_1)
 
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer["address"]
         account.keyfile = issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -2216,6 +2246,8 @@ class TestProcessor:
         async_db.add(token_1)
 
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer["address"]
         account.keyfile = issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -2352,6 +2384,8 @@ class TestProcessor:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = issuer_address
         account.keyfile = user_1["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/batch/test_processor_dvp_async_tx.py
+++ b/tests/batch/test_processor_dvp_async_tx.py
@@ -111,6 +111,7 @@ class TestProcessor:
     ):
         # Prepare data
         _account = Account()
+        _account.is_deleted = False
         _account.issuer_address = self.issuer_address
         _account.keyfile = self.issuer_keyfile
         _account.eoa_password = self.issuer_eoa_password
@@ -179,6 +180,7 @@ class TestProcessor:
     ):
         # Prepare data
         _account = Account()
+        _account.is_deleted = False
         _account.issuer_address = self.issuer_address
         _account.keyfile = self.issuer_keyfile
         _account.eoa_password = self.issuer_eoa_password
@@ -272,6 +274,7 @@ class TestProcessor:
     ):
         # Prepare data
         _account = Account()
+        _account.is_deleted = False
         _account.issuer_address = self.issuer_address
         _account.keyfile = self.issuer_keyfile
         _account.eoa_password = self.issuer_eoa_password
@@ -407,6 +410,7 @@ class TestProcessor:
     ):
         # Prepare data
         _account = Account()
+        _account.is_deleted = False
         _account.issuer_address = self.issuer_address
         _account.keyfile = "invalid_keyfile"  # type: ignore
         _account.eoa_password = self.issuer_eoa_password
@@ -468,6 +472,7 @@ class TestProcessor:
     ):
         # Prepare data
         _account = Account()
+        _account.is_deleted = False
         _account.issuer_address = self.issuer_address
         _account.keyfile = self.issuer_keyfile
         _account.eoa_password = self.issuer_eoa_password
@@ -541,6 +546,7 @@ class TestProcessor:
     ):
         # Prepare data
         _account = Account()
+        _account.is_deleted = False
         _account.issuer_address = self.issuer_address
         _account.keyfile = self.issuer_keyfile
         _account.eoa_password = self.issuer_eoa_password
@@ -604,6 +610,7 @@ class TestProcessor:
     ):
         # Prepare data
         _account = Account()
+        _account.is_deleted = False
         _account.issuer_address = self.issuer_address
         _account.keyfile = self.issuer_keyfile
         _account.eoa_password = self.issuer_eoa_password
@@ -677,6 +684,7 @@ class TestProcessor:
     ):
         # Prepare data
         _account = Account()
+        _account.is_deleted = False
         _account.issuer_address = self.issuer_address
         _account.keyfile = self.issuer_keyfile
         _account.eoa_password = self.issuer_eoa_password
@@ -743,6 +751,7 @@ class TestProcessor:
     ):
         # Prepare data
         _account = Account()
+        _account.is_deleted = False
         _account.issuer_address = self.issuer_address
         _account.keyfile = self.issuer_keyfile
         _account.eoa_password = self.issuer_eoa_password
@@ -837,6 +846,7 @@ class TestProcessor:
     ):
         # Prepare data
         _account = Account()
+        _account.is_deleted = False
         _account.issuer_address = self.issuer_address
         _account.keyfile = self.issuer_keyfile
         _account.eoa_password = self.issuer_eoa_password
@@ -973,6 +983,7 @@ class TestProcessor:
     ):
         # Prepare data
         _account = Account()
+        _account.is_deleted = False
         _account.issuer_address = self.issuer_address
         _account.keyfile = self.issuer_keyfile
         _account.eoa_password = self.issuer_eoa_password
@@ -1045,6 +1056,7 @@ class TestProcessor:
     ):
         # Prepare data
         _account = Account()
+        _account.is_deleted = False
         _account.issuer_address = self.issuer_address
         _account.keyfile = self.issuer_keyfile
         _account.eoa_password = self.issuer_eoa_password
@@ -1115,6 +1127,7 @@ class TestProcessor:
     ):
         # Prepare data
         _account = Account()
+        _account.is_deleted = False
         _account.issuer_address = self.issuer_address
         _account.keyfile = self.issuer_keyfile
         _account.eoa_password = self.issuer_eoa_password
@@ -1185,6 +1198,7 @@ class TestProcessor:
     ):
         # Prepare data
         _account = Account()
+        _account.is_deleted = False
         _account.issuer_address = self.issuer_address
         _account.keyfile = self.issuer_keyfile
         _account.eoa_password = self.issuer_eoa_password
@@ -1255,6 +1269,7 @@ class TestProcessor:
     ):
         # Prepare data
         _account = Account()
+        _account.is_deleted = False
         _account.issuer_address = self.issuer_address
         _account.keyfile = self.issuer_keyfile
         _account.eoa_password = self.issuer_eoa_password
@@ -1398,6 +1413,7 @@ class TestProcessor:
     ):
         # Prepare data
         _account = Account()
+        _account.is_deleted = False
         _account.issuer_address = self.issuer_address
         _account.keyfile = self.issuer_keyfile
         _account.eoa_password = self.issuer_eoa_password

--- a/tests/batch/test_processor_generate_rsa_key.py
+++ b/tests/batch/test_processor_generate_rsa_key.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -24,7 +26,7 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.model.db import Account, AccountRsaKeyTemporary, AccountRsaStatus
+from app.model.db import Account, AccountRsaKeyTemporary
 from app.utils.e2ee_utils import E2EEUtils
 from batch.processor_generate_rsa_key import Processor
 from tests.account_config import default_eth_account
@@ -73,6 +75,7 @@ class TestProcessor:
         # prepare data
         # data:CREATING
         account_1 = Account()
+        account_1.is_deleted = False
         account_1.issuer_address = issuer_address_1
         account_1.keyfile = keyfile_1
         account_1.eoa_password = eoa_password_1
@@ -82,6 +85,7 @@ class TestProcessor:
 
         # data:CHANGING
         account_2 = Account()
+        account_2.is_deleted = False
         account_2.issuer_address = issuer_address_2
         account_2.keyfile = keyfile_2
         account_2.eoa_password = eoa_password_2
@@ -100,6 +104,7 @@ class TestProcessor:
 
         # data:UNSET(Non-Target)
         account_3 = Account()
+        account_3.is_deleted = False
         account_3.issuer_address = issuer_address_3
         account_3.keyfile = keyfile_3
         account_3.eoa_password = eoa_password_3
@@ -108,6 +113,7 @@ class TestProcessor:
 
         # data:SET(Non-Target)
         account_4 = Account()
+        account_4.is_deleted = False
         account_4.issuer_address = issuer_address_4
         account_4.keyfile = keyfile_4
         account_4.eoa_password = eoa_password_4

--- a/tests/batch/test_processor_modify_personal_info.py
+++ b/tests/batch/test_processor_modify_personal_info.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -32,7 +34,6 @@ from web3.middleware import ExtraDataToPOAMiddleware
 from app.model.db import (
     Account,
     AccountRsaKeyTemporary,
-    AccountRsaStatus,
     IDXPersonalInfo,
     PersonalInfoDataSource,
     Token,
@@ -219,6 +220,7 @@ class TestProcessor:
         # prepare data
         # account
         account = Account()
+        account.is_deleted = False
         account.issuer_address = user_1["address"]
         account.keyfile = user_1["keyfile_json"]
         eoa_password = E2EEUtils.encrypt("password")

--- a/tests/batch/test_processor_register_personal_info.py
+++ b/tests/batch/test_processor_register_personal_info.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -159,6 +161,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _account["address"]
         account.eoa_password = E2EEUtils.encrypt("password")
         account.keyfile = _account["keyfile"]
@@ -209,6 +213,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _account["address"]
         account.eoa_password = E2EEUtils.encrypt("password")
         account.keyfile = _account["keyfile"]
@@ -320,6 +326,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _account["address"]
         account.eoa_password = E2EEUtils.encrypt("password")
         account.keyfile = _account["keyfile"]
@@ -484,6 +492,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _account["address"]
         account.eoa_password = E2EEUtils.encrypt("password")
         account.keyfile = _account["keyfile"]
@@ -745,6 +755,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _account["address"]
         account.eoa_password = E2EEUtils.encrypt("password_ng")
         account.keyfile = _account["keyfile"]
@@ -879,6 +891,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _account["address"]
         account.eoa_password = E2EEUtils.encrypt("password_ng")
         account.keyfile = _account["keyfile"]
@@ -1013,6 +1027,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _account["address"]
         account.eoa_password = E2EEUtils.encrypt("password_ng")
         account.keyfile = _account["keyfile"]

--- a/tests/batch/test_processor_scheduled_events.py
+++ b/tests/batch/test_processor_scheduled_events.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -74,6 +76,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.eoa_password = E2EEUtils.encrypt("password")
         account.keyfile = _keyfile
@@ -226,6 +230,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.eoa_password = E2EEUtils.encrypt("password")
         account.keyfile = _keyfile
@@ -379,6 +385,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.eoa_password = E2EEUtils.encrypt("password")
         account.keyfile = _keyfile
@@ -516,8 +524,13 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.keyfile = default_eth_account("user1")["keyfile_json"]
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
-        account.eoa_password = E2EEUtils.encrypt("password")
+        account.eoa_password = E2EEUtils.encrypt(
+            "incorrect_password"
+        )  # incorrect password to cause decryption failure
         async_db.add(account)
 
         # prepare data : ScheduledEvents
@@ -579,6 +592,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.eoa_password = E2EEUtils.encrypt("password")
         account.keyfile = _keyfile
@@ -654,6 +669,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.eoa_password = E2EEUtils.encrypt("password")
         account.keyfile = _keyfile
@@ -735,6 +752,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.eoa_password = E2EEUtils.encrypt("password")
         account.keyfile = _keyfile
@@ -826,6 +845,8 @@ class TestProcessor:
 
         # Prepare data : Account
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.eoa_password = E2EEUtils.encrypt("password")
         account.keyfile = _keyfile

--- a/tests/batch/test_processor_update_token.py
+++ b/tests/batch/test_processor_update_token.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -77,6 +79,8 @@ class TestProcessor:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -370,6 +374,8 @@ class TestProcessor:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = "test"  # not target
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -596,6 +602,8 @@ class TestProcessor:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password_ng")  # invalid
@@ -822,6 +830,8 @@ class TestProcessor:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -1062,6 +1072,8 @@ class TestProcessor:
 
         # prepare data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = _issuer_address
         account.keyfile = _keyfile
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/batch/test_processor_wst_ava_bridge_to_ibet.py
+++ b/tests/batch/test_processor_wst_ava_bridge_to_ibet.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -98,6 +100,8 @@ class TestProcessor:
         caplog: pytest.LogCaptureFixture,
     ):
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -159,6 +163,8 @@ class TestProcessor:
         caplog: pytest.LogCaptureFixture,
     ):
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -289,6 +295,8 @@ class TestProcessor:
         caplog: pytest.LogCaptureFixture,
     ):
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -339,6 +347,8 @@ class TestProcessor:
         caplog: pytest.LogCaptureFixture,
     ):
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -391,6 +401,8 @@ class TestProcessor:
         caplog: pytest.LogCaptureFixture,
     ):
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/batch/test_processor_wst_ava_monitor_bridge_events.py
+++ b/tests/batch/test_processor_wst_ava_monitor_bridge_events.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -180,6 +182,7 @@ class TestProcessor:
 
         # Prepare test data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -335,6 +338,8 @@ class TestProcessor:
 
         # Prepare test data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -457,6 +462,8 @@ class TestProcessor:
 
         # Prepare test data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -579,6 +586,8 @@ class TestProcessor:
 
         # Prepare test data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -681,6 +690,8 @@ class TestProcessor:
 
         # Prepare test data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -796,6 +807,8 @@ class TestProcessor:
 
         # Prepare test data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/batch/test_processor_wst_ava_send_tx.py
+++ b/tests/batch/test_processor_wst_ava_send_tx.py
@@ -1,3 +1,6 @@
+from app.model.db import AccountRsaStatus
+from app.utils.e2ee_utils import E2EEUtils
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -130,6 +133,9 @@ class TestProcessor:
 
         # Prepare test data
         account = Account()
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         async_db.add(account)
@@ -192,6 +198,9 @@ class TestProcessor:
 
         # Prepare test data
         account = Account()
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         async_db.add(account)
@@ -265,6 +274,9 @@ class TestProcessor:
 
         # Prepare test data
         account = Account()
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         async_db.add(account)
@@ -336,6 +348,9 @@ class TestProcessor:
 
         # Prepare test data
         account = Account()
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         async_db.add(account)
@@ -414,6 +429,9 @@ class TestProcessor:
 
         # Prepare test data
         account = Account()
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         async_db.add(account)
@@ -485,6 +503,9 @@ class TestProcessor:
 
         # Prepare test data
         account = Account()
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         async_db.add(account)
@@ -554,6 +575,9 @@ class TestProcessor:
 
         # Prepare test data
         account = Account()
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         async_db.add(account)
@@ -623,6 +647,9 @@ class TestProcessor:
 
         # Prepare test data
         account = Account()
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         async_db.add(account)
@@ -695,6 +722,9 @@ class TestProcessor:
 
         # Prepare test data
         account = Account()
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         async_db.add(account)
@@ -767,6 +797,9 @@ class TestProcessor:
 
         # Prepare test data
         account = Account()
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         async_db.add(account)
@@ -842,6 +875,9 @@ class TestProcessor:
 
         # Prepare test data
         account = Account()
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         async_db.add(account)
@@ -905,6 +941,9 @@ class TestProcessor:
 
         # Prepare test data
         account = Account()
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         async_db.add(account)
@@ -964,6 +1003,9 @@ class TestProcessor:
 
         # Prepare test data
         account = Account()
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         async_db.add(account)

--- a/tests/batch/test_processor_wst_eth_bridge_to_ibet.py
+++ b/tests/batch/test_processor_wst_eth_bridge_to_ibet.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -109,6 +111,8 @@ class TestProcessor:
     ):
         # Prepare test data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -178,6 +182,8 @@ class TestProcessor:
     ):
         # Prepare test data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -284,6 +290,8 @@ class TestProcessor:
     ):
         # Prepare test data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -347,6 +355,8 @@ class TestProcessor:
     ):
         # Prepare test data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -410,6 +420,8 @@ class TestProcessor:
     ):
         # Prepare test data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/batch/test_processor_wst_eth_monitor_bridge_events.py
+++ b/tests/batch/test_processor_wst_eth_monitor_bridge_events.py
@@ -1,3 +1,5 @@
+from app.model.db import AccountRsaStatus
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -180,6 +182,7 @@ class TestProcessor:
 
         # Prepare test data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -335,6 +338,8 @@ class TestProcessor:
 
         # Prepare test data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -457,6 +462,8 @@ class TestProcessor:
 
         # Prepare test data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -579,6 +586,8 @@ class TestProcessor:
 
         # Prepare test data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -681,6 +690,8 @@ class TestProcessor:
 
         # Prepare test data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")
@@ -796,6 +807,8 @@ class TestProcessor:
 
         # Prepare test data
         account = Account()
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         account.eoa_password = E2EEUtils.encrypt("password")

--- a/tests/batch/test_processor_wst_eth_send_tx.py
+++ b/tests/batch/test_processor_wst_eth_send_tx.py
@@ -1,3 +1,6 @@
+from app.model.db import AccountRsaStatus
+from app.utils.e2ee_utils import E2EEUtils
+
 """
 Copyright BOOSTRY Co., Ltd.
 
@@ -131,6 +134,9 @@ class TestProcessor:
 
         # Prepare test data
         account = Account()
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         async_db.add(account)
@@ -194,6 +200,9 @@ class TestProcessor:
 
         # Prepare test data
         account = Account()
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         async_db.add(account)
@@ -268,6 +277,9 @@ class TestProcessor:
 
         # Prepare test data
         account = Account()
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         async_db.add(account)
@@ -340,6 +352,9 @@ class TestProcessor:
 
         # Prepare test data
         account = Account()
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         async_db.add(account)
@@ -419,6 +434,9 @@ class TestProcessor:
 
         # Prepare test data
         account = Account()
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         async_db.add(account)
@@ -491,6 +509,9 @@ class TestProcessor:
 
         # Prepare test data
         account = Account()
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         async_db.add(account)
@@ -561,6 +582,9 @@ class TestProcessor:
 
         # Prepare test data
         account = Account()
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         async_db.add(account)
@@ -631,6 +655,9 @@ class TestProcessor:
 
         # Prepare test data
         account = Account()
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         async_db.add(account)
@@ -704,6 +731,9 @@ class TestProcessor:
 
         # Prepare test data
         account = Account()
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         async_db.add(account)
@@ -777,6 +807,9 @@ class TestProcessor:
 
         # Prepare test data
         account = Account()
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         async_db.add(account)
@@ -853,6 +886,9 @@ class TestProcessor:
 
         # Prepare test data
         account = Account()
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         async_db.add(account)
@@ -917,6 +953,9 @@ class TestProcessor:
 
         # Prepare test data
         account = Account()
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         async_db.add(account)
@@ -977,6 +1016,9 @@ class TestProcessor:
 
         # Prepare test data
         account = Account()
+        account.eoa_password = E2EEUtils.encrypt("password")
+        account.rsa_status = AccountRsaStatus.UNSET.value
+        account.is_deleted = False
         account.issuer_address = self.issuer["address"]
         account.keyfile = self.issuer["keyfile_json"]
         async_db.add(account)


### PR DESCRIPTION
Enforce non-null constraints for account-related fields and update code accordingly.

## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- Related to #1001

## 🔄 Changes

<!-- List the major changes in this PR. -->

- Update Account and FreezeLogAccount models to mark keyfile, eoa_password, rsa_status and is_deleted as non-nullable (with defaults where appropriate).
- Remove redundant runtime None checks and assertions across ibet models, routers and batch processors.
- Other minor improvements were also implemented.

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
