### PR TITLE
Pin GitHub Actions to specific SHAs

### DIFF
--- a/.github/actions/setup-test-image/action.yml
+++ b/.github/actions/setup-test-image/action.yml
@@ -3,15 +3,15 @@ description: 'Setup docker builder for using github actions cache'
 runs:
   using: "composite"
   steps:
-    - uses: docker/setup-buildx-action@v3
+    - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
     - name: Set metadata
       id: metadata
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
       with:
         images: ibet-prime
         tags: |
           type=sha,format=short
-    - uses: docker/build-push-action@v6
+    - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
       with:
         context: .
         file: ./tests/Dockerfile_unittest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,13 +11,13 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -28,7 +28,7 @@ jobs:
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
 
       - name: Build and Push (ibet-prime)
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           file: Dockerfile

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,19 +26,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           languages: ${{ matrix.language }}
 
       # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,15 +7,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-test-image
   lint-ruff:
     name: "Lint check (ruff and pyright)"
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
-      - uses: astral-sh/ruff-action@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6 # v3.6.1
       - name: Install uv
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
         with:
@@ -25,7 +25,7 @@ jobs:
             **/uv.lock
       - name: Restore cache
         id: cache-venv
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ hashFiles('**/pyproject.toml', '**/uv.lock') }}
@@ -48,7 +48,7 @@ jobs:
         test_target: ["tests/app/", "tests/batch/", "tests/e2e/"]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-test-image
       - name: build image on compose
         run: docker compose build
@@ -59,13 +59,13 @@ jobs:
       - name: run unit test using postgres
         run: docker compose run -e TEST_TARGET="${{ matrix.test_target }}" ibet-prime-postgres
       - run: mv cov/.coverage cov/.coverage-${{ strategy.job-index }}
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: .coverage-${{ strategy.job-index }}
           path: cov/.coverage-${{ strategy.job-index }}
           include-hidden-files: true
       - run: mv cov/pytest.xml cov/pytest-${{ strategy.job-index }}.xml
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pytest-${{ strategy.job-index }}
           path: cov/pytest-${{ strategy.job-index }}.xml
@@ -79,7 +79,7 @@ jobs:
       pull-requests: write
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-test-image
       - name: build image on compose
         run: docker compose build
@@ -87,7 +87,7 @@ jobs:
         run: |
           sudo chown runner:docker /home/runner/work/ibet-Prime/ibet-Prime/cov
           sudo chmod 777 /home/runner/work/ibet-Prime/ibet-Prime/cov
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: ".coverage-*"
           path: cov/
@@ -96,14 +96,14 @@ jobs:
         run: docker compose run -w /app/ibet-Prime/cov ibet-prime-postgres bash --login -c 'uv run coverage combine .coverage-*'
       - name: generate coverage xml file
         run: docker compose run -w /app/ibet-Prime ibet-prime-postgres bash --login -c 'uv run coverage xml --data-file=cov/.coverage -o cov/coverage.xml'
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: "pytest-*"
           path: cov/
           merge-multiple: true
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20
+          node-version: 24
       - name: Install junit-report-merger
         run: npm install -g junit-report-merger@9.0.3
       - name: Merge reports
@@ -132,7 +132,7 @@ jobs:
     needs: build
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-test-image
       - name: run unit test using postgres
         run: docker compose run ibet-prime-postgres bash --login -c "cd /app/ibet-Prime && pytest -vv --test-alembic -m 'alembic'"


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

This pull request updates the GitHub Actions workflows to use specific commit SHAs for all third-party actions, instead of version tags. This improves security and reproducibility by ensuring that the workflows always use the exact same code for each action, preventing unexpected changes from upstream updates. 

Additionally, some actions are updated to newer versions, and the Node.js version is bumped from 20 to 24 in the test workflow.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
None

## 🔄 Changes

<!-- List the major changes in this PR. -->

**Security and Reproducibility Improvements:**

* All GitHub Actions in `.github/workflows/pr.yml`, `.github/workflows/build.yml`, `.github/workflows/codeql-analysis.yml`, and `.github/actions/setup-test-image/action.yml` now reference specific commit SHAs rather than version tags, ensuring consistent and secure workflow execution. 

**Node.js Version Update:**

* The Node.js version used in the test workflow (`actions/setup-node`) is updated from version 20 to 24.

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
