### PR TITLE
Add Anvil transaction sync patch for tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Iterator
 from typing import cast
 
 import pytest
@@ -42,6 +42,7 @@ from app.model.db import Base
 from app.utils.ibet_contract_utils import ContractUtils as IbetContractUtils
 from config import CHAIN_ID, TX_GAS_LIMIT, WEB3_HTTP_PROVIDER
 from tests.account_config import default_eth_account
+from tests.helpers.anvil_transaction_sync import install_anvil_transaction_sync_patch
 
 web3 = Web3(Web3.HTTPProvider(WEB3_HTTP_PROVIDER))
 web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
@@ -64,6 +65,22 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
     session_scope_marker = pytest.mark.asyncio(loop_scope="session")
     for async_test in pytest_asyncio_tests:
         async_test.add_marker(session_scope_marker, append=False)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def anvil_transaction_sync_patch() -> Iterator[None]:
+    try:
+        client_version = web3.client_version
+    except Exception:
+        yield
+        return
+
+    if "anvil" not in client_version.lower():
+        yield
+        return
+
+    with install_anvil_transaction_sync_patch(web3):
+        yield
 
 
 #####################################################

--- a/tests/helpers/anvil_transaction_sync.py
+++ b/tests/helpers/anvil_transaction_sync.py
@@ -1,0 +1,125 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any, cast
+from unittest import mock
+
+from hexbytes import HexBytes
+from web3.eth.async_eth import AsyncEth
+from web3.eth.eth import Eth
+from web3.types import RPCEndpoint
+
+
+@contextmanager
+def install_anvil_transaction_sync_patch(_: Any = None) -> Iterator[None]:
+    """Route transaction sending through Anvil's synchronous RPC during tests."""
+
+    transaction_receipt_cache: dict[HexBytes, Any] = {}
+    original_sync_get_transaction_receipt = Eth.get_transaction_receipt
+    original_async_get_transaction_receipt = AsyncEth.get_transaction_receipt
+
+    def _cache_receipt(receipt: Any) -> HexBytes:
+        transaction_hash = HexBytes(receipt["transactionHash"])
+        transaction_receipt_cache[transaction_hash] = receipt
+        return transaction_hash
+
+    def _get_cached_receipt(transaction_hash: Any) -> Any:
+        cached_receipt = transaction_receipt_cache.get(HexBytes(transaction_hash))
+        if cached_receipt is not None:
+            return cached_receipt
+        return None
+
+    def _send_transaction_via_sync_api(self: Eth, transaction: Any) -> HexBytes:
+        transaction_params = self.send_transaction_munger(transaction)[0]
+        receipt = self.w3.manager.request_blocking(
+            cast(RPCEndpoint, "eth_sendTransactionSync"), [transaction_params]
+        )
+        return _cache_receipt(receipt)
+
+    def _send_raw_transaction_via_sync_api(self: Eth, transaction: Any) -> HexBytes:
+        receipt = self.w3.manager.request_blocking(
+            cast(RPCEndpoint, "eth_sendRawTransactionSync"), [transaction]
+        )
+        return _cache_receipt(receipt)
+
+    async def _async_send_transaction_via_sync_api(
+        self: AsyncEth, transaction: Any
+    ) -> HexBytes:
+        transaction_params = self.send_transaction_munger(transaction)[0]
+        receipt = await self.w3.manager.coro_request(
+            cast(RPCEndpoint, "eth_sendTransactionSync"), [transaction_params]
+        )
+        return _cache_receipt(receipt)
+
+    async def _async_send_raw_transaction_via_sync_api(
+        self: AsyncEth, transaction: Any
+    ) -> HexBytes:
+        receipt = await self.w3.manager.coro_request(
+            cast(RPCEndpoint, "eth_sendRawTransactionSync"), [transaction]
+        )
+        return _cache_receipt(receipt)
+
+    def _get_transaction_receipt_with_cache(self: Eth, transaction_hash: Any) -> Any:
+        cached_receipt = _get_cached_receipt(transaction_hash)
+        if cached_receipt is not None:
+            return cached_receipt
+        return original_sync_get_transaction_receipt(self, transaction_hash)
+
+    async def _async_get_transaction_receipt_with_cache(
+        self: AsyncEth, transaction_hash: Any
+    ) -> Any:
+        cached_receipt = _get_cached_receipt(transaction_hash)
+        if cached_receipt is not None:
+            return cached_receipt
+        return await original_async_get_transaction_receipt(self, transaction_hash)
+
+    with (
+        mock.patch.object(
+            Eth,
+            "send_transaction",
+            _send_transaction_via_sync_api,
+        ),
+        mock.patch.object(
+            Eth,
+            "send_raw_transaction",
+            _send_raw_transaction_via_sync_api,
+        ),
+        mock.patch.object(
+            Eth,
+            "get_transaction_receipt",
+            _get_transaction_receipt_with_cache,
+        ),
+        mock.patch.object(
+            AsyncEth,
+            "send_transaction",
+            _async_send_transaction_via_sync_api,
+        ),
+        mock.patch.object(
+            AsyncEth,
+            "send_raw_transaction",
+            _async_send_raw_transaction_via_sync_api,
+        ),
+        mock.patch.object(
+            AsyncEth,
+            "get_transaction_receipt",
+            _async_get_transaction_receipt_with_cache,
+        ),
+    ):
+        yield


### PR DESCRIPTION

## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

Introduce a test helper and fixture to route Web3 transaction sending through Anvil's synchronous RPC.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- Related to: #1034 

## 🔄 Changes

<!-- List the major changes in this PR. -->

**Anvil Transaction Sync Patch Integration:**

* Added a new helper module `anvil_transaction_sync.py` that provides a context manager (`install_anvil_transaction_sync_patch`) to patch `web3`'s transaction sending and receipt retrieval methods, routing them through Anvil's synchronous RPC endpoints and using a cache for transaction receipts.
* Registered a session-scoped, automatically-used pytest fixture `anvil_transaction_sync_patch` in `conftest.py` to apply the patch during test runs when the client is Anvil.

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
