### PR TITLE
Add Playwright E2E tests for explorer UI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -115,10 +115,10 @@ jobs:
           report-only-changed-files: true
           pytest-xml-coverage-path: cov/coverage.xml
           junitxml-path: cov/pytest.xml
-      - name: Count test cases in repository
+      - name: Count test cases in coverage scope
         id: countTest
         run: |
-          RESULT=$(docker compose run -w /app/ibet-Prime ibet-prime-postgres bash --login -c 'uv run pytest --collect-only | grep -e "<Function" -e "<Coroutine"' | wc -l)
+          RESULT=$(docker compose run -w /app/ibet-Prime ibet-prime-postgres bash --login -c 'uv run pytest --collect-only tests/app tests/batch | grep -e "<Function" -e "<Coroutine"' | wc -l)
           echo "test_count=${RESULT}" >> $GITHUB_OUTPUT
       - run: echo ${{ steps.coverageComment.outputs.tests }}
       - run: echo ${{ steps.countTest.outputs.test_count }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        test_target: ["tests/app/", "tests/batch/"]
+        test_target: ["tests/app/", "tests/batch/", "tests/e2e/"]
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
@@ -118,7 +118,7 @@ jobs:
       - name: Count test cases in coverage scope
         id: countTest
         run: |
-          RESULT=$(docker compose run -w /app/ibet-Prime ibet-prime-postgres bash --login -c 'uv run pytest --collect-only tests/app tests/batch | grep -e "<Function" -e "<Coroutine"' | wc -l)
+          RESULT=$(docker compose run -w /app/ibet-Prime ibet-prime-postgres bash --login -c 'uv run pytest --collect-only | grep -e "<Function" -e "<Coroutine"' | wc -l)
           echo "test_count=${RESULT}" >> $GITHUB_OUTPUT
       - run: echo ${{ steps.coverageComment.outputs.tests }}
       - run: echo ${{ steps.countTest.outputs.test_count }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dev = [
     "opentelemetry-instrumentation-psycopg>=0.54b0,<1.0.0",
     "opentelemetry-instrumentation-sqlalchemy>=0.54b0,<1.0.0",
     "opentelemetry-exporter-otlp-proto-grpc>=1.33.1,<2.0.0",
+    "playwright>=1.58.0",
 ]
 
 [tool.ruff]

--- a/tests/Dockerfile_unittest
+++ b/tests/Dockerfile_unittest
@@ -114,6 +114,8 @@ RUN apt-get update -q \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+ENV PLAYWRIGHT_BROWSERS_PATH=/home/apl/.cache/ms-playwright
+
 # copy test cases
 USER apl
 RUN mkdir -p /app/ibet-Prime/tests/
@@ -130,6 +132,13 @@ COPY --from=builder --chown=apl:apl /home/apl/.venv/ /home/apl/.venv/
 COPY --from=builder --chown=apl:apl /app/ibet-Prime/ /app/ibet-Prime/
 COPY --from=builder --chown=apl:apl /usr/local/bin/uv /usr/local/bin/uv
 COPY --from=builder --chown=apl:apl /usr/local/bin/uvx /usr/local/bin/uvx
+
+USER root
+RUN mkdir -p /home/apl/.cache/ms-playwright \
+  && /home/apl/.venv/bin/python -m playwright install --with-deps chromium \
+  && chown -R apl:apl /home/apl/.cache
+
+USER apl
 
 ENV LANG=ja_JP.utf8
 ENV UV_PROJECT_ENVIRONMENT="/home/apl/.venv"

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,407 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import asyncio
+import socket
+import threading
+import time
+from collections.abc import AsyncGenerator, Iterator
+from dataclasses import dataclass
+from typing import Any, Protocol, TypedDict
+
+import pytest
+import pytest_asyncio
+import uvicorn
+from fastapi import HTTPException
+from playwright.async_api import Browser, async_playwright
+
+from app.database import db_async_session
+from app.main import app
+from app.routers.misc import bc_explorer, bc_explorer_ui
+
+
+@dataclass(frozen=True)
+class ExplorerSeedData:
+    """
+    Seed data for the blockchain explorer used in E2E tests.
+    """
+
+    latest_block_number: int
+    block_with_transactions_number: int
+    block_without_transactions_number: int
+    block_with_transactions_hash: str
+    block_without_transactions_hash: str
+    tx_hash: str
+    from_address: str
+    to_address: str
+
+
+class BlockQuery(Protocol):
+    """
+    Query parameters for listing blocks in the explorer.
+    """
+
+    from_block_number: int | None
+    to_block_number: int | None
+    sort_order: int | None
+    limit: int | None
+    offset: int | None
+    has_transactions: bool | None
+
+
+class BlockDataRow(TypedDict):
+    """
+    Data structure representing a block in the block list response.
+    """
+
+    number: int
+    hash: str
+    transactions: list[str]
+    timestamp: int
+    gas_limit: int
+    gas_used: int
+    size: int
+
+
+class BlockDetailRow(TypedDict):
+    """
+    Data structure representing detailed block information in the block detail response.
+    """
+
+    number: int
+    parent_hash: str
+    sha3_uncles: str
+    miner: str
+    state_root: str
+    transactions_root: str
+    receipts_root: str
+    logs_bloom: str
+    difficulty: int
+    gas_limit: int
+    gas_used: int
+    timestamp: int
+    proof_of_authority_data: str
+    mix_hash: str
+    nonce: str
+    hash: str
+    size: int
+    transactions: list[str]
+
+
+class TxDetailRow(TypedDict):
+    """
+    Data structure representing detailed transaction information in the transaction detail response.
+    """
+
+    hash: str
+    block_hash: str
+    block_number: int
+    transaction_index: int
+    from_address: str
+    to_address: str
+    contract_name: str | None
+    contract_function: str | None
+    contract_parameters: dict[str, Any] | None
+    gas: int
+    gas_price: int
+    value: int
+    nonce: int
+
+
+# Fixed values that keep the browser assertions deterministic.
+EXPLORER_SEED_DATA = ExplorerSeedData(
+    latest_block_number=7,
+    block_with_transactions_number=7,
+    block_without_transactions_number=6,
+    block_with_transactions_hash="0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    block_without_transactions_hash="0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    tx_hash="0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    from_address="0x1234567890abcdef1234567890abcdef12345678",
+    to_address="0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+)
+
+
+def _make_block_data(
+    block_number: int, block_hash: str, transactions: list[str]
+) -> BlockDataRow:
+    """
+    Create a block data row with the given parameters and deterministic timestamp and size.
+    """
+    return {
+        "number": block_number,
+        "hash": block_hash,
+        "transactions": transactions,
+        "timestamp": 1_700_000_000
+        - (EXPLORER_SEED_DATA.latest_block_number - block_number) * 100,
+        "gas_limit": 30_000_000,
+        "gas_used": 21_000 if transactions else 0,
+        "size": 1_024 if transactions else 512,
+    }
+
+
+def _make_block_detail(
+    block_number: int, block_hash: str, transactions: list[str]
+) -> BlockDetailRow:
+    """
+    Create a block detail row with the given parameters and deterministic values for other fields.
+    """
+    return {
+        "number": block_number,
+        "parent_hash": "0x1111111111111111111111111111111111111111111111111111111111111111",
+        "sha3_uncles": "0x2222222222222222222222222222222222222222222222222222222222222222",
+        "miner": "0x3333333333333333333333333333333333333333",
+        "state_root": "0x4444444444444444444444444444444444444444444444444444444444444444",
+        "transactions_root": "0x5555555555555555555555555555555555555555555555555555555555555555",
+        "receipts_root": "0x6666666666666666666666666666666666666666666666666666666666666666",
+        "logs_bloom": "0x" + "00" * 256,
+        "difficulty": 1,
+        "gas_limit": 30_000_000,
+        "gas_used": 21_000 if transactions else 0,
+        "timestamp": 1_700_000_000
+        - (EXPLORER_SEED_DATA.latest_block_number - block_number) * 100,
+        "proof_of_authority_data": "0x7777777777777777",
+        "mix_hash": "0x8888888888888888888888888888888888888888888888888888888888888888",
+        "nonce": "0x0000000000000000",
+        "hash": block_hash,
+        "size": 1_024 if transactions else 512,
+        "transactions": transactions,
+    }
+
+
+def _make_tx_detail(tx_hash: str) -> TxDetailRow:
+    """
+    Create a transaction detail row with the given hash and deterministic values for other fields.
+    """
+    return {
+        "hash": tx_hash,
+        "block_hash": EXPLORER_SEED_DATA.block_with_transactions_hash,
+        "block_number": EXPLORER_SEED_DATA.block_with_transactions_number,
+        "transaction_index": 0,
+        "from_address": EXPLORER_SEED_DATA.from_address,
+        "to_address": EXPLORER_SEED_DATA.to_address,
+        "contract_name": None,
+        "contract_function": None,
+        "contract_parameters": None,
+        "gas": 21_000,
+        "gas_price": 1,
+        "value": 123,
+        "nonce": 9,
+    }
+
+
+@pytest.fixture(scope="session", autouse=True)
+def enable_bc_explorer_ui() -> Iterator[None]:
+    """
+    Fixture to enable the blockchain explorer UI and mock its backend services for E2E tests.
+
+    This fixture performs the following actions:
+    1. Overrides the blockchain explorer services with deterministic in-memory implementations that return fixed data based on `EXPLORER_SEED_DATA`.
+    2. Ensures the explorer UI router is included in the FastAPI app.
+    3. Yields control to the test, allowing it to run with the mocked services.
+    4. Restores the original services and router after the test completes.
+    """
+
+    # Swap the explorer services with deterministic in-memory responses for E2E.
+    original_bc_enabled = bc_explorer_ui.BC_EXPLORER_ENABLED
+    original_get_latest_block_number = getattr(
+        bc_explorer_ui, "_get_latest_block_number"
+    )
+    original_list_block_data = bc_explorer.service_list_block_data
+    original_get_block_data = bc_explorer.service_get_block_data
+    original_get_tx_data = bc_explorer.service_get_tx_data
+
+    async def _mock_get_latest_block_number(_: Any) -> int:
+        """Return the latest block number from the seed data."""
+        return EXPLORER_SEED_DATA.latest_block_number
+
+    async def _mock_list_block_data(db: Any, get_query: BlockQuery) -> dict[str, Any]:
+        """Return a list of blocks based on the seed data, applying filters and pagination from the query."""
+        blocks: list[BlockDataRow] = [
+            _make_block_data(
+                EXPLORER_SEED_DATA.block_without_transactions_number,
+                EXPLORER_SEED_DATA.block_without_transactions_hash,
+                [],
+            ),
+            _make_block_data(
+                EXPLORER_SEED_DATA.block_with_transactions_number,
+                EXPLORER_SEED_DATA.block_with_transactions_hash,
+                [EXPLORER_SEED_DATA.tx_hash],
+            ),
+        ]
+
+        if get_query.from_block_number is not None:
+            blocks = [
+                block
+                for block in blocks
+                if block["number"] >= get_query.from_block_number
+            ]
+        if get_query.to_block_number is not None:
+            blocks = [
+                block
+                for block in blocks
+                if block["number"] <= get_query.to_block_number
+            ]
+        if get_query.has_transactions:
+            blocks = [block for block in blocks if len(block["transactions"]) > 0]
+
+        sort_order = get_query.sort_order or 1
+        blocks = sorted(
+            blocks,
+            key=lambda block: block["number"],
+            reverse=sort_order != 0,
+        )
+
+        offset = get_query.offset or 0
+        limit = get_query.limit or len(blocks)
+        sliced_blocks = blocks[offset : offset + limit]
+
+        return {
+            "result_set": {
+                "count": len(blocks),
+                "offset": offset,
+                "limit": limit,
+                "total": EXPLORER_SEED_DATA.latest_block_number + 1,
+            },
+            "block_data": sliced_blocks,
+        }
+
+    async def _mock_get_block_data(db: Any, block_number: int) -> BlockDetailRow:
+        """Return block details based on the block number, using the seed data."""
+        if block_number == EXPLORER_SEED_DATA.block_with_transactions_number:
+            return _make_block_detail(
+                EXPLORER_SEED_DATA.block_with_transactions_number,
+                EXPLORER_SEED_DATA.block_with_transactions_hash,
+                [EXPLORER_SEED_DATA.tx_hash],
+            )
+        if block_number == EXPLORER_SEED_DATA.block_without_transactions_number:
+            return _make_block_detail(
+                EXPLORER_SEED_DATA.block_without_transactions_number,
+                EXPLORER_SEED_DATA.block_without_transactions_hash,
+                [],
+            )
+        raise HTTPException(status_code=404, detail="block data not found")
+
+    async def _mock_get_tx_data(db: Any, hash: str) -> TxDetailRow:
+        """Return transaction details based on the transaction hash, using the seed data."""
+        if hash == EXPLORER_SEED_DATA.tx_hash:
+            return _make_tx_detail(hash)
+        raise HTTPException(status_code=404, detail="block data not found")
+
+    bc_explorer_ui.BC_EXPLORER_ENABLED = True
+
+    # The UI module uses a private helper, so we replace it directly for the test run.
+    bc_explorer_ui._get_latest_block_number = _mock_get_latest_block_number  # pyright: ignore[reportPrivateUsage]
+    bc_explorer.service_list_block_data = _mock_list_block_data
+    bc_explorer.service_get_block_data = _mock_get_block_data
+    bc_explorer.service_get_tx_data = _mock_get_tx_data
+    app.dependency_overrides[db_async_session] = lambda: object()
+
+    # Ensure the explorer UI router is included in the app if not already present.
+    if not any(
+        getattr(route, "path", None) == "/blockchain_explorer/ui"
+        for route in app.router.routes
+    ):
+        app.include_router(bc_explorer_ui.router)
+
+    # Yield control to the test
+    yield
+
+    # Restore the original services and router after the test completes.
+    bc_explorer_ui.BC_EXPLORER_ENABLED = original_bc_enabled
+    bc_explorer_ui._get_latest_block_number = original_get_latest_block_number  # pyright: ignore[reportPrivateUsage]
+    bc_explorer.service_list_block_data = original_list_block_data
+    bc_explorer.service_get_block_data = original_get_block_data
+    bc_explorer.service_get_tx_data = original_get_tx_data
+    app.dependency_overrides.pop(db_async_session, None)
+
+
+@pytest.fixture(scope="function", autouse=True)
+def ibet_block_number() -> Iterator[None]:
+    yield
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+@pytest.fixture(scope="session")
+def browser_server(enable_bc_explorer_ui: None) -> Iterator[str]:
+    """
+    Fixture to start the FastAPI app on a real port for Playwright E2E tests.
+
+    This fixture performs the following actions:
+    1. Finds a free port and starts the FastAPI app using Uvicorn in a separate thread.
+    2. Waits for the server to be ready before yielding the server URL to the test.
+    3. After the test completes, signals the server to shut down and waits for the thread to finish.
+    """
+    port = _find_free_port()
+    config = uvicorn.Config(
+        app,
+        host="127.0.0.1",
+        port=port,
+        log_level="warning",
+        access_log=False,
+        lifespan="off",
+    )
+    server = uvicorn.Server(config)
+
+    def _run() -> None:
+        asyncio.run(server.serve())
+
+    thread = threading.Thread(target=_run, daemon=True)
+    thread.start()
+
+    deadline = time.monotonic() + 10.0
+    while time.monotonic() < deadline:
+        if server.started:
+            try:
+                with socket.create_connection(("127.0.0.1", port), timeout=0.2):
+                    break
+            except OSError:
+                time.sleep(0.05)
+        else:
+            time.sleep(0.05)
+    else:
+        server.should_exit = True
+        thread.join(timeout=5)
+        raise RuntimeError("Playwright test server did not start")
+
+    yield f"http://127.0.0.1:{port}"
+
+    server.should_exit = True
+    thread.join(timeout=5)
+
+
+@pytest.fixture(scope="function")
+def seeded_explorer_data() -> ExplorerSeedData:
+    """Fixture to provide the seeded explorer data for tests."""
+    return EXPLORER_SEED_DATA
+
+
+@pytest_asyncio.fixture(scope="session")
+async def browser() -> AsyncGenerator[Browser, None]:
+    """Fixture to launch a Playwright browser instance for E2E tests."""
+    async with async_playwright() as playwright:
+        launched_browser = await playwright.chromium.launch()
+        try:
+            yield launched_browser
+        finally:
+            await launched_browser.close()

--- a/tests/e2e/test_bc_explorer_ui_playwright.py
+++ b/tests/e2e/test_bc_explorer_ui_playwright.py
@@ -1,0 +1,177 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import pytest
+from playwright.async_api import Browser, expect
+
+from tests.e2e.conftest import ExplorerSeedData
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+
+def _truncate(value: str, prefix_length: int, suffix_length: int) -> str:
+    """Helper function to truncate a string with an ellipsis in the middle."""
+    return f"{value[:prefix_length]}…{value[-suffix_length:]}"
+
+
+async def test_bc_explorer_index_page_renders_shell(
+    browser_server: str,
+    browser: Browser,
+    seeded_explorer_data: ExplorerSeedData,
+) -> None:
+    """
+    Verify the blockchain explorer index page renders the main shell
+    and expected dynamic content based on the seeded explorer data.
+
+        The test covers the following scenarios:
+        1. The main shell renders with the expected header and search input.
+        2. The latest synced block number from the seeded data is displayed in the banner.
+    """
+
+    context = await browser.new_context()
+    page = await context.new_page()
+
+    response = await page.goto(
+        f"{browser_server}/blockchain_explorer/ui",
+        wait_until="domcontentloaded",
+    )
+
+    assert response is not None
+    assert response.status == 200
+
+    # Verify the initial shell renders with the expected explorer header.
+    await expect(
+        page.get_by_role("heading", name="ibet Blockchain Explorer")
+    ).to_be_visible()
+
+    # Verify the search input is present and exposes the expected placeholder.
+    await expect(page.locator("#header-txhash")).to_have_attribute(
+        "placeholder", "Tx hash (0x...)"
+    )
+
+    # Verify the page reflects the latest synced block number in the banner.
+    await expect(
+        page.get_by_text(
+            f"Latest synced block: #{seeded_explorer_data.latest_block_number}"
+        )
+    ).to_be_visible()
+
+    await context.close()
+
+
+async def test_bc_explorer_fragments_render_block_and_tx_details(
+    browser_server: str,
+    browser: Browser,
+    seeded_explorer_data: ExplorerSeedData,
+) -> None:
+    """
+    Verify the blockchain explorer fragments render expected block
+    and transaction details based on the seeded explorer data.
+
+        The test covers the following scenarios:
+        1. The blocks fragment correctly filters and paginates blocks with transactions.
+        2. The block detail fragment shows the full block hash and truncated transaction hashes.
+        3. The transaction detail fragment renders truncated hashes and optional contract metadata.
+    """
+
+    blocks_context = await browser.new_context(
+        extra_http_headers={"HX-Request": "true"}
+    )
+    blocks_page = await blocks_context.new_page()
+
+    blocks_response = await blocks_page.goto(
+        (
+            f"{browser_server}/blockchain_explorer/ui/blocks"
+            f"?from_block_number={seeded_explorer_data.block_without_transactions_number}"
+            f"&to_block_number={seeded_explorer_data.block_with_transactions_number}"
+            "&sort_order=1&limit=10&offset=0&has_transactions=true"
+        ),
+        wait_until="domcontentloaded",
+    )
+
+    assert blocks_response is not None
+    assert blocks_response.status == 200
+
+    # Verify the filtered block list only keeps the block with transactions.
+    await expect(
+        blocks_page.locator(
+            f'tr[data-block-number="{seeded_explorer_data.block_with_transactions_number}"]'
+        )
+    ).to_have_count(1)
+
+    # Verify the no-transaction block is excluded by the has_transactions filter.
+    await expect(
+        blocks_page.locator(
+            f'tr[data-block-number="{seeded_explorer_data.block_without_transactions_number}"]'
+        )
+    ).to_have_count(0)
+
+    # Verify the fragment exposes the list count and pagination metadata.
+    await expect(
+        blocks_page.get_by_text("Count: 1 / Total: 8 | limit: 10 offset: 0")
+    ).to_be_visible()
+
+    block_detail_context = await browser.new_context(
+        extra_http_headers={"HX-Request": "true"}
+    )
+    block_detail_page = await block_detail_context.new_page()
+
+    block_detail_response = await block_detail_page.goto(
+        f"{browser_server}/blockchain_explorer/ui/block/{seeded_explorer_data.block_with_transactions_number}",
+        wait_until="domcontentloaded",
+    )
+
+    assert block_detail_response is not None
+    assert block_detail_response.status == 200
+
+    # Verify the selected block detail shows the full block hash.
+    await expect(
+        block_detail_page.get_by_text(seeded_explorer_data.block_with_transactions_hash)
+    ).to_be_visible()
+
+    # Verify the transaction hash is truncated in the block detail view.
+    await expect(
+        block_detail_page.get_by_text(_truncate(seeded_explorer_data.tx_hash, 10, 8))
+    ).to_be_visible()
+
+    tx_detail_context = await browser.new_context(
+        extra_http_headers={"HX-Request": "true"}
+    )
+    tx_detail_page = await tx_detail_context.new_page()
+
+    tx_detail_response = await tx_detail_page.goto(
+        f"{browser_server}/blockchain_explorer/ui/tx/{seeded_explorer_data.tx_hash}",
+        wait_until="domcontentloaded",
+    )
+
+    assert tx_detail_response is not None
+    assert tx_detail_response.status == 200
+
+    # Verify the transaction detail page shows the truncated transaction hash in the header.
+    await expect(
+        tx_detail_page.get_by_text(_truncate(seeded_explorer_data.tx_hash, 14, 10))
+    ).to_be_visible()
+
+    # Verify optional contract metadata is rendered even when the transaction is not decoded.
+    await expect(tx_detail_page.get_by_text("Contract")).to_be_visible()
+    await expect(tx_detail_page.get_by_text("None / None")).to_be_visible()
+
+    await tx_detail_context.close()
+    await block_detail_context.close()
+    await blocks_context.close()

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = "==3.13.11"
 
 [options]
-exclude-newer = "2026-04-07T12:42:04.733771Z"
+exclude-newer = "2026-04-08T11:32:38.638515Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -776,6 +776,7 @@ dev = [
     { name = "opentelemetry-instrumentation-psycopg" },
     { name = "opentelemetry-instrumentation-sqlalchemy" },
     { name = "opentelemetry-sdk" },
+    { name = "playwright" },
     { name = "pre-commit" },
     { name = "pyright" },
     { name = "pyroscope-io" },
@@ -831,6 +832,7 @@ dev = [
     { name = "opentelemetry-instrumentation-psycopg", specifier = ">=0.54b0,<1.0.0" },
     { name = "opentelemetry-instrumentation-sqlalchemy", specifier = ">=0.54b0,<1.0.0" },
     { name = "opentelemetry-sdk", specifier = ">=1.33.0" },
+    { name = "playwright", specifier = ">=1.58.0" },
     { name = "pre-commit", specifier = ">=4.1.0,<5.0.0" },
     { name = "pyright", specifier = ">=1.1.407" },
     { name = "pyroscope-io", specifier = ">=0.8.11" },
@@ -1351,6 +1353,25 @@ wheels = [
 ]
 
 [[package]]
+name = "playwright"
+version = "1.58.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/c9/9c6061d5703267f1baae6a4647bfd1862e386fbfdb97d889f6f6ae9e3f64/playwright-1.58.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:96e3204aac292ee639edbfdef6298b4be2ea0a55a16b7068df91adac077cc606", size = 42251098, upload-time = "2026-01-30T15:09:24.028Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/40/59d34a756e02f8c670f0fee987d46f7ee53d05447d43cd114ca015cb168c/playwright-1.58.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:70c763694739d28df71ed578b9c8202bb83e8fe8fb9268c04dd13afe36301f71", size = 41039625, upload-time = "2026-01-30T15:09:27.558Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/ee/3ce6209c9c74a650aac9028c621f357a34ea5cd4d950700f8e2c4b7fe2c4/playwright-1.58.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:185e0132578733d02802dfddfbbc35f42be23a45ff49ccae5081f25952238117", size = 42251098, upload-time = "2026-01-30T15:09:30.461Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/af/009958cbf23fac551a940d34e3206e6c7eed2b8c940d0c3afd1feb0b0589/playwright-1.58.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:c95568ba1eda83812598c1dc9be60b4406dffd60b149bc1536180ad108723d6b", size = 46235268, upload-time = "2026-01-30T15:09:33.787Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/a6/0e66ad04b6d3440dae73efb39540c5685c5fc95b17c8b29340b62abbd952/playwright-1.58.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f9999948f1ab541d98812de25e3a8c410776aa516d948807140aff797b4bffa", size = 45964214, upload-time = "2026-01-30T15:09:36.751Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/236e60ab9f6d62ed0fd32150d61f1f494cefbf02304c0061e78ed80c1c32/playwright-1.58.0-py3-none-win32.whl", hash = "sha256:1e03be090e75a0fabbdaeab65ce17c308c425d879fa48bb1d7986f96bfad0b99", size = 36815998, upload-time = "2026-01-30T15:09:39.627Z" },
+    { url = "https://files.pythonhosted.org/packages/41/f8/5ec599c5e59d2f2f336a05b4f318e733077cd5044f24adb6f86900c3e6a7/playwright-1.58.0-py3-none-win_amd64.whl", hash = "sha256:a2bf639d0ce33b3ba38de777e08697b0d8f3dc07ab6802e4ac53fb65e3907af8", size = 36816005, upload-time = "2026-01-30T15:09:42.449Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c4/cc0229fea55c87d6c9c67fe44a21e2cd28d1d558a5478ed4d617e9fb0c93/playwright-1.58.0-py3-none-win_arm64.whl", hash = "sha256:32ffe5c303901a13a0ecab91d1c3f74baf73b84f4bedbb6b935f5bc11cc98e1b", size = 33085919, upload-time = "2026-01-30T15:09:45.71Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1557,6 +1578,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/d9/c248c103856f807ef70c18a4f986693a46a8ffe1602e5d361485da502d20/pydantic_core-2.41.5-cp313-cp313-win32.whl", hash = "sha256:650ae77860b45cfa6e2cdafc42618ceafab3a2d9a3811fcfbd3bbf8ac3c40d36", size = 1994679, upload-time = "2025-11-04T13:40:50.619Z" },
     { url = "https://files.pythonhosted.org/packages/9e/8b/341991b158ddab181cff136acd2552c9f35bd30380422a639c0671e99a91/pydantic_core-2.41.5-cp313-cp313-win_amd64.whl", hash = "sha256:79ec52ec461e99e13791ec6508c722742ad745571f234ea6255bed38c6480f11", size = 2019766, upload-time = "2025-11-04T13:40:52.631Z" },
     { url = "https://files.pythonhosted.org/packages/73/7d/f2f9db34af103bea3e09735bb40b021788a5e834c81eedb541991badf8f5/pydantic_core-2.41.5-cp313-cp313-win_arm64.whl", hash = "sha256:3f84d5c1b4ab906093bdc1ff10484838aca54ef08de4afa9de0f5f14d69639cd", size = 1981005, upload-time = "2025-11-04T13:40:54.734Z" },
+]
+
+[[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add end-to-end Playwright tests for the blockchain explorer UI.

## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

This pull request adds Playwright-based end-to-end (E2E) tests for the blockchain explorer UI. 

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
None

## 🔄 Changes

<!-- List the major changes in this PR. -->

**Testing enhancements:**

* Added `tests/e2e/test_bc_explorer_ui_playwright.py`, which introduces asynchronous Playwright tests to check that the blockchain explorer index page, block list, block details, and transaction details render and behave as expected, including content filtering, pagination, and display of dynamic values.

**Development dependencies:**

* Updated the `pyproject.toml` development dependencies to include `playwright>=1.58.0`, enabling Playwright-based browser automation for E2E testing.

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
