### PR TITLE
Update dependabot config and pin junit-report-merger

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,15 +37,3 @@ updates:
       all-dependencies:
         patterns:
           - "*"
-
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    allow:
-      - dependency-name: "*"
-        dependency-type: "direct"
-    groups:
-      all-dependencies:
-        patterns:
-          - "*"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -105,7 +105,7 @@ jobs:
         with:
           node-version: 20
       - name: Install junit-report-merger
-        run: npm install -g junit-report-merger
+        run: npm install -g junit-report-merger@9.0.3
       - name: Merge reports
         run: jrm cov/pytest.xml "cov/pytest-*.xml"
       - name: Pytest coverage comment


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

- Remove npm dependabot config.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
None

## 🔄 Changes

<!-- List the major changes in this PR. -->

- Remove the redundant npm package-ecosystem block from .github/dependabot.yml to streamline Dependabot updates. 
- Pin the globally-installed junit-report-merger to v9.0.3 in .github/workflows/pr.yml.

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
