### PR TITLE
Add web3 provider utils and endpoint cache

### DIFF
--- a/app/utils/ava_contract_utils.py
+++ b/app/utils/ava_contract_utils.py
@@ -47,6 +47,10 @@ from app.database import async_engine
 from app.exceptions import SendTransactionError, ServiceUnavailableError
 from app.model import EthereumAddress
 from app.model.db import AvalancheNode
+from app.utils.web3_provider_utils import (
+    KeepAliveHTTPSessionManager,
+    ResolvedEndpointCacheMixin,
+)
 from avalanche_config import (
     AVA_CHAIN_ID,
     AVA_WEB3_HTTP_PROVIDER,
@@ -104,17 +108,51 @@ class _AvaWeb3Context:
         return async_web3
 
     def _create_web3(self) -> AsyncWeb3[Any]:
-        return AsyncWeb3(AvaFailOverHTTPProvider(fail_over_mode=self._fail_over_mode))
+        return AsyncWeb3(
+            AvaFailOverHTTPProvider(
+                fail_over_mode=self._fail_over_mode,
+                session_manager=KeepAliveHTTPSessionManager(),
+            )
+        )
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self.get_web3(), name)
 
 
-class AvaFailOverHTTPProvider(AsyncHTTPProvider):
-    def __init__(self, fail_over_mode: bool = False, *args: Any, **kwargs: Any) -> None:
+class AvaFailOverHTTPProvider(ResolvedEndpointCacheMixin, AsyncHTTPProvider):
+    def __init__(
+        self,
+        fail_over_mode: bool = False,
+        session_manager: KeepAliveHTTPSessionManager | None = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
         super().__init__(*args, **kwargs)
+        self._init_resolved_endpoint_cache()
+        if session_manager is not None:
+            self._request_session_manager = session_manager
         self.fail_over_mode = fail_over_mode
         self.endpoint_uri: URI | None = None
+
+    async def _resolve_endpoint_uri(self, db_session: AsyncSession) -> URI | None:
+        cached_endpoint_uri = self._get_cached_endpoint_uri()
+        if cached_endpoint_uri is not None:
+            return cached_endpoint_uri
+
+        node: AvalancheNode | None = (
+            await db_session.scalars(
+                select(AvalancheNode)
+                .where(AvalancheNode.is_synced.is_(True))
+                .order_by(AvalancheNode.priority, AvalancheNode.id)
+                .limit(1)
+            )
+        ).first()
+        if node is None or node.endpoint_uri is None:
+            return None
+
+        endpoint_uri = URI(node.endpoint_uri)
+        self._set_cached_endpoint_uri(endpoint_uri)
+        return endpoint_uri
 
     async def make_request(self, method: RPCEndpoint, params: Any) -> RPCResponse:
         """Make an HTTP request to the Avalanche node."""
@@ -122,6 +160,17 @@ class AvaFailOverHTTPProvider(AsyncHTTPProvider):
         db_session = AsyncSession(autocommit=False, autoflush=True, bind=async_engine)
         try:
             if self.fail_over_mode:
+                cached_endpoint_uri = self._get_cached_endpoint_uri()
+                if cached_endpoint_uri is not None:
+                    self.endpoint_uri = cached_endpoint_uri
+                    try:
+                        return await super().make_request(method, params)
+                    except ClientError, JSONDecodeError:
+                        self._clear_cached_endpoint_uri()
+                        LOG.info(
+                            f"Retry web3 request due to connection fail: method={method}, params={params}"
+                        )
+
                 # If the block synchronization monitoring process has not started yet, connect to the primary node.
                 node = (
                     await db_session.scalars(select(AvalancheNode).limit(1))
@@ -132,16 +181,8 @@ class AvaFailOverHTTPProvider(AsyncHTTPProvider):
 
                 counter = 0
                 while counter <= AVA_WEB3_REQUEST_RETRY_COUNT:
-                    # Switch to an available node
-                    node: AvalancheNode | None = (
-                        await db_session.scalars(
-                            select(AvalancheNode)
-                            .where(AvalancheNode.is_synced.is_(True))
-                            .order_by(AvalancheNode.priority, AvalancheNode.id)
-                            .limit(1)
-                        )
-                    ).first()
-                    if node is None:
+                    endpoint_uri = await self._resolve_endpoint_uri(db_session)
+                    if endpoint_uri is None:
                         counter += 1
                         # If the number of retries is within the limit, retry.
                         if counter <= AVA_WEB3_REQUEST_RETRY_COUNT:
@@ -152,21 +193,13 @@ class AvaFailOverHTTPProvider(AsyncHTTPProvider):
                             "Cannot connect to any Avalanche node"
                         )
 
-                    if node.endpoint_uri is None:
-                        counter += 1
-                        if counter <= AVA_WEB3_REQUEST_RETRY_COUNT:
-                            await asyncio.sleep(AVA_WEB3_REQUEST_WAIT_TIME)
-                            continue
-                        raise ServiceUnavailableError(
-                            "Cannot connect to any Avalanche node"
-                        )
-
-                    self.endpoint_uri = URI(node.endpoint_uri)
+                    self.endpoint_uri = endpoint_uri
                     try:
                         # Send request
                         return await super().make_request(method, params)
                     except ClientError, JSONDecodeError:
                         # JSONDecodeError may occur when sending a request during geth shutdown, etc.
+                        self._clear_cached_endpoint_uri()
                         LOG.info(
                             f"Retry web3 request due to connection fail: method={method}, params={params}"
                         )

--- a/app/utils/ava_contract_utils.py
+++ b/app/utils/ava_contract_utils.py
@@ -134,6 +134,9 @@ class AvaFailOverHTTPProvider(ResolvedEndpointCacheMixin, AsyncHTTPProvider):
         self.fail_over_mode = fail_over_mode
         self.endpoint_uri: URI | None = None
 
+    def _get_cache_ttl(self) -> float:
+        return float(AVA_WEB3_REQUEST_WAIT_TIME)
+
     async def _resolve_endpoint_uri(self, db_session: AsyncSession) -> URI | None:
         cached_endpoint_uri = self._get_cached_endpoint_uri()
         if cached_endpoint_uri is not None:

--- a/app/utils/eth_contract_utils.py
+++ b/app/utils/eth_contract_utils.py
@@ -47,6 +47,10 @@ from app.database import async_engine
 from app.exceptions import SendTransactionError, ServiceUnavailableError
 from app.model import EthereumAddress
 from app.model.db import EthereumNode
+from app.utils.web3_provider_utils import (
+    KeepAliveHTTPSessionManager,
+    ResolvedEndpointCacheMixin,
+)
 from eth_config import (
     ETH_CHAIN_ID,
     ETH_WEB3_HTTP_PROVIDER,
@@ -104,22 +108,51 @@ class _EthWeb3Context:
         return async_web3
 
     def _create_web3(self) -> AsyncWeb3[Any]:
-        return AsyncWeb3(EthFailOverHTTPProvider(fail_over_mode=self._fail_over_mode))
+        return AsyncWeb3(
+            EthFailOverHTTPProvider(
+                fail_over_mode=self._fail_over_mode,
+                session_manager=KeepAliveHTTPSessionManager(),
+            )
+        )
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self.get_web3(), name)
 
 
-class EthFailOverHTTPProvider(AsyncHTTPProvider):
+class EthFailOverHTTPProvider(ResolvedEndpointCacheMixin, AsyncHTTPProvider):
     def __init__(
         self,
         fail_over_mode: bool = False,
+        session_manager: KeepAliveHTTPSessionManager | None = None,
         *args: Any,
         **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
+        self._init_resolved_endpoint_cache()
+        if session_manager is not None:
+            self._request_session_manager = session_manager
         self.fail_over_mode = fail_over_mode
-        self.endpoint_uri = None
+        self.endpoint_uri: URI | None = None
+
+    async def _resolve_endpoint_uri(self, db_session: AsyncSession) -> URI | None:
+        cached_endpoint_uri = self._get_cached_endpoint_uri()
+        if cached_endpoint_uri is not None:
+            return cached_endpoint_uri
+
+        node: EthereumNode | None = (
+            await db_session.scalars(
+                select(EthereumNode)
+                .where(EthereumNode.is_synced.is_(True))
+                .order_by(EthereumNode.priority, EthereumNode.id)
+                .limit(1)
+            )
+        ).first()
+        if node is None or node.endpoint_uri is None:
+            return None
+
+        endpoint_uri = URI(node.endpoint_uri)
+        self._set_cached_endpoint_uri(endpoint_uri)
+        return endpoint_uri
 
     async def make_request(self, method: RPCEndpoint, params: Any) -> RPCResponse:
         """Make an HTTP request to the Ethereum node."""
@@ -127,6 +160,17 @@ class EthFailOverHTTPProvider(AsyncHTTPProvider):
         db_session = AsyncSession(autocommit=False, autoflush=True, bind=async_engine)
         try:
             if self.fail_over_mode:
+                cached_endpoint_uri = self._get_cached_endpoint_uri()
+                if cached_endpoint_uri is not None:
+                    self.endpoint_uri = cached_endpoint_uri
+                    try:
+                        return await super().make_request(method, params)
+                    except ClientError, JSONDecodeError:
+                        self._clear_cached_endpoint_uri()
+                        LOG.info(
+                            f"Retry web3 request due to connection fail: method={method}, params={params}"
+                        )
+
                 # If the block synchronization monitoring process has not started yet, connect to the primary node.
                 node = (await db_session.scalars(select(EthereumNode).limit(1))).first()
                 if node is None:
@@ -135,16 +179,8 @@ class EthFailOverHTTPProvider(AsyncHTTPProvider):
 
                 counter = 0
                 while counter <= ETH_WEB3_REQUEST_RETRY_COUNT:
-                    # Switch to an available node
-                    node: EthereumNode | None = (
-                        await db_session.scalars(
-                            select(EthereumNode)
-                            .where(EthereumNode.is_synced.is_(True))
-                            .order_by(EthereumNode.priority, EthereumNode.id)
-                            .limit(1)
-                        )
-                    ).first()
-                    if node is None:
+                    endpoint_uri = await self._resolve_endpoint_uri(db_session)
+                    if endpoint_uri is None:
                         counter += 1
                         # If the number of retries is within the limit, retry.
                         if counter <= ETH_WEB3_REQUEST_RETRY_COUNT:
@@ -155,13 +191,13 @@ class EthFailOverHTTPProvider(AsyncHTTPProvider):
                             "Cannot connect to any Ethereum node"
                         )
 
-                    assert node.endpoint_uri is not None
-                    self.endpoint_uri = URI(node.endpoint_uri)
+                    self.endpoint_uri = endpoint_uri
                     try:
                         # Send request
                         return await super().make_request(method, params)
                     except ClientError, JSONDecodeError:
                         # JSONDecodeError may occur when sending a request during geth shutdown, etc.
+                        self._clear_cached_endpoint_uri()
                         LOG.info(
                             f"Retry web3 request due to connection fail: method={method}, params={params}"
                         )

--- a/app/utils/eth_contract_utils.py
+++ b/app/utils/eth_contract_utils.py
@@ -134,6 +134,9 @@ class EthFailOverHTTPProvider(ResolvedEndpointCacheMixin, AsyncHTTPProvider):
         self.fail_over_mode = fail_over_mode
         self.endpoint_uri: URI | None = None
 
+    def _get_cache_ttl(self) -> float:
+        return float(ETH_WEB3_REQUEST_WAIT_TIME)
+
     async def _resolve_endpoint_uri(self, db_session: AsyncSession) -> URI | None:
         cached_endpoint_uri = self._get_cached_endpoint_uri()
         if cached_endpoint_uri is not None:

--- a/app/utils/ibet_web3_utils.py
+++ b/app/utils/ibet_web3_utils.py
@@ -208,6 +208,9 @@ class FailOverHTTPProvider(ResolvedEndpointCacheMixin, HTTPProvider):
         self._init_resolved_endpoint_cache()
         self.endpoint_uri: URI | None = None
 
+    def _get_cache_ttl(self) -> float:
+        return float(WEB3_REQUEST_WAIT_TIME)
+
     def _resolve_endpoint_uri(self, db_session: Session) -> URI | None:
         cached_endpoint_uri = self._get_cached_endpoint_uri()
         if cached_endpoint_uri is not None:
@@ -296,6 +299,9 @@ class AsyncFailOverHTTPProvider(ResolvedEndpointCacheMixin, AsyncHTTPProvider):
         if session_manager is not None:
             self._request_session_manager = session_manager
         self.endpoint_uri: URI | None = None
+
+    def _get_cache_ttl(self) -> float:
+        return float(WEB3_REQUEST_WAIT_TIME)
 
     async def _resolve_endpoint_uri(self, db_session: AsyncSession) -> URI | None:
         cached_endpoint_uri = self._get_cached_endpoint_uri()

--- a/app/utils/ibet_web3_utils.py
+++ b/app/utils/ibet_web3_utils.py
@@ -38,12 +38,18 @@ from web3.middleware import ExtraDataToPOAMiddleware
 from web3.net import AsyncNet
 from web3.types import RPCEndpoint, RPCResponse
 
+from app import log
 from app.database import async_engine, engine
 from app.exceptions import ServiceUnavailableError
 from app.model.db import Node
+from app.utils.web3_provider_utils import (
+    KeepAliveHTTPSessionManager,
+    ResolvedEndpointCacheMixin,
+)
 from config import WEB3_HTTP_PROVIDER, WEB3_REQUEST_RETRY_COUNT, WEB3_REQUEST_WAIT_TIME
 
 thread_local = threading.local()
+LOG = log.get_logger()
 
 # Cache AsyncWeb3 by timeout shape so wrappers with different timeout settings
 # do not accidentally share the same provider/session.
@@ -181,13 +187,16 @@ class AsyncWeb3Wrapper:
     @staticmethod
     def _create_web3(timeout: ClientTimeout) -> AsyncWeb3[Any]:
         async_web3 = AsyncWeb3(
-            AsyncFailOverHTTPProvider(request_kwargs={"timeout": timeout})
+            AsyncFailOverHTTPProvider(
+                request_kwargs={"timeout": timeout},
+                session_manager=KeepAliveHTTPSessionManager(),
+            )
         )
         async_web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
         return async_web3
 
 
-class FailOverHTTPProvider(HTTPProvider):
+class FailOverHTTPProvider(ResolvedEndpointCacheMixin, HTTPProvider):
     fail_over_mode = False  # If False, use only the default(primary) provider
 
     def __init__(
@@ -196,12 +205,44 @@ class FailOverHTTPProvider(HTTPProvider):
         **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
+        self._init_resolved_endpoint_cache()
         self.endpoint_uri: URI | None = None
+
+    def _resolve_endpoint_uri(self, db_session: Session) -> URI | None:
+        cached_endpoint_uri = self._get_cached_endpoint_uri()
+        if cached_endpoint_uri is not None:
+            return cached_endpoint_uri
+
+        node = db_session.scalars(
+            select(Node)
+            .where(Node.is_synced == True)
+            .order_by(Node.priority, Node.id)
+            .limit(1)
+        ).first()
+        if node is None or node.endpoint_uri is None:
+            return None
+
+        endpoint_uri = URI(node.endpoint_uri)
+        self._set_cached_endpoint_uri(endpoint_uri)
+        return endpoint_uri
 
     def make_request(self, method: RPCEndpoint, params: Any) -> RPCResponse:
         db_session = Session(autocommit=False, autoflush=True, bind=engine)
         try:
             if FailOverHTTPProvider.fail_over_mode is True:
+                # Try cached endpoint first to avoid unnecessary DB query,
+                # and fallback to resolving from DB if it fails.
+                cached_endpoint_uri = self._get_cached_endpoint_uri()
+                if cached_endpoint_uri is not None:
+                    self.endpoint_uri = cached_endpoint_uri
+                    try:
+                        return super().make_request(method, params)
+                    except ConnectionError, JSONDecodeError, HTTPError:
+                        self._clear_cached_endpoint_uri()
+                        LOG.info(
+                            f"Retry web3 request due to connection fail: method={method}, params={params}"
+                        )
+
                 # If never running the block monitoring processor,
                 # use default(primary) node.
                 if db_session.scalars(select(Node).limit(1)).first() is None:
@@ -209,27 +250,21 @@ class FailOverHTTPProvider(HTTPProvider):
                     return super().make_request(method, params)
                 counter = 0
                 while counter <= WEB3_REQUEST_RETRY_COUNT:
-                    # Switch alive node
-                    _node = db_session.scalars(
-                        select(Node)
-                        .where(Node.is_synced == True)
-                        .order_by(Node.priority, Node.id)
-                        .limit(1)
-                    ).first()
-                    if _node is None:
+                    endpoint_uri = self._resolve_endpoint_uri(db_session)
+                    if endpoint_uri is None:
                         counter += 1
                         if counter <= WEB3_REQUEST_RETRY_COUNT:
                             time.sleep(WEB3_REQUEST_WAIT_TIME)
                             continue
                         raise ServiceUnavailableError("Block synchronization is down")
-                    assert _node.endpoint_uri is not None
-                    self.endpoint_uri = URI(_node.endpoint_uri)
+                    self.endpoint_uri = endpoint_uri
                     try:
                         return super().make_request(method, params)
                     except ConnectionError, JSONDecodeError, HTTPError:
                         # NOTE:
                         #  JSONDecodeError will be raised if a request is sent
                         #  while Quorum is terminating.
+                        self._clear_cached_endpoint_uri()
                         counter += 1
                         if counter <= WEB3_REQUEST_RETRY_COUNT:
                             time.sleep(WEB3_REQUEST_WAIT_TIME)
@@ -247,21 +282,58 @@ class FailOverHTTPProvider(HTTPProvider):
         FailOverHTTPProvider.fail_over_mode = use_fail_over
 
 
-class AsyncFailOverHTTPProvider(AsyncHTTPProvider):
+class AsyncFailOverHTTPProvider(ResolvedEndpointCacheMixin, AsyncHTTPProvider):
     fail_over_mode = False  # If False, use only the default(primary) provider
 
     def __init__(
         self,
+        session_manager: KeepAliveHTTPSessionManager | None = None,
         *args: Any,
         **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
+        self._init_resolved_endpoint_cache()
+        if session_manager is not None:
+            self._request_session_manager = session_manager
         self.endpoint_uri: URI | None = None
+
+    async def _resolve_endpoint_uri(self, db_session: AsyncSession) -> URI | None:
+        cached_endpoint_uri = self._get_cached_endpoint_uri()
+        if cached_endpoint_uri is not None:
+            return cached_endpoint_uri
+
+        node = (
+            await db_session.scalars(
+                select(Node)
+                .where(Node.is_synced == True)
+                .order_by(Node.priority, Node.id)
+                .limit(1)
+            )
+        ).first()
+        if node is None or node.endpoint_uri is None:
+            return None
+
+        endpoint_uri = URI(node.endpoint_uri)
+        self._set_cached_endpoint_uri(endpoint_uri)
+        return endpoint_uri
 
     async def make_request(self, method: RPCEndpoint, params: Any) -> RPCResponse:
         db_session = AsyncSession(autocommit=False, autoflush=True, bind=async_engine)
         try:
             if AsyncFailOverHTTPProvider.fail_over_mode is True:
+                # Try cached endpoint first to avoid unnecessary DB query,
+                # and fallback to resolving from DB if it fails.
+                cached_endpoint_uri = self._get_cached_endpoint_uri()
+                if cached_endpoint_uri is not None:
+                    self.endpoint_uri = cached_endpoint_uri
+                    try:
+                        return await super().make_request(method, params)
+                    except ClientError, JSONDecodeError:
+                        self._clear_cached_endpoint_uri()
+                        LOG.info(
+                            f"Retry web3 request due to connection fail: method={method}, params={params}"
+                        )
+
                 # If never running the block monitoring processor,
                 # use default(primary) node.
                 if (await db_session.scalars(select(Node).limit(1))).first() is None:
@@ -269,29 +341,21 @@ class AsyncFailOverHTTPProvider(AsyncHTTPProvider):
                     return await super().make_request(method, params)
                 counter = 0
                 while counter <= WEB3_REQUEST_RETRY_COUNT:
-                    # Switch alive node
-                    _node = (
-                        await db_session.scalars(
-                            select(Node)
-                            .where(Node.is_synced == True)
-                            .order_by(Node.priority, Node.id)
-                            .limit(1)
-                        )
-                    ).first()
-                    if _node is None:
+                    endpoint_uri = await self._resolve_endpoint_uri(db_session)
+                    if endpoint_uri is None:
                         counter += 1
                         if counter <= WEB3_REQUEST_RETRY_COUNT:
                             await asyncio.sleep(WEB3_REQUEST_WAIT_TIME)
                             continue
                         raise ServiceUnavailableError("Block synchronization is down")
-                    assert _node.endpoint_uri is not None
-                    self.endpoint_uri = URI(_node.endpoint_uri)
+                    self.endpoint_uri = endpoint_uri
                     try:
                         return await super().make_request(method, params)
                     except ClientError, JSONDecodeError:
                         # NOTE:
                         #  JSONDecodeError will be raised if a request is sent
                         #  while Quorum is terminating.
+                        self._clear_cached_endpoint_uri()
                         counter += 1
                         if counter <= WEB3_REQUEST_RETRY_COUNT:
                             await asyncio.sleep(WEB3_REQUEST_WAIT_TIME)

--- a/app/utils/web3_provider_utils.py
+++ b/app/utils/web3_provider_utils.py
@@ -1,0 +1,165 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import asyncio
+import time
+from dataclasses import dataclass
+from typing import cast
+
+from aiohttp import ClientSession, ClientTimeout, TCPConnector
+from eth_typing import URI
+from web3._utils.async_caching import async_lock
+from web3._utils.caching.caching_utils import generate_cache_key
+from web3._utils.http import DEFAULT_HTTP_TIMEOUT
+from web3._utils.http_session_manager import HTTPSessionManager
+
+DEFAULT_RESOLVED_ENDPOINT_CACHE_TTL = 1.0
+
+
+@dataclass
+class ResolvedEndpointCache:
+    endpoint_uri: URI
+    expires_at: float
+
+
+class ResolvedEndpointCacheMixin:
+    def _init_resolved_endpoint_cache(self) -> None:
+        self._resolved_endpoint_cache: ResolvedEndpointCache | None = None
+
+    def _get_cache_ttl(self) -> float:
+        return DEFAULT_RESOLVED_ENDPOINT_CACHE_TTL
+
+    def _get_cached_endpoint_uri(self) -> URI | None:
+        cached_endpoint = self._resolved_endpoint_cache
+        if cached_endpoint is None:
+            return None
+        # TTL expiry is handled lazily on access so the provider does not need
+        # a separate cleanup path between requests.
+        if cached_endpoint.expires_at <= time.monotonic():
+            self._clear_cached_endpoint_uri()
+            return None
+        return cached_endpoint.endpoint_uri
+
+    def _set_cached_endpoint_uri(self, endpoint_uri: URI) -> None:
+        self._resolved_endpoint_cache = ResolvedEndpointCache(
+            endpoint_uri=endpoint_uri,
+            expires_at=time.monotonic() + self._get_cache_ttl(),
+        )
+
+    def _clear_cached_endpoint_uri(self) -> None:
+        self._resolved_endpoint_cache = None
+
+
+class KeepAliveHTTPSessionManager(HTTPSessionManager):
+    @staticmethod
+    def _create_async_session() -> ClientSession:
+        # Keep the connector reusable so repeated RPC calls share connections.
+        return ClientSession(
+            raise_for_status=True,
+            connector=TCPConnector(),
+        )
+
+    async def async_cache_and_return_session(
+        self,
+        endpoint_uri: URI,
+        session: ClientSession | None = None,
+        request_timeout: ClientTimeout | None = None,
+    ) -> ClientSession:
+        # Preserve async HTTP keep-alive for RPC-heavy workloads.
+        cache_key = self._async_session_cache_key(endpoint_uri)
+
+        evicted_items = None
+        cached_session: ClientSession | None = None
+        async with async_lock(self.session_pool, self._lock):
+            if cache_key not in self.session_cache:
+                if session is None:
+                    session = self._create_async_session()
+
+                cached_session, evicted_items = self.session_cache.cache(
+                    cache_key, session
+                )
+                self.logger.debug(
+                    "Async session cached: %s, %s", endpoint_uri, cached_session
+                )
+
+            else:
+                cached_session = cast(
+                    ClientSession,
+                    self.session_cache.get_cache_entry(cache_key),
+                )
+                session_is_closed = cached_session.closed
+                session_loop = getattr(cached_session, "_loop", None)
+                session_loop_is_closed = bool(
+                    session_loop is not None and session_loop.is_closed()
+                )
+
+                warning = (
+                    "Async session was closed"
+                    if session_is_closed
+                    else (
+                        "Loop was closed for async session"
+                        if session_loop_is_closed
+                        else None
+                    )
+                )
+                if warning:
+                    self.logger.debug(
+                        "%s: %s, %s. Creating and caching a new async session for uri.",
+                        warning,
+                        endpoint_uri,
+                        cached_session,
+                    )
+
+                    self.session_cache.pop(cache_key)
+                    if not session_is_closed:
+                        await cached_session.close()
+                    self.logger.debug(
+                        "Async session closed and evicted from cache: %s",
+                        cached_session,
+                    )
+
+                    replacement_session = self._create_async_session()
+                    cached_session, evicted_items = self.session_cache.cache(
+                        cache_key, replacement_session
+                    )
+                    self.logger.debug(
+                        "Async session cached: %s, %s", endpoint_uri, cached_session
+                    )
+
+        if evicted_items is not None:
+            evicted_sessions = list(evicted_items.values())
+            for evicted_session in evicted_sessions:
+                self.logger.debug(
+                    "Async session cache full. Session evicted from cache: %s",
+                    evicted_session,
+                )
+            timeout_total = DEFAULT_HTTP_TIMEOUT
+            if request_timeout is not None and request_timeout.total is not None:
+                timeout_total = request_timeout.total
+            asyncio.create_task(
+                self._async_close_evicted_sessions(
+                    timeout_total + 0.1,
+                    evicted_sessions,
+                )
+            )
+
+        assert cached_session is not None
+        return cached_session
+
+    @staticmethod
+    def _async_session_cache_key(endpoint_uri: URI) -> str:
+        return generate_cache_key(f"{id(asyncio.get_event_loop())}:{endpoint_uri}")

--- a/tests/app/utils/test_ava_asynccontract_utils.py
+++ b/tests/app/utils/test_ava_asynccontract_utils.py
@@ -30,6 +30,7 @@ from web3.exceptions import Web3Exception
 from app.exceptions import SendTransactionError
 from app.utils import ava_contract_utils as contract_module
 from app.utils.ava_contract_utils import AvaAsyncContractUtils, AvaWeb3
+from app.utils.web3_provider_utils import KeepAliveHTTPSessionManager
 from tests.account_config import default_eth_account
 
 
@@ -253,6 +254,19 @@ class TestAvaWeb3Scope:
         finally:
             for loop in loops:
                 loop.close()
+
+    # <Normal_2>
+    # Async provider uses the shared keep-alive session manager
+    def test_normal_2(self):
+        loop = asyncio.new_event_loop()
+
+        try:
+            async_web3 = loop.run_until_complete(_get_ava_web3())
+        finally:
+            loop.close()
+
+        session_manager = cast(Any, async_web3.provider)._request_session_manager
+        assert isinstance(session_manager, KeepAliveHTTPSessionManager)
 
 
 # Test for call_function

--- a/tests/app/utils/test_ava_failover_http_provider.py
+++ b/tests/app/utils/test_ava_failover_http_provider.py
@@ -17,15 +17,19 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
+from types import SimpleNamespace
 from unittest import mock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 from web3 import AsyncWeb3
+from web3.types import RPCEndpoint
 
 from app.exceptions import ServiceUnavailableError
 from app.model.db import AvalancheNode
 from app.utils.ava_contract_utils import AvaFailOverHTTPProvider
+from app.utils.web3_provider_utils import KeepAliveHTTPSessionManager
 from avalanche_config import AVA_WEB3_HTTP_PROVIDER
 
 
@@ -39,9 +43,13 @@ class TestAvaFailOverHTTPProvider:
     # - Test that the provider connects successfully when fail_over_mode is False
     async def test_normal_1(self):
         web3 = AsyncWeb3(AvaFailOverHTTPProvider(fail_over_mode=False))
-        assert (await web3.is_connected()) is True
+        try:
+            assert (await web3.is_connected()) is True
+        finally:
+            await web3.provider.disconnect()
 
     # Normal_2
+    # - Test that the provider connects successfully when fail_over_mode is True
     async def test_normal_2(self, async_db: AsyncSession):
         # Add a node information to the database
         node = AvalancheNode(
@@ -50,9 +58,52 @@ class TestAvaFailOverHTTPProvider:
         async_db.add(node)
         await async_db.commit()
 
-        # Test that the provider connects successfully when fail_over_mode is True
         web3 = AsyncWeb3(AvaFailOverHTTPProvider(fail_over_mode=True))
-        assert (await web3.is_connected()) is True
+        try:
+            assert (await web3.is_connected()) is True
+        finally:
+            await web3.provider.disconnect()
+
+    # Normal_3
+    # - Test that the provider reuses a cached endpoint without querying the DB again
+    async def test_normal_3(self):
+        provider = AvaFailOverHTTPProvider(
+            fail_over_mode=True,
+            session_manager=KeepAliveHTTPSessionManager(),
+        )
+        method = RPCEndpoint("eth_chainId")
+        fake_session = MagicMock()
+        fake_session.scalars = AsyncMock(
+            side_effect=[
+                MagicMock(first=MagicMock(return_value=object())),
+                MagicMock(
+                    first=MagicMock(
+                        return_value=SimpleNamespace(
+                            endpoint_uri=AVA_WEB3_HTTP_PROVIDER
+                        )
+                    )
+                ),
+            ]
+        )
+        fake_session.close = AsyncMock()
+
+        with (
+            patch(
+                "app.utils.ava_contract_utils.AsyncSession", return_value=fake_session
+            ),
+            patch(
+                "web3.providers.rpc.async_rpc.AsyncHTTPProvider.make_request",
+                AsyncMock(return_value={"result": "ok"}),
+            ) as make_request,
+        ):
+            first_response = await provider.make_request(method, [])
+            second_response = await provider.make_request(method, [])
+
+        assert first_response == {"result": "ok"}
+        assert second_response == {"result": "ok"}
+        assert fake_session.scalars.await_count == 2
+        assert make_request.await_count == 2
+        assert fake_session.close.await_count == 2
 
     ########################################################
     # Error
@@ -71,10 +122,13 @@ class TestAvaFailOverHTTPProvider:
 
         # Test that an error is raised
         web3 = AsyncWeb3(AvaFailOverHTTPProvider(fail_over_mode=True))
-        with pytest.raises(
-            ServiceUnavailableError, match="Cannot connect to any Avalanche node"
-        ):
-            await web3.is_connected()
+        try:
+            with pytest.raises(
+                ServiceUnavailableError, match="Cannot connect to any Avalanche node"
+            ):
+                await web3.is_connected()
+        finally:
+            await web3.provider.disconnect()
 
     # Error_2
     # - Test that an error is raised when no nodes are available
@@ -87,7 +141,10 @@ class TestAvaFailOverHTTPProvider:
 
         # Test that an error is raised
         web3 = AsyncWeb3(AvaFailOverHTTPProvider(fail_over_mode=True))
-        with pytest.raises(
-            ServiceUnavailableError, match="Cannot connect to any Avalanche node"
-        ):
-            await web3.is_connected()
+        try:
+            with pytest.raises(
+                ServiceUnavailableError, match="Cannot connect to any Avalanche node"
+            ):
+                await web3.is_connected()
+        finally:
+            await web3.provider.disconnect()

--- a/tests/app/utils/test_eth_asynccontract_utils.py
+++ b/tests/app/utils/test_eth_asynccontract_utils.py
@@ -30,6 +30,7 @@ from web3.exceptions import Web3Exception
 from app.exceptions import SendTransactionError
 from app.utils import eth_contract_utils as contract_module
 from app.utils.eth_contract_utils import EthAsyncContractUtils, EthTxUtils, EthWeb3
+from app.utils.web3_provider_utils import KeepAliveHTTPSessionManager
 from tests.account_config import default_eth_account
 
 
@@ -253,6 +254,19 @@ class TestEthWeb3Scope:
         finally:
             for loop in loops:
                 loop.close()
+
+    # <Normal_2>
+    # Async provider uses the shared keep-alive session manager
+    def test_normal_2(self):
+        loop = asyncio.new_event_loop()
+
+        try:
+            async_web3 = loop.run_until_complete(_get_eth_web3())
+        finally:
+            loop.close()
+
+        session_manager = cast(Any, async_web3.provider)._request_session_manager
+        assert isinstance(session_manager, KeepAliveHTTPSessionManager)
 
 
 # Test for call_function

--- a/tests/app/utils/test_eth_failover_http_provider.py
+++ b/tests/app/utils/test_eth_failover_http_provider.py
@@ -17,15 +17,19 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
+from types import SimpleNamespace
 from unittest import mock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 from web3 import AsyncWeb3
+from web3.types import RPCEndpoint
 
 from app.exceptions import ServiceUnavailableError
 from app.model.db import EthereumNode
 from app.utils.eth_contract_utils import EthFailOverHTTPProvider
+from app.utils.web3_provider_utils import KeepAliveHTTPSessionManager
 from eth_config import ETH_WEB3_HTTP_PROVIDER
 
 
@@ -39,7 +43,10 @@ class TestEthFailOverHTTPProvider:
     # - Test that the provider connects successfully when fail_over_mode is False
     async def test_normal_1(self):
         web3 = AsyncWeb3(EthFailOverHTTPProvider(fail_over_mode=False))
-        assert (await web3.is_connected()) is True
+        try:
+            assert (await web3.is_connected()) is True
+        finally:
+            await web3.provider.disconnect()
 
     # Normal_2
     async def test_normal_2(self, async_db: AsyncSession):
@@ -52,7 +59,51 @@ class TestEthFailOverHTTPProvider:
 
         # Test that the provider connects successfully when fail_over_mode is True
         web3 = AsyncWeb3(EthFailOverHTTPProvider(fail_over_mode=True))
-        assert (await web3.is_connected()) is True
+        try:
+            assert (await web3.is_connected()) is True
+        finally:
+            await web3.provider.disconnect()
+
+    # Normal_3
+    # - Test that the provider reuses a cached endpoint without querying the DB again
+    async def test_normal_3(self):
+        provider = EthFailOverHTTPProvider(
+            fail_over_mode=True,
+            session_manager=KeepAliveHTTPSessionManager(),
+        )
+        method = RPCEndpoint("eth_chainId")
+        fake_session = MagicMock()
+        fake_session.scalars = AsyncMock(
+            side_effect=[
+                MagicMock(first=MagicMock(return_value=object())),
+                MagicMock(
+                    first=MagicMock(
+                        return_value=SimpleNamespace(
+                            endpoint_uri=ETH_WEB3_HTTP_PROVIDER
+                        )
+                    )
+                ),
+            ]
+        )
+        fake_session.close = AsyncMock()
+
+        with (
+            patch(
+                "app.utils.eth_contract_utils.AsyncSession", return_value=fake_session
+            ),
+            patch(
+                "web3.providers.rpc.async_rpc.AsyncHTTPProvider.make_request",
+                AsyncMock(return_value={"result": "ok"}),
+            ) as make_request,
+        ):
+            first_response = await provider.make_request(method, [])
+            second_response = await provider.make_request(method, [])
+
+        assert first_response == {"result": "ok"}
+        assert second_response == {"result": "ok"}
+        assert fake_session.scalars.await_count == 2
+        assert make_request.await_count == 2
+        assert fake_session.close.await_count == 2
 
     ########################################################
     # Error
@@ -71,10 +122,13 @@ class TestEthFailOverHTTPProvider:
 
         # Test that an error is raised
         web3 = AsyncWeb3(EthFailOverHTTPProvider(fail_over_mode=True))
-        with pytest.raises(
-            ServiceUnavailableError, match="Cannot connect to any Ethereum node"
-        ):
-            await web3.is_connected()
+        try:
+            with pytest.raises(
+                ServiceUnavailableError, match="Cannot connect to any Ethereum node"
+            ):
+                await web3.is_connected()
+        finally:
+            await web3.provider.disconnect()
 
     # Error_2
     # - Test that an error is raised when no nodes are available
@@ -87,7 +141,10 @@ class TestEthFailOverHTTPProvider:
 
         # Test that an error is raised
         web3 = AsyncWeb3(EthFailOverHTTPProvider(fail_over_mode=True))
-        with pytest.raises(
-            ServiceUnavailableError, match="Cannot connect to any Ethereum node"
-        ):
-            await web3.is_connected()
+        try:
+            with pytest.raises(
+                ServiceUnavailableError, match="Cannot connect to any Ethereum node"
+            ):
+                await web3.is_connected()
+        finally:
+            await web3.provider.disconnect()

--- a/tests/app/utils/test_ibet_asynccontract_utils.py
+++ b/tests/app/utils/test_ibet_asynccontract_utils.py
@@ -36,6 +36,7 @@ from app.model.db import TransactionLock
 from app.utils import ibet_contract_utils as contract_module
 from app.utils.ibet_contract_utils import AsyncContractUtils
 from app.utils.ibet_web3_utils import AsyncWeb3Wrapper
+from app.utils.web3_provider_utils import KeepAliveHTTPSessionManager
 from config import CHAIN_ID, TX_GAS_LIMIT, WEB3_HTTP_PROVIDER
 from tests.account_config import default_eth_account
 
@@ -310,6 +311,20 @@ class TestAsyncWeb3Wrapper:
         finally:
             for loop in loops:
                 loop.close()
+
+    # <Normal_3>
+    # Async provider uses the shared keep-alive session manager
+    def test_normal_3(self):
+        loop = asyncio.new_event_loop()
+        wrapper = AsyncWeb3Wrapper()
+
+        try:
+            async_web3 = loop.run_until_complete(_get_web3(wrapper))
+        finally:
+            loop.close()
+
+        session_manager = cast(Any, async_web3.provider)._request_session_manager
+        assert isinstance(session_manager, KeepAliveHTTPSessionManager)
 
 
 # Test for send_transaction

--- a/tests/app/utils/test_ibet_failover_http_provider.py
+++ b/tests/app/utils/test_ibet_failover_http_provider.py
@@ -1,0 +1,114 @@
+"""
+Copyright BOOSTRY Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from web3.types import RPCEndpoint
+
+from app.utils.ibet_web3_utils import AsyncFailOverHTTPProvider, FailOverHTTPProvider
+from app.utils.web3_provider_utils import KeepAliveHTTPSessionManager
+from config import WEB3_HTTP_PROVIDER
+
+
+class TestFailOverHTTPProvider:
+    ###########################################################################
+    # Normal Case
+    ###########################################################################
+
+    # <Normal_1>
+    # Resolved endpoint is cached and reused on the second request
+    def test_normal_1(self, monkeypatch: pytest.MonkeyPatch):
+        provider = FailOverHTTPProvider()
+        fake_session = MagicMock()
+        fake_session.scalars.side_effect = [
+            MagicMock(first=MagicMock(return_value=object())),
+            MagicMock(
+                first=MagicMock(
+                    return_value=SimpleNamespace(endpoint_uri=WEB3_HTTP_PROVIDER)
+                )
+            ),
+        ]
+        fake_session.close = MagicMock()
+
+        monkeypatch.setattr(FailOverHTTPProvider, "fail_over_mode", True)
+        method = RPCEndpoint("eth_chainId")
+
+        with (
+            patch("app.utils.ibet_web3_utils.Session", return_value=fake_session),
+            patch(
+                "web3.providers.rpc.rpc.HTTPProvider.make_request",
+                return_value={"result": "ok"},
+            ) as make_request,
+        ):
+            first_response = provider.make_request(method, [])
+            second_response = provider.make_request(method, [])
+
+        assert first_response == {"result": "ok"}
+        assert second_response == {"result": "ok"}
+        assert fake_session.scalars.call_count == 2
+        assert make_request.call_count == 2
+        assert fake_session.close.call_count == 2
+
+
+@pytest.mark.asyncio
+class TestAsyncFailOverHTTPProvider:
+    ###########################################################################
+    # Normal Case
+    ###########################################################################
+
+    # <Normal_1>
+    # Resolved endpoint is cached and reused on the second async request
+    async def test_normal_1(self, monkeypatch: pytest.MonkeyPatch):
+        provider = AsyncFailOverHTTPProvider(
+            session_manager=KeepAliveHTTPSessionManager()
+        )
+        fake_session = MagicMock()
+        fake_session.scalars = AsyncMock(
+            side_effect=[
+                MagicMock(first=MagicMock(return_value=object())),
+                MagicMock(
+                    first=MagicMock(
+                        return_value=SimpleNamespace(endpoint_uri=WEB3_HTTP_PROVIDER)
+                    )
+                ),
+            ]
+        )
+        fake_session.close = AsyncMock()
+
+        monkeypatch.setattr(AsyncFailOverHTTPProvider, "fail_over_mode", True)
+        method = RPCEndpoint("eth_chainId")
+
+        with (
+            patch(
+                "app.utils.ibet_web3_utils.AsyncSession",
+                return_value=fake_session,
+            ),
+            patch(
+                "web3.providers.rpc.async_rpc.AsyncHTTPProvider.make_request",
+                AsyncMock(return_value={"result": "ok"}),
+            ) as make_request,
+        ):
+            first_response = await provider.make_request(method, [])
+            second_response = await provider.make_request(method, [])
+
+        assert first_response == {"result": "ok"}
+        assert second_response == {"result": "ok"}
+        assert fake_session.scalars.await_count == 2
+        assert make_request.await_count == 2
+        assert fake_session.close.await_count == 2


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

This pull request refactors the failover HTTP provider logic for Avalanche, Ethereum, and ibet Web3 utilities to improve endpoint selection, caching, and reliability. 

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
None

## 🔄 Changes

<!-- List the major changes in this PR. -->

**Provider Refactoring and Endpoint Caching**

* Refactored failover HTTP providers (`AvaFailOverHTTPProvider`, `EthFailOverHTTPProvider`, `FailOverHTTPProvider`, `AsyncFailOverHTTPProvider`) to inherit from the new `ResolvedEndpointCacheMixin`, which adds endpoint URI caching and cache invalidation on failures. This reduces unnecessary database queries and improves performance. 

* Added `_resolve_endpoint_uri` methods (sync and async) to select the highest-priority, synced node from the database, cache the result, and use it for subsequent requests. If the cached endpoint fails, it is cleared and the next available node is selected. 

**Session Management Improvements**

* Integrated `KeepAliveHTTPSessionManager` into all failover HTTP providers to reuse HTTP sessions, reducing connection overhead and improving reliability. 

**Failover and Retry Logic Enhancements**

* Enhanced retry logic to first attempt requests using the cached endpoint, and only query the database for a new endpoint if the cached one fails. This applies to both sync and async providers, and ensures that cache is invalidated on connection or decode errors.

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
