### PR TITLE
Add contract_version to token issue response

### DIFF
--- a/app/model/schema/__init__.py
+++ b/app/model/schema/__init__.py
@@ -214,6 +214,7 @@ from .token import (
     IbetStraightBondTransfer,
     IbetStraightBondUpdate,
     IssueRedeemSortItem,
+    IssueTokenResponse,
     ListAdditionalIssuanceHistoryQuery,
     ListAllAdditionalIssueUploadQuery,
     ListAllHoldersQuery,
@@ -228,7 +229,6 @@ from .token import (
     ListTokenHistorySortItem,
     ListTokenOperationLogHistoryQuery,
     ListTokenOperationLogHistoryResponse,
-    TokenAddressResponse,
     TokenUpdateOperationCategory,
 )
 from .token_holders import (

--- a/app/model/schema/token.py
+++ b/app/model/schema/token.py
@@ -613,11 +613,12 @@ class ListAllIssuedTokensResponse(BaseModel):
     tokens: list[IssuedToken]
 
 
-class TokenAddressResponse(BaseModel):
-    """token address"""
+class IssueTokenResponse(BaseModel):
+    """Issue token response"""
 
     token_address: str
     token_status: TokenStatus
+    contract_version: IbetStraightBondContractVersion | IbetShareContractVersion
 
 
 class IbetWSTSettingsByBlockchainResponse(BaseModel):

--- a/app/routers/issuer/bond.py
+++ b/app/routers/issuer/bond.py
@@ -149,6 +149,7 @@ from app.model.schema import (
     IbetStraightBondUpdate,
     IssueRedeemHistoryResponse,
     IssueRedeemSortItem,
+    IssueTokenResponse,
     ListAdditionalIssuanceHistoryQuery,
     ListAllAdditionalIssueUploadQuery,
     ListAllHoldersQuery,
@@ -179,7 +180,6 @@ from app.model.schema import (
     ScheduledEventIdListResponse,
     ScheduledEventIdResponse,
     ScheduledEventResponse,
-    TokenAddressResponse,
     TransferApprovalHistoryResponse,
     TransferApprovalsResponse,
     TransferApprovalTokenDetailResponse,
@@ -295,7 +295,7 @@ def _decode_private_key(
 @router.post(
     "/tokens",
     operation_id="IssueBondToken",
-    response_model=TokenAddressResponse,
+    response_model=IssueTokenResponse,
     responses=get_routers_responses(422, 401, AuthorizationError, SendTransactionError),
 )
 async def issue_bond_token(
@@ -502,7 +502,11 @@ async def issue_bond_token(
     await db.commit()
 
     return json_response(
-        {"token_address": _token.token_address, "token_status": token_status}
+        {
+            "token_address": _token.token_address,
+            "token_status": token_status,
+            "contract_version": _token.version,
+        }
     )
 
 

--- a/app/routers/issuer/share.py
+++ b/app/routers/issuer/share.py
@@ -149,6 +149,7 @@ from app.model.schema import (
     IbetShareTransfer,
     IbetShareUpdate,
     IssueRedeemHistoryResponse,
+    IssueTokenResponse,
     ListAdditionalIssuanceHistoryQuery,
     ListAllAdditionalIssueUploadQuery,
     ListAllHoldersQuery,
@@ -179,7 +180,6 @@ from app.model.schema import (
     ScheduledEventIdListResponse,
     ScheduledEventIdResponse,
     ScheduledEventResponse,
-    TokenAddressResponse,
     TransferApprovalHistoryResponse,
     TransferApprovalsResponse,
     TransferApprovalTokenDetailResponse,
@@ -295,7 +295,7 @@ def _decode_private_key(
 @router.post(
     "/tokens",
     operation_id="IssueShareToken",
-    response_model=TokenAddressResponse,
+    response_model=IssueTokenResponse,
     responses=get_routers_responses(422, 401, AuthorizationError, SendTransactionError),
 )
 async def issue_share_token(
@@ -492,7 +492,11 @@ async def issue_share_token(
     await db.commit()
 
     return json_response(
-        {"token_address": _token.token_address, "token_status": token_status}
+        {
+            "token_address": _token.token_address,
+            "token_status": token_status,
+            "contract_version": _token.version,
+        }
     )
 
 

--- a/docs/ibet_prime.yaml
+++ b/docs/ibet_prime.yaml
@@ -782,7 +782,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TokenAddressResponse'
+                $ref: '#/components/schemas/IssueTokenResponse'
         '422':
           description: Validation Error
           content:
@@ -5405,7 +5405,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TokenAddressResponse'
+                $ref: '#/components/schemas/IssueTokenResponse'
         '422':
           description: Validation Error
           content:
@@ -16582,6 +16582,25 @@ components:
         - amount
       title: IssueRedeemSortItem
       description: Issue/Redeem sort item
+    IssueTokenResponse:
+      properties:
+        token_address:
+          type: string
+          title: Token Address
+        token_status:
+          $ref: '#/components/schemas/TokenStatus'
+        contract_version:
+          anyOf:
+            - $ref: '#/components/schemas/IbetStraightBondContractVersion'
+            - $ref: '#/components/schemas/IbetShareContractVersion'
+          title: Contract Version
+      type: object
+      required:
+        - token_address
+        - token_status
+        - contract_version
+      title: IssueTokenResponse
+      description: Issue token response
     IssuedToken:
       properties:
         issuer_address:
@@ -19032,19 +19051,6 @@ components:
         - 1
       title: SortOrder
       description: 'Sort order (0: ASC, 1: DESC)'
-    TokenAddressResponse:
-      properties:
-        token_address:
-          type: string
-          title: Token Address
-        token_status:
-          $ref: '#/components/schemas/TokenStatus'
-      type: object
-      required:
-        - token_address
-        - token_status
-      title: TokenAddressResponse
-      description: token address
     TokenHolderBatchStatus:
       type: string
       enum:

--- a/tests/app/test_bond_tokens_IssueBondToken.py
+++ b/tests/app/test_bond_tokens_IssueBondToken.py
@@ -163,6 +163,7 @@ class TestIssueBondToken:
             assert resp.status_code == 200
             assert resp.json()["token_address"] == "contract_address_test1"
             assert resp.json()["token_status"] == 1
+            assert resp.json()["contract_version"] == "25_09"
 
             token_after = (await async_db.scalars(select(Token))).all()
             assert 0 == len(token_before)

--- a/tests/app/test_share_tokens_IssueShareToken.py
+++ b/tests/app/test_share_tokens_IssueShareToken.py
@@ -162,6 +162,7 @@ class TestIssueShareToken:
             assert resp.status_code == 200
             assert resp.json()["token_address"] == "contract_address_test1"
             assert resp.json()["token_status"] == 1
+            assert resp.json()["contract_version"] == "25_09"
 
             token_after = (await async_db.scalars(select(Token))).all()
             assert 0 == len(token_before)


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

Rename TokenAddressResponse to IssueTokenResponse and include a contract_version field in the issue token response.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
None

## 🔄 Changes

<!-- List the major changes in this PR. -->

**API and Schema Updates:**

* Introduced a new response model, `IssueTokenResponse`, in `token.py` to include `token_address`, `token_status`, and `contract_version`, replacing the old `TokenAddressResponse` model.

**API Endpoint Changes:**

* Modified the `/tokens` POST endpoints for both bond and share tokens to return the new `IssueTokenResponse` schema, now including `contract_version` in the response payload. (`app/routers/issuer/bond.py`, `app/routers/issuer/share.py`)

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
