### PR TITLE
Enable prune-history

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,22 +67,6 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
         async_test.add_marker(session_scope_marker, append=False)
 
 
-@pytest.fixture(scope="session", autouse=True)
-def anvil_transaction_sync_patch() -> Iterator[None]:
-    try:
-        client_version = web3.client_version
-    except Exception:
-        yield
-        return
-
-    if "anvil" not in client_version.lower():
-        yield
-        return
-
-    with install_anvil_transaction_sync_patch(web3):
-        yield
-
-
 #####################################################
 # Test Client
 #####################################################
@@ -149,6 +133,22 @@ async def async_db(async_db_engine: AsyncEngine) -> AsyncGenerator[AsyncSession,
 #####################################################
 # ibet: Blockchain & Smart Contract
 #####################################################
+@pytest.fixture(scope="session", autouse=True)
+def anvil_transaction_sync_patch() -> Iterator[None]:
+    try:
+        client_version = web3.client_version
+    except Exception:
+        yield
+        return
+
+    if "anvil" not in client_version.lower():
+        yield
+        return
+
+    with install_anvil_transaction_sync_patch(web3):
+        yield
+
+
 @pytest.fixture(scope="function", autouse=True)
 def ibet_block_number(request: pytest.FixtureRequest) -> None:
     # save blockchain state before function starts

--- a/tests/run_anvil.sh
+++ b/tests/run_anvil.sh
@@ -17,6 +17,7 @@ anvil \
   --chain-id "${CHAIN_ID}" \
   --hardfork "${ANVIL_HARDFORK}" \
   --slots-in-an-epoch "${ANVIL_SLOTS_IN_AN_EPOCH}" \
+  --prune-history \
   --gas-price 0 \
   --block-base-fee-per-gas 0 \
   --gas-limit "${BLOCK_GAS_LIMIT}" &


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

Add --prune-history to the anvil invocation in tests/run_anvil.sh to enable chain history pruning (reduces disk usage/runtime state for test runs).

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
None

## 🔄 Changes

<!-- List the major changes in this PR. -->

Added --prune-history to the anvil invocation in tests/run_anvil.sh.

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
