### PR TITLE
Scope AsyncWeb3 per loop/timeout; per-web3 caches

### DIFF
--- a/app/utils/ava_contract_utils.py
+++ b/app/utils/ava_contract_utils.py
@@ -75,6 +75,8 @@ class _AvaWeb3Context:
             loop = None
 
         if loop is None:
+            # Preserve a per-thread fallback instance for code paths that touch
+            # AvaWeb3 before entering an event loop.
             try:
                 return cast(AsyncWeb3[Any], thread_local.ava_web3_without_loop)
             except AttributeError:
@@ -82,6 +84,8 @@ class _AvaWeb3Context:
                 thread_local.ava_web3_without_loop = async_web3
                 return async_web3
 
+        # AsyncWeb3 instances are isolated per event loop because the provider
+        # session must not be shared across loops.
         try:
             ava_web3_by_loop = cast(
                 WeakKeyDictionary[asyncio.AbstractEventLoop, AsyncWeb3[Any]],
@@ -249,6 +253,7 @@ class AvaAsyncContractEventsView:
 
 
 class AvaAsyncContractUtils:
+    # Contract factories are bound to the AsyncWeb3 that created them.
     factory_map: WeakKeyDictionary[AsyncWeb3[Any], dict[str, type[AsyncContract]]] = (
         WeakKeyDictionary()
     )
@@ -332,6 +337,8 @@ class AvaAsyncContractUtils:
         :param contract_address: contract address
         :return: Contract
         """
+        # Reuse factories only within the same AsyncWeb3 context so provider
+        # state and loop ownership stay consistent.
         current_async_web3 = AvaWeb3.get_web3()
         contract_factory_map = cls.factory_map.get(current_async_web3)
         if contract_factory_map is None:

--- a/app/utils/ava_contract_utils.py
+++ b/app/utils/ava_contract_utils.py
@@ -23,6 +23,7 @@ import sys
 import threading
 from json import JSONDecodeError
 from typing import Any, TypeAlias, cast
+from weakref import WeakKeyDictionary
 
 from aiohttp import ClientError
 from eth_typing import URI, HexStr
@@ -58,6 +59,51 @@ LOG = log.get_logger()
 
 ContractArtifact: TypeAlias = dict[str, Any]
 EventArgumentFilters: TypeAlias = dict[str, Any] | None
+
+
+class _AvaWeb3Context:
+    def __init__(self) -> None:
+        if "pytest" in sys.modules:
+            self._fail_over_mode = False
+        else:
+            self._fail_over_mode = True
+
+    def get_web3(self) -> AsyncWeb3[Any]:
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+
+        if loop is None:
+            try:
+                return cast(AsyncWeb3[Any], thread_local.ava_web3_without_loop)
+            except AttributeError:
+                async_web3 = self._create_web3()
+                thread_local.ava_web3_without_loop = async_web3
+                return async_web3
+
+        try:
+            ava_web3_by_loop = cast(
+                WeakKeyDictionary[asyncio.AbstractEventLoop, AsyncWeb3[Any]],
+                thread_local.ava_web3_by_loop,
+            )
+        except AttributeError:
+            ava_web3_by_loop: WeakKeyDictionary[
+                asyncio.AbstractEventLoop, AsyncWeb3[Any]
+            ] = WeakKeyDictionary()
+            thread_local.ava_web3_by_loop = ava_web3_by_loop
+
+        async_web3 = ava_web3_by_loop.get(loop)
+        if async_web3 is None:
+            async_web3 = self._create_web3()
+            ava_web3_by_loop[loop] = async_web3
+        return async_web3
+
+    def _create_web3(self) -> AsyncWeb3[Any]:
+        return AsyncWeb3(AvaFailOverHTTPProvider(fail_over_mode=self._fail_over_mode))
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self.get_web3(), name)
 
 
 class AvaFailOverHTTPProvider(AsyncHTTPProvider):
@@ -139,14 +185,7 @@ class AvaFailOverHTTPProvider(AsyncHTTPProvider):
             await db_session.close()
 
 
-try:
-    AvaWeb3 = thread_local.AvaWeb3
-except AttributeError:
-    if "pytest" in sys.modules:  # For unit tests
-        AvaWeb3 = AsyncWeb3(AvaFailOverHTTPProvider(fail_over_mode=False))
-    else:
-        AvaWeb3 = AsyncWeb3(AvaFailOverHTTPProvider(fail_over_mode=True))
-    thread_local.AvaWeb3 = AvaWeb3
+AvaWeb3 = _AvaWeb3Context()
 
 
 class AvaTxUtils:
@@ -210,7 +249,9 @@ class AvaAsyncContractEventsView:
 
 
 class AvaAsyncContractUtils:
-    factory_map: dict[str, type[AsyncContract]] = {}
+    factory_map: WeakKeyDictionary[AsyncWeb3[Any], dict[str, type[AsyncContract]]] = (
+        WeakKeyDictionary()
+    )
 
     @staticmethod
     def get_contract_code(contract_name: str) -> tuple[Any, Any, Any]:
@@ -291,14 +332,20 @@ class AvaAsyncContractUtils:
         :param contract_address: contract address
         :return: Contract
         """
-        contract_factory = cls.factory_map.get(contract_name)
+        current_async_web3 = AvaWeb3.get_web3()
+        contract_factory_map = cls.factory_map.get(current_async_web3)
+        if contract_factory_map is None:
+            contract_factory_map = {}
+            cls.factory_map[current_async_web3] = contract_factory_map
+
+        contract_factory = contract_factory_map.get(contract_name)
         if contract_factory is not None:
             return contract_factory(address=to_checksum_address(contract_address))
 
         contract_file = f"contracts/wst/{contract_name}.json"
         contract_json: ContractArtifact = json.load(open(contract_file, "r"))
-        contract_factory = AvaWeb3.eth.contract(abi=contract_json["abi"])
-        cls.factory_map[contract_name] = contract_factory
+        contract_factory = current_async_web3.eth.contract(abi=contract_json["abi"])
+        contract_factory_map[contract_name] = contract_factory
         return contract_factory(address=to_checksum_address(contract_address))
 
     @staticmethod

--- a/app/utils/eth_contract_utils.py
+++ b/app/utils/eth_contract_utils.py
@@ -75,6 +75,8 @@ class _EthWeb3Context:
             loop = None
 
         if loop is None:
+            # Preserve a per-thread fallback instance for code paths that touch
+            # EthWeb3 before entering an event loop.
             try:
                 return cast(AsyncWeb3[Any], thread_local.eth_web3_without_loop)
             except AttributeError:
@@ -82,6 +84,8 @@ class _EthWeb3Context:
                 thread_local.eth_web3_without_loop = async_web3
                 return async_web3
 
+        # AsyncWeb3 instances are isolated per event loop because the provider
+        # session must not be shared across loops.
         try:
             eth_web3_by_loop = cast(
                 WeakKeyDictionary[asyncio.AbstractEventLoop, AsyncWeb3[Any]],
@@ -240,6 +244,7 @@ class EthAsyncContractEventsView:
 
 
 class EthAsyncContractUtils:
+    # Contract factories are bound to the AsyncWeb3 that created them.
     factory_map: WeakKeyDictionary[AsyncWeb3[Any], dict[str, type[AsyncContract]]] = (
         WeakKeyDictionary()
     )
@@ -324,6 +329,8 @@ class EthAsyncContractUtils:
         :param contract_address: contract address
         :return: Contract
         """
+        # Reuse factories only within the same AsyncWeb3 context so provider
+        # state and loop ownership stay consistent.
         current_async_web3 = EthWeb3.get_web3()
         contract_factory_map = cls.factory_map.get(current_async_web3)
         if contract_factory_map is None:

--- a/app/utils/eth_contract_utils.py
+++ b/app/utils/eth_contract_utils.py
@@ -23,6 +23,7 @@ import sys
 import threading
 from json import JSONDecodeError
 from typing import Any, TypeAlias, cast
+from weakref import WeakKeyDictionary
 
 from aiohttp import ClientError
 from eth_typing import URI, HexStr
@@ -58,6 +59,51 @@ LOG = log.get_logger()
 
 ContractArtifact: TypeAlias = dict[str, Any]
 EventArgumentFilters: TypeAlias = dict[str, Any] | None
+
+
+class _EthWeb3Context:
+    def __init__(self) -> None:
+        if "pytest" in sys.modules:
+            self._fail_over_mode = False
+        else:
+            self._fail_over_mode = True
+
+    def get_web3(self) -> AsyncWeb3[Any]:
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+
+        if loop is None:
+            try:
+                return cast(AsyncWeb3[Any], thread_local.eth_web3_without_loop)
+            except AttributeError:
+                async_web3 = self._create_web3()
+                thread_local.eth_web3_without_loop = async_web3
+                return async_web3
+
+        try:
+            eth_web3_by_loop = cast(
+                WeakKeyDictionary[asyncio.AbstractEventLoop, AsyncWeb3[Any]],
+                thread_local.eth_web3_by_loop,
+            )
+        except AttributeError:
+            eth_web3_by_loop: WeakKeyDictionary[
+                asyncio.AbstractEventLoop, AsyncWeb3[Any]
+            ] = WeakKeyDictionary()
+            thread_local.eth_web3_by_loop = eth_web3_by_loop
+
+        async_web3 = eth_web3_by_loop.get(loop)
+        if async_web3 is None:
+            async_web3 = self._create_web3()
+            eth_web3_by_loop[loop] = async_web3
+        return async_web3
+
+    def _create_web3(self) -> AsyncWeb3[Any]:
+        return AsyncWeb3(EthFailOverHTTPProvider(fail_over_mode=self._fail_over_mode))
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self.get_web3(), name)
 
 
 class EthFailOverHTTPProvider(AsyncHTTPProvider):
@@ -134,14 +180,7 @@ class EthFailOverHTTPProvider(AsyncHTTPProvider):
             await db_session.close()
 
 
-try:
-    EthWeb3 = thread_local.EthWeb3
-except AttributeError:
-    if "pytest" in sys.modules:  # For unit tests
-        EthWeb3 = AsyncWeb3(EthFailOverHTTPProvider(fail_over_mode=False))
-    else:
-        EthWeb3 = AsyncWeb3(EthFailOverHTTPProvider(fail_over_mode=True))
-    thread_local.EthWeb3 = EthWeb3
+EthWeb3 = _EthWeb3Context()
 
 
 class EthTxUtils:
@@ -201,7 +240,9 @@ class EthAsyncContractEventsView:
 
 
 class EthAsyncContractUtils:
-    factory_map: dict[str, type[AsyncContract]] = {}
+    factory_map: WeakKeyDictionary[AsyncWeb3[Any], dict[str, type[AsyncContract]]] = (
+        WeakKeyDictionary()
+    )
 
     @staticmethod
     def get_contract_code(contract_name: str) -> tuple[Any, Any, Any]:
@@ -283,15 +324,21 @@ class EthAsyncContractUtils:
         :param contract_address: contract address
         :return: Contract
         """
-        contract_factory = cls.factory_map.get(contract_name)
+        current_async_web3 = EthWeb3.get_web3()
+        contract_factory_map = cls.factory_map.get(current_async_web3)
+        if contract_factory_map is None:
+            contract_factory_map = {}
+            cls.factory_map[current_async_web3] = contract_factory_map
+
+        contract_factory = contract_factory_map.get(contract_name)
         if contract_factory is not None:
             return contract_factory(address=to_checksum_address(contract_address))
 
         contract_file = f"contracts/wst/{contract_name}.json"
         contract_json: ContractArtifact = json.load(open(contract_file, "r"))
 
-        contract_factory = EthWeb3.eth.contract(abi=contract_json["abi"])
-        cls.factory_map[contract_name] = contract_factory
+        contract_factory = current_async_web3.eth.contract(abi=contract_json["abi"])
+        contract_factory_map[contract_name] = contract_factory
         return contract_factory(address=to_checksum_address(contract_address))
 
     @staticmethod

--- a/app/utils/ibet_contract_utils.py
+++ b/app/utils/ibet_contract_utils.py
@@ -349,6 +349,8 @@ class AsyncContractEventsView:
 
 
 class AsyncContractUtils:
+    # web3.py contract factories retain the AsyncWeb3 used to create them, so
+    # keep a separate factory map per AsyncWeb3 instance.
     factory_map: WeakKeyDictionary[AsyncWeb3[Any], dict[str, type[AsyncContract]]] = (
         WeakKeyDictionary()
     )
@@ -437,6 +439,8 @@ class AsyncContractUtils:
         :param contract_address: contract address
         :return: Contract
         """
+        # Resolve the current AsyncWeb3 first so the factory cache follows the
+        # actual runtime context selected by AsyncWeb3Wrapper.
         current_async_web3 = async_web3.get_web3()
         contract_factory_map = cls.factory_map.get(current_async_web3)
         if contract_factory_map is None:

--- a/app/utils/ibet_contract_utils.py
+++ b/app/utils/ibet_contract_utils.py
@@ -19,6 +19,7 @@ SPDX-License-Identifier: Apache-2.0
 
 import json
 from typing import Any, TypeAlias, cast
+from weakref import WeakKeyDictionary
 
 from eth_typing import HexStr
 from eth_utils.address import to_checksum_address
@@ -27,6 +28,7 @@ from sqlalchemy import AsyncAdaptedQueuePool, create_engine, select
 from sqlalchemy.exc import DBAPIError, OperationalError
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import Session
+from web3 import AsyncWeb3
 from web3.contract import AsyncContract, Contract
 from web3.contract.async_contract import AsyncContractEvents
 from web3.exceptions import (
@@ -347,7 +349,9 @@ class AsyncContractEventsView:
 
 
 class AsyncContractUtils:
-    factory_map: dict[str, type[AsyncContract]] = {}
+    factory_map: WeakKeyDictionary[AsyncWeb3[Any], dict[str, type[AsyncContract]]] = (
+        WeakKeyDictionary()
+    )
 
     @staticmethod
     def get_contract_code(contract_name: str) -> tuple[Any, Any, Any]:
@@ -433,14 +437,20 @@ class AsyncContractUtils:
         :param contract_address: contract address
         :return: Contract
         """
-        contract_factory = cls.factory_map.get(contract_name)
+        current_async_web3 = async_web3.get_web3()
+        contract_factory_map = cls.factory_map.get(current_async_web3)
+        if contract_factory_map is None:
+            contract_factory_map = {}
+            cls.factory_map[current_async_web3] = contract_factory_map
+
+        contract_factory = contract_factory_map.get(contract_name)
         if contract_factory is not None:
             return contract_factory(address=to_checksum_address(contract_address))
 
         contract_file = f"contracts/ibet/{contract_name}.json"
         contract_json: ContractArtifact = json.load(open(contract_file, "r"))
-        contract_factory = async_web3.eth.contract(abi=contract_json["abi"])
-        cls.factory_map[contract_name] = contract_factory
+        contract_factory = current_async_web3.eth.contract(abi=contract_json["abi"])
+        contract_factory_map[contract_name] = contract_factory
         return contract_factory(address=to_checksum_address(contract_address))
 
     @staticmethod

--- a/app/utils/ibet_web3_utils.py
+++ b/app/utils/ibet_web3_utils.py
@@ -45,6 +45,8 @@ from config import WEB3_HTTP_PROVIDER, WEB3_REQUEST_RETRY_COUNT, WEB3_REQUEST_WA
 
 thread_local = threading.local()
 
+# Cache AsyncWeb3 by timeout shape so wrappers with different timeout settings
+# do not accidentally share the same provider/session.
 AsyncWeb3TimeoutKey = tuple[Any, Any, Any, Any]
 AsyncWeb3CacheMap = dict[AsyncWeb3TimeoutKey, AsyncWeb3[Any]]
 
@@ -124,6 +126,8 @@ class AsyncWeb3Wrapper:
     @classmethod
     def _get_web3(cls, request_timeout: int | ClientTimeout) -> AsyncWeb3[Any]:
         timeout = cls._normalize_async_timeout(request_timeout)
+        # Use normalized timeout fields as the cache key because ClientTimeout
+        # itself is mutable-like and not suitable as a stable dict key here.
         timeout_key: AsyncWeb3TimeoutKey = (
             timeout.total,
             timeout.connect,
@@ -137,6 +141,8 @@ class AsyncWeb3Wrapper:
             loop = None
 
         if loop is None:
+            # Some call sites still resolve AsyncWeb3 outside a running loop.
+            # Keep a separate per-thread cache for that fallback path.
             try:
                 async_web3_map = cast(
                     AsyncWeb3CacheMap,
@@ -152,6 +158,8 @@ class AsyncWeb3Wrapper:
                 async_web3_map[timeout_key] = async_web3
             return async_web3
 
+        # AsyncHTTPProvider owns an aiohttp session, so reuse is limited to the
+        # event loop that created it.
         try:
             async_web3_by_loop = cast(
                 WeakKeyDictionary[asyncio.AbstractEventLoop, AsyncWeb3CacheMap],

--- a/app/utils/ibet_web3_utils.py
+++ b/app/utils/ibet_web3_utils.py
@@ -22,9 +22,10 @@ import sys
 import threading
 import time
 from json.decoder import JSONDecodeError
-from typing import Any
+from typing import Any, cast
+from weakref import WeakKeyDictionary
 
-from aiohttp import ClientError
+from aiohttp import ClientError, ClientTimeout
 from eth_typing import URI
 from requests.exceptions import ConnectionError, HTTPError
 from sqlalchemy import select
@@ -43,6 +44,9 @@ from app.model.db import Node
 from config import WEB3_HTTP_PROVIDER, WEB3_REQUEST_RETRY_COUNT, WEB3_REQUEST_WAIT_TIME
 
 thread_local = threading.local()
+
+AsyncWeb3TimeoutKey = tuple[Any, Any, Any, Any]
+AsyncWeb3CacheMap = dict[AsyncWeb3TimeoutKey, AsyncWeb3[Any]]
 
 
 class Web3Wrapper:
@@ -86,38 +90,92 @@ class Web3Wrapper:
 class AsyncWeb3Wrapper:
     DEFAULT_TIMEOUT = 5
 
-    def __init__(self, request_timeout: int = DEFAULT_TIMEOUT):
+    def __init__(self, request_timeout: int | ClientTimeout = DEFAULT_TIMEOUT):
         if "pytest" not in sys.modules:
             AsyncFailOverHTTPProvider.set_fail_over_mode(True)
         self.request_timeout = request_timeout
 
     @property
     def eth(self) -> AsyncEth:
-        web3 = self._get_web3(self.request_timeout)
+        web3 = self.get_web3()
         return web3.eth
 
     @property
     def geth(self) -> AsyncGeth:
-        web3 = self._get_web3(self.request_timeout)
+        web3 = self.get_web3()
         return web3.geth
 
     @property
     def net(self) -> AsyncNet:
-        web3 = self._get_web3(self.request_timeout)
+        web3 = self.get_web3()
         return web3.net
 
-    @staticmethod
-    def _get_web3(request_timeout: int) -> AsyncWeb3[Any]:
-        # Get web3 for each thread because make to FailOverHTTPProvider thread-safe
-        try:
-            async_web3 = thread_local.async_web3
-        except AttributeError:
-            async_web3 = AsyncWeb3(
-                AsyncFailOverHTTPProvider(request_kwargs={"timeout": request_timeout})
-            )
-            async_web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
-            thread_local.async_web3 = async_web3
+    def get_web3(self) -> AsyncWeb3[Any]:
+        return self._get_web3(self.request_timeout)
 
+    @staticmethod
+    def _normalize_async_timeout(
+        request_timeout: int | ClientTimeout,
+    ) -> ClientTimeout:
+        if isinstance(request_timeout, ClientTimeout):
+            return request_timeout
+        return ClientTimeout(total=request_timeout)
+
+    @classmethod
+    def _get_web3(cls, request_timeout: int | ClientTimeout) -> AsyncWeb3[Any]:
+        timeout = cls._normalize_async_timeout(request_timeout)
+        timeout_key: AsyncWeb3TimeoutKey = (
+            timeout.total,
+            timeout.connect,
+            timeout.sock_connect,
+            timeout.sock_read,
+        )
+
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+
+        if loop is None:
+            try:
+                async_web3_map = cast(
+                    AsyncWeb3CacheMap,
+                    thread_local.async_web3_without_loop,
+                )
+            except AttributeError:
+                async_web3_map = {}
+                thread_local.async_web3_without_loop = async_web3_map
+
+            async_web3 = async_web3_map.get(timeout_key)
+            if async_web3 is None:
+                async_web3 = cls._create_web3(timeout)
+                async_web3_map[timeout_key] = async_web3
+            return async_web3
+
+        try:
+            async_web3_by_loop = cast(
+                WeakKeyDictionary[asyncio.AbstractEventLoop, AsyncWeb3CacheMap],
+                thread_local.async_web3_by_loop,
+            )
+        except AttributeError:
+            async_web3_by_loop: WeakKeyDictionary[
+                asyncio.AbstractEventLoop, AsyncWeb3CacheMap
+            ] = WeakKeyDictionary()
+            thread_local.async_web3_by_loop = async_web3_by_loop
+
+        loop_web3_map: AsyncWeb3CacheMap = async_web3_by_loop.setdefault(loop, {})
+        async_web3 = loop_web3_map.get(timeout_key)
+        if async_web3 is None:
+            async_web3 = cls._create_web3(timeout)
+            loop_web3_map[timeout_key] = async_web3
+        return async_web3
+
+    @staticmethod
+    def _create_web3(timeout: ClientTimeout) -> AsyncWeb3[Any]:
+        async_web3 = AsyncWeb3(
+            AsyncFailOverHTTPProvider(request_kwargs={"timeout": timeout})
+        )
+        async_web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
         return async_web3
 
 

--- a/tests/app/utils/test_ava_asynccontract_utils.py
+++ b/tests/app/utils/test_ava_asynccontract_utils.py
@@ -17,17 +17,24 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
+import asyncio
 import json
+from typing import Any, cast
 from unittest.mock import patch
 
 import pytest
 from hexbytes import HexBytes
-from web3 import Web3
+from web3 import AsyncHTTPProvider, AsyncWeb3, Web3
 from web3.exceptions import Web3Exception
 
 from app.exceptions import SendTransactionError
-from app.utils.ava_contract_utils import AvaAsyncContractUtils
+from app.utils import ava_contract_utils as contract_module
+from app.utils.ava_contract_utils import AvaAsyncContractUtils, AvaWeb3
 from tests.account_config import default_eth_account
+
+
+async def _get_ava_web3() -> AsyncWeb3[AsyncHTTPProvider]:
+    return AvaWeb3.get_web3()
 
 
 # Test for get_contract_code
@@ -167,6 +174,34 @@ class TestGetContract:
         assert contract is not None
         assert contract.address == Web3.to_checksum_address(contract_address)
 
+    # <Normal_2>
+    # Contract factory cache is scoped by AsyncWeb3 instance
+    async def test_normal_2(self, monkeypatch: pytest.MonkeyPatch):
+        web3_1 = AsyncWeb3(AsyncHTTPProvider("http://127.0.0.1:8545"))
+        web3_2 = AsyncWeb3(AsyncHTTPProvider("http://127.0.0.1:8545"))
+
+        contract_module.AvaAsyncContractUtils.factory_map.clear()
+
+        monkeypatch.setattr(contract_module.AvaWeb3, "get_web3", lambda: web3_1)
+        contract_1 = AvaAsyncContractUtils.get_contract(
+            contract_name="AuthIbetWST",
+            contract_address="0x0000000000000000000000000000000000000001",
+        )
+
+        monkeypatch.setattr(contract_module.AvaWeb3, "get_web3", lambda: web3_2)
+        contract_2 = AvaAsyncContractUtils.get_contract(
+            contract_name="AuthIbetWST",
+            contract_address="0x0000000000000000000000000000000000000002",
+        )
+
+        assert cast(Any, contract_1).w3 is web3_1
+        assert cast(Any, contract_2).w3 is web3_2
+        assert len(contract_module.AvaAsyncContractUtils.factory_map) == 2
+        assert len(contract_module.AvaAsyncContractUtils.factory_map[web3_1]) == 1
+        assert len(contract_module.AvaAsyncContractUtils.factory_map[web3_2]) == 1
+
+        contract_module.AvaAsyncContractUtils.factory_map.clear()
+
     ########################################################
     # Error
     ########################################################
@@ -196,6 +231,28 @@ class TestGetContract:
                 contract_name="NOT_EXIST_CONTRACT",
                 contract_address=contract_address,
             )
+
+
+# Test for AsyncWeb3 scope
+class TestAvaWeb3Scope:
+    # <Normal_1>
+    # AsyncWeb3 instance is scoped by event loop
+    def test_normal_1(self):
+        loops: list[asyncio.AbstractEventLoop] = []
+
+        def get_web3_for_new_loop() -> AsyncWeb3[AsyncHTTPProvider]:
+            loop = asyncio.new_event_loop()
+            loops.append(loop)
+            return loop.run_until_complete(_get_ava_web3())
+
+        async_web3_1 = get_web3_for_new_loop()
+        async_web3_2 = get_web3_for_new_loop()
+
+        try:
+            assert async_web3_1 is not async_web3_2
+        finally:
+            for loop in loops:
+                loop.close()
 
 
 # Test for call_function

--- a/tests/app/utils/test_eth_asynccontract_utils.py
+++ b/tests/app/utils/test_eth_asynccontract_utils.py
@@ -17,17 +17,24 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
+import asyncio
 import json
+from typing import Any, cast
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from hexbytes import HexBytes
-from web3 import Web3
+from web3 import AsyncHTTPProvider, AsyncWeb3, Web3
 from web3.exceptions import Web3Exception
 
 from app.exceptions import SendTransactionError
-from app.utils.eth_contract_utils import EthAsyncContractUtils, EthTxUtils
+from app.utils import eth_contract_utils as contract_module
+from app.utils.eth_contract_utils import EthAsyncContractUtils, EthTxUtils, EthWeb3
 from tests.account_config import default_eth_account
+
+
+async def _get_eth_web3() -> AsyncWeb3[AsyncHTTPProvider]:
+    return EthWeb3.get_web3()
 
 
 # Test for get_contract_code
@@ -167,6 +174,34 @@ class TestGetContract:
         assert contract is not None
         assert contract.address == Web3.to_checksum_address(contract_address)
 
+    # <Normal_2>
+    # Contract factory cache is scoped by AsyncWeb3 instance
+    async def test_normal_2(self, monkeypatch: pytest.MonkeyPatch):
+        web3_1 = AsyncWeb3(AsyncHTTPProvider("http://127.0.0.1:8545"))
+        web3_2 = AsyncWeb3(AsyncHTTPProvider("http://127.0.0.1:8545"))
+
+        contract_module.EthAsyncContractUtils.factory_map.clear()
+
+        monkeypatch.setattr(contract_module.EthWeb3, "get_web3", lambda: web3_1)
+        contract_1 = EthAsyncContractUtils.get_contract(
+            contract_name="AuthIbetWST",
+            contract_address="0x0000000000000000000000000000000000000001",
+        )
+
+        monkeypatch.setattr(contract_module.EthWeb3, "get_web3", lambda: web3_2)
+        contract_2 = EthAsyncContractUtils.get_contract(
+            contract_name="AuthIbetWST",
+            contract_address="0x0000000000000000000000000000000000000002",
+        )
+
+        assert cast(Any, contract_1).w3 is web3_1
+        assert cast(Any, contract_2).w3 is web3_2
+        assert len(contract_module.EthAsyncContractUtils.factory_map) == 2
+        assert len(contract_module.EthAsyncContractUtils.factory_map[web3_1]) == 1
+        assert len(contract_module.EthAsyncContractUtils.factory_map[web3_2]) == 1
+
+        contract_module.EthAsyncContractUtils.factory_map.clear()
+
     ########################################################
     # Error
     ########################################################
@@ -196,6 +231,28 @@ class TestGetContract:
                 contract_name="NOT_EXIST_CONTRACT",
                 contract_address=contract_address,
             )
+
+
+# Test for AsyncWeb3 scope
+class TestEthWeb3Scope:
+    # <Normal_1>
+    # AsyncWeb3 instance is scoped by event loop
+    def test_normal_1(self):
+        loops: list[asyncio.AbstractEventLoop] = []
+
+        def get_web3_for_new_loop() -> AsyncWeb3[AsyncHTTPProvider]:
+            loop = asyncio.new_event_loop()
+            loops.append(loop)
+            return loop.run_until_complete(_get_eth_web3())
+
+        async_web3_1 = get_web3_for_new_loop()
+        async_web3_2 = get_web3_for_new_loop()
+
+        try:
+            assert async_web3_1 is not async_web3_2
+        finally:
+            for loop in loops:
+                loop.close()
 
 
 # Test for call_function

--- a/tests/app/utils/test_ibet_asynccontract_utils.py
+++ b/tests/app/utils/test_ibet_asynccontract_utils.py
@@ -17,21 +17,25 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
+import asyncio
 import json
-from typing import Any
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from aiohttp import ClientTimeout
 from eth_keyfile.keyfile import decode_keyfile_json
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
-from web3 import Web3
+from web3 import AsyncHTTPProvider, AsyncWeb3, Web3
 from web3.exceptions import ContractLogicError, TimeExhausted, Web3Exception
 from web3.middleware import ExtraDataToPOAMiddleware
 
 from app.exceptions import ContractRevertError, SendTransactionError
 from app.model.db import TransactionLock
+from app.utils import ibet_contract_utils as contract_module
 from app.utils.ibet_contract_utils import AsyncContractUtils
+from app.utils.ibet_web3_utils import AsyncWeb3Wrapper
 from config import CHAIN_ID, TX_GAS_LIMIT, WEB3_HTTP_PROVIDER
 from tests.account_config import default_eth_account
 
@@ -41,6 +45,11 @@ web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
 
 
+async def _get_web3(wrapper: AsyncWeb3Wrapper) -> AsyncWeb3[AsyncHTTPProvider]:
+    return wrapper.get_web3()
+
+
+# Test for get_contract_code
 class TestGetContractCode:
     contract_list = [
         "IbetCoupon",
@@ -92,6 +101,7 @@ class TestGetContractCode:
             AsyncContractUtils.get_contract_code(contract_name="NO_EXISTS")
 
 
+# Test for deploy_contract
 class TestDeployContract:
     test_account = default_eth_account("user1")
     eoa_password = "password"
@@ -173,6 +183,7 @@ class TestDeployContract:
         assert str(ex_info.typename) == "SendTransactionError"
 
 
+# Test for deploy_contract
 class TestGetContract:
     test_account = default_eth_account("user1")
     eoa_password = "password"
@@ -210,6 +221,38 @@ class TestGetContract:
             assert contract.bytecode_runtime is None
             assert contract.address == test_address
 
+    # <Normal_2>
+    # Contract factory cache is scoped by AsyncWeb3 instance
+    @pytest.mark.asyncio
+    async def test_normal_2(self, monkeypatch: pytest.MonkeyPatch):
+        web3_1 = AsyncWeb3(AsyncHTTPProvider("http://127.0.0.1:8545"))
+        web3_2 = AsyncWeb3(AsyncHTTPProvider("http://127.0.0.1:8545"))
+
+        contract_module.AsyncContractUtils.factory_map.clear()
+
+        monkeypatch.setattr(contract_module.async_web3, "get_web3", lambda: web3_1)
+        contract_1 = AsyncContractUtils.get_contract(
+            contract_name="IbetShare",
+            contract_address="0x0000000000000000000000000000000000000001",
+        )
+
+        monkeypatch.setattr(contract_module.async_web3, "get_web3", lambda: web3_2)
+        contract_2 = AsyncContractUtils.get_contract(
+            contract_name="IbetShare",
+            contract_address="0x0000000000000000000000000000000000000002",
+        )
+
+        assert cast(Any, contract_1).w3 is web3_1
+        assert cast(Any, contract_2).w3 is web3_2
+        assert len(contract_module.AsyncContractUtils.factory_map) == 2
+        assert len(contract_module.AsyncContractUtils.factory_map[web3_1]) == 1
+        assert len(contract_module.AsyncContractUtils.factory_map[web3_2]) == 1
+
+        contract_module.AsyncContractUtils.factory_map.clear()
+
+    ###########################################################################
+    # Error Case
+    ###########################################################################
     # <Error_1>
     # Contract address is not address
     @pytest.mark.asyncio
@@ -231,6 +274,45 @@ class TestGetContract:
             )
 
 
+# Test for AsyncWeb3 scope
+class TestAsyncWeb3Wrapper:
+    # <Normal_1>
+    # Request timeout is normalized to ClientTimeout
+    def test_normal_1(self):
+        loop = asyncio.new_event_loop()
+        wrapper = AsyncWeb3Wrapper(5)
+
+        try:
+            async_web3 = loop.run_until_complete(_get_web3(wrapper))
+        finally:
+            loop.close()
+
+        timeout = cast(Any, async_web3.provider)._request_kwargs["timeout"]
+        assert isinstance(timeout, ClientTimeout)
+        assert timeout.total == 5
+
+    # <Normal_2>
+    # AsyncWeb3 instance is scoped by event loop
+    def test_normal_2(self):
+        wrapper = AsyncWeb3Wrapper()
+        loops: list[asyncio.AbstractEventLoop] = []
+
+        def get_web3_for_new_loop() -> AsyncWeb3[AsyncHTTPProvider]:
+            loop = asyncio.new_event_loop()
+            loops.append(loop)
+            return loop.run_until_complete(_get_web3(wrapper))
+
+        async_web3_1 = get_web3_for_new_loop()
+        async_web3_2 = get_web3_for_new_loop()
+
+        try:
+            assert async_web3_1 is not async_web3_2
+        finally:
+            for loop in loops:
+                loop.close()
+
+
+# Test for send_transaction
 class TestSendTransaction:
     test_account = default_eth_account("user1")
     eoa_password = "password"
@@ -464,6 +546,7 @@ class TestSendTransaction:
         await async_db.rollback()
 
 
+# Test for send_transaction_no_wait and wait_for_transaction_receipt
 class TestSendTransactionNoWait:
     test_account = default_eth_account("user1")
     eoa_password = "password"
@@ -670,6 +753,7 @@ class TestSendTransactionNoWait:
                 await AsyncContractUtils.wait_for_transaction_receipt(rtn_tx_hash)
 
 
+# Test for get_block_by_transaction_hash
 class TestGetBlockByTransactionHash:
     test_account = default_eth_account("user1")
     eoa_password = "password"
@@ -737,7 +821,3 @@ class TestGetBlockByTransactionHash:
         assert block_number == tx_receipt["blockNumber"]
         assert block_timestamp is not None
         assert block_timestamp > 0
-
-    ###########################################################################
-    # Error Case
-    ###########################################################################


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

Make AsyncWeb3 instances and contract factory caches scoped to event loops and request timeouts to avoid cross-loop/timeout state leakage.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
None

## 🔄 Changes

<!-- List the major changes in this PR. -->

- Introduce _AvaWeb3Context and _EthWeb3Context to lazily create and return AsyncWeb3 per running event loop (or per-thread if no loop).
- Use WeakKeyDictionary+thread-local maps to store AsyncWeb3 instances per asyncio loop and to keep factory_map keyed by AsyncWeb3 instances instead of global strings.
- Update ibet AsyncContractUtils to use per-web3 factory_map and import WeakKeyDictionary/AsyncWeb3 where needed.
- Normalize AsyncWeb3Wrapper request timeout to aiohttp.ClientTimeout and scope AsyncWeb3 instances by both event loop and timeout key; create per-timeout caches.
- Adjust provider fail-over mode selection to be controlled by the new web3 context classes.
- Add/extend unit tests to assert: AsyncWeb3 instances are loop-scoped, factory_map is scoped per AsyncWeb3, and AsyncWeb3Wrapper normalizes timeouts.

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
