### PR TITLE
Make batch_issue_redeem.upload_id non-nullable

### DIFF
--- a/app/model/db/batch_issue_redeem.py
+++ b/app/model/db/batch_issue_redeem.py
@@ -59,7 +59,7 @@ class BatchIssueRedeem(Base):
     # sequence id
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     # upload id (UUID)
-    upload_id: Mapped[str | None] = mapped_column(String(36), index=True)
+    upload_id: Mapped[str] = mapped_column(String(36), index=True, nullable=False)
     # target account
     account_address: Mapped[str] = mapped_column(String(42), nullable=False)
     # amount

--- a/app/routers/issuer/bond.py
+++ b/app/routers/issuer/bond.py
@@ -21,7 +21,7 @@ import json
 import uuid
 from collections import defaultdict
 from datetime import UTC, datetime
-from typing import Annotated, Any, List, Optional, Sequence, cast as typing_cast
+from typing import Annotated, Any, List, Optional, Sequence
 
 import pytz
 from eth_keyfile.keyfile import decode_keyfile_json
@@ -1686,8 +1686,7 @@ async def list_all_batch_bond_redemption(
         str, list[tuple[BatchIssueRedeem, IDXPersonalInfo | None]]
     ] = defaultdict(list)
     for record in record_list:
-        if record[0].upload_id is not None:
-            record_list_by_upload_id[record[0].upload_id].append(record)
+        record_list_by_upload_id[record[0].upload_id].append(record)
 
     personal_info_default = {
         "key_manager": None,
@@ -2173,8 +2172,9 @@ async def schedule_bond_token_update_events_in_batch(
                 )
 
         # Register an event
+        _event_id = str(uuid.uuid4())
         _scheduled_event = ScheduledEvents()
-        _scheduled_event.event_id = str(uuid.uuid4())
+        _scheduled_event.event_id = _event_id
         _scheduled_event.issuer_address = issuer_address
         _scheduled_event.token_address = token_address
         _scheduled_event.token_type = TokenType.IBET_STRAIGHT_BOND
@@ -2186,8 +2186,7 @@ async def schedule_bond_token_update_events_in_batch(
         _scheduled_event.status = ScheduledEventStatus.PROCESSING
         db.add(_scheduled_event)
 
-        assert _scheduled_event.event_id is not None
-        _event_id_list.append(typing_cast(str, _scheduled_event.event_id))
+        _event_id_list.append(_event_id)
 
     await db.commit()
 

--- a/app/routers/issuer/share.py
+++ b/app/routers/issuer/share.py
@@ -22,7 +22,7 @@ import uuid
 from collections import defaultdict
 from datetime import UTC, datetime
 from decimal import Decimal
-from typing import Annotated, Any, List, Optional, Sequence, cast as typing_cast
+from typing import Annotated, Any, List, Optional, Sequence
 
 import pytz
 from eth_keyfile.keyfile import decode_keyfile_json
@@ -1625,7 +1625,7 @@ async def list_all_batch_share_redemption(
         record_list = (
             (
                 await db.execute(
-                    select(BatchIssueRedeem, IDXPersonalInfo)
+                    select(BatchIssueRedeem, Nullable(IDXPersonalInfo))
                     .outerjoin(
                         IDXPersonalInfo,
                         and_(
@@ -1646,7 +1646,6 @@ async def list_all_batch_share_redemption(
         str, list[tuple[BatchIssueRedeem, IDXPersonalInfo | None]]
     ] = defaultdict(list)
     for record in record_list:
-        assert record[0].upload_id is not None
         record_list_by_upload_id[record[0].upload_id].append(record)
 
     personal_info_default = {
@@ -1664,7 +1663,6 @@ async def list_all_batch_share_redemption(
         if _upload.created is None:
             continue
         created_utc = pytz.timezone("UTC").localize(_upload.created)
-        assert _upload.upload_id is not None
         results: list[dict[str, Any]] = [
             {
                 "account_address": record[0].account_address,
@@ -2094,8 +2092,9 @@ async def schedule_share_token_update_events_in_batch(
                 )
 
         # Register an event
+        _event_id = str(uuid.uuid4())
         _scheduled_event = ScheduledEvents()
-        _scheduled_event.event_id = str(uuid.uuid4())
+        _scheduled_event.event_id = _event_id
         _scheduled_event.issuer_address = issuer_address
         _scheduled_event.token_address = token_address
         _scheduled_event.token_type = TokenType.IBET_SHARE
@@ -2107,8 +2106,7 @@ async def schedule_share_token_update_events_in_batch(
         _scheduled_event.status = ScheduledEventStatus.PROCESSING
         db.add(_scheduled_event)
 
-        assert _scheduled_event.event_id is not None
-        _event_id_list.append(typing_cast(str, _scheduled_event.event_id))
+        _event_id_list.append(_event_id)
 
     await db.commit()
 
@@ -2162,7 +2160,6 @@ async def retrieve_scheduled_share_token_update_event(
     if _token_event is None:
         raise HTTPException(status_code=404, detail="event not found")
 
-    assert _token_event.scheduled_datetime is not None
     assert _token_event.created is not None
     scheduled_datetime_utc = pytz.timezone("UTC").localize(
         _token_event.scheduled_datetime
@@ -2237,7 +2234,6 @@ async def delete_scheduled_share_token_update_event(
     if _token_event is None:
         raise HTTPException(status_code=404, detail="event not found")
 
-    assert _token_event.scheduled_datetime is not None
     assert _token_event.created is not None
     scheduled_datetime_utc = pytz.timezone("UTC").localize(
         _token_event.scheduled_datetime

--- a/migrations/versions/4ded95375da2_v26_6_0_feature_1001_2.py
+++ b/migrations/versions/4ded95375da2_v26_6_0_feature_1001_2.py
@@ -1,0 +1,39 @@
+"""v26_6_0_feature_1001_2
+
+Revision ID: 4ded95375da2
+Revises: 7b965ee0f8f1
+Create Date: 2026-04-10 10:08:49.952551
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+from app.database import get_db_schema
+
+# revision identifiers, used by Alembic.
+revision = "4ded95375da2"
+down_revision = "7b965ee0f8f1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column(
+        "batch_issue_redeem",
+        "upload_id",
+        existing_type=sa.VARCHAR(length=36),
+        nullable=False,
+        schema=get_db_schema(),
+    )
+
+
+def downgrade():
+    op.alter_column(
+        "batch_issue_redeem",
+        "upload_id",
+        existing_type=sa.VARCHAR(length=36),
+        nullable=True,
+        schema=get_db_schema(),
+    )


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

Related to #1001

- Changed BatchIssueRedeem.upload_id to nullable=False.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- Related to #1001

## 🔄 Changes

<!-- List the major changes in this PR. -->

- Change BatchIssueRedeem.upload_id to nullable=False and add an Alembic migration to alter the column.
- Update issuer bond/share routers to reflect the non-null constraint (remove Optional checks/asserts and adapt query/record handling), simplify scheduled event id generation to reuse a single uuid, and clean up some typing imports/usages.

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
