### PR TITLE
Fix: Add Rejected state

### DIFF
--- a/app/model/schema/ibet_wst.py
+++ b/app/model/schema/ibet_wst.py
@@ -43,7 +43,7 @@ class IbetWSTToken(BaseModel):
 
     issuer_address: str = Field(description="Issuer address")
     ibet_wst_address: str = Field(description="IbetWST contract address")
-    ibet_wst_name: str = Field(description="IbetWST name")
+    ibet_wst_name: str | None = Field(description="IbetWST name")
     ibet_token_address: str = Field(description="ibet token contract address")
     ibet_token_type: TokenType = Field(description="ibet token type")
     ibet_token_attributes: IbetStraightBond | IbetShare = Field(
@@ -102,7 +102,7 @@ class IbetWSTTrade(BaseModel):
     buyer_sc_account_address: str = Field(description="SC buyer account address")
     st_value: int = Field(description="Value of IbetWST to trade")
     sc_value: int = Field(description="Value of SC token to trade")
-    state: Literal["Pending", "Executed", "Cancelled"] = Field(
+    state: Literal["Pending", "Executed", "Cancelled", "Rejected"] = Field(
         description="Trade state"
     )
     memo: str = Field(description="Memo for the trade")
@@ -361,7 +361,7 @@ class ListIbetWSTTradesQuery(BasePaginationQuery):
     buyer_sc_account_address: Optional[ChecksumEthereumAddress] = Field(
         None, description="SC buyer account address"
     )
-    state: Optional[Literal["Pending", "Executed", "Cancelled"]] = Field(
+    state: Optional[Literal["Pending", "Executed", "Cancelled", "Rejected"]] = Field(
         None, description="Trade state"
     )
 

--- a/app/model/schema/ibet_wst.py
+++ b/app/model/schema/ibet_wst.py
@@ -43,7 +43,7 @@ class IbetWSTToken(BaseModel):
 
     issuer_address: str = Field(description="Issuer address")
     ibet_wst_address: str = Field(description="IbetWST contract address")
-    ibet_wst_name: str | None = Field(description="IbetWST name")
+    ibet_wst_name: str = Field(description="IbetWST name")
     ibet_token_address: str = Field(description="ibet token contract address")
     ibet_token_type: TokenType = Field(description="ibet token type")
     ibet_token_attributes: IbetStraightBond | IbetShare = Field(

--- a/app/routers/misc/ibet_wst.py
+++ b/app/routers/misc/ibet_wst.py
@@ -194,7 +194,9 @@ async def list_all_ibet_wst_tokens(
     # Load tokens and filter on application side to avoid direct dependency
     # on deprecated single-chain IbetWST columns.
     issued_tokens: list[Token] = []
-    all_tokens = (await db.scalars(select(Token))).all()
+    all_tokens = (
+        await db.scalars(select(Token).where(Token.ibet_wst_name.is_not(None)))
+    ).all()
     for token in all_tokens:
         wst_address = _get_wst_address(token, blockchain_platform)
         if not token.is_ibet_wst_deployed(blockchain_platform):

--- a/docs/ibet_prime.yaml
+++ b/docs/ibet_prime.yaml
@@ -10722,6 +10722,7 @@ paths:
                   - Pending
                   - Executed
                   - Cancelled
+                  - Rejected
                 type: string
               - type: 'null'
             description: Trade state
@@ -16302,6 +16303,7 @@ components:
             - Pending
             - Executed
             - Cancelled
+            - Rejected
           title: State
           description: Trade state
         memo:

--- a/tests/app/test_ibet_wst_GetIbetWSTTrade.py
+++ b/tests/app/test_ibet_wst_GetIbetWSTTrade.py
@@ -161,6 +161,42 @@ class TestGetIbetWSTTrade:
             "memo": "test1",
         }
 
+    # <Normal_1_3>
+    # Test that rejected trades are returned without response validation errors.
+    async def test_normal_1_3(self, async_client: AsyncClient, async_db: AsyncSession):
+        trade = {
+            "ibet_wst_address": self.ibet_wst_address_1,
+            "index": 3,
+            "seller_st_account_address": self.user_address_1,
+            "buyer_st_account_address": self.user_address_2,
+            "sc_token_address": self.sc_token_address_1,
+            "seller_sc_account_address": self.user_address_1,
+            "buyer_sc_account_address": self.user_address_2,
+            "st_value": 5000,
+            "sc_value": 6000,
+            "state": "Rejected",
+            "memo": "test3",
+        }
+        await self.insert_trade_eth(async_db, trade)
+
+        resp = await async_client.get(
+            self.apiurl.format(ibet_wst_address=self.ibet_wst_address_1, index=3)
+        )
+
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "index": 3,
+            "seller_st_account_address": self.user_address_1,
+            "buyer_st_account_address": self.user_address_2,
+            "sc_token_address": self.sc_token_address_1,
+            "seller_sc_account_address": self.user_address_1,
+            "buyer_sc_account_address": self.user_address_2,
+            "st_value": 5000,
+            "sc_value": 6000,
+            "state": "Rejected",
+            "memo": "test3",
+        }
+
     # <Normal_2>
     # This test verifies that the API can handle and return maximum uint256 values correctly.
     # RESPONSE_VALIDATION_MODE is set False to allow the API to return large integers without validation errors.

--- a/tests/app/test_ibet_wst_ListAllIbetWSTTokens.py
+++ b/tests/app/test_ibet_wst_ListAllIbetWSTTokens.py
@@ -259,7 +259,7 @@ class TestListAllIbetWSTTokens:
 
     # <Normal_2_3>
     # Legacy data with missing IbetWST name
-    # - This test case checks that tokens with a missing IbetWST name are still returned.
+    # - This test case checks that tokens with a missing IbetWST name are excluded.
     @pytest.mark.freeze_time("2025-01-31 12:34:56")
     @mock.patch("app.model.ibet.token.IbetStraightBondContract.get")
     async def test_normal_2_3(
@@ -337,22 +337,12 @@ class TestListAllIbetWSTTokens:
         assert resp.status_code == 200
         assert resp.json() == {
             "result_set": {
-                "count": 1,
+                "count": 0,
                 "offset": None,
                 "limit": None,
-                "total": 1,
+                "total": 0,
             },
-            "tokens": [
-                {
-                    "issuer_address": self.issuer_address_1,
-                    "ibet_wst_address": self.ibet_wst_address_1,
-                    "ibet_wst_name": None,
-                    "ibet_token_address": self.ibet_token_address_1,
-                    "ibet_token_type": TokenType.IBET_STRAIGHT_BOND,
-                    "ibet_token_attributes": token_attr,
-                    "created": "2025-01-31T21:34:56+09:00",
-                }
-            ],
+            "tokens": [],
         }
 
     # <Normal_3>

--- a/tests/app/test_ibet_wst_ListAllIbetWSTTokens.py
+++ b/tests/app/test_ibet_wst_ListAllIbetWSTTokens.py
@@ -257,6 +257,104 @@ class TestListAllIbetWSTTokens:
             ],
         }
 
+    # <Normal_2_3>
+    # Legacy data with missing IbetWST name
+    # - This test case checks that tokens with a missing IbetWST name are still returned.
+    @pytest.mark.freeze_time("2025-01-31 12:34:56")
+    @mock.patch("app.model.ibet.token.IbetStraightBondContract.get")
+    async def test_normal_2_3(
+        self,
+        mock_IbetStraightBondContract_get: MagicMock,
+        async_client: AsyncClient,
+        async_db: AsyncSession,
+    ):
+        # Prepare data: Token
+        _token = Token()
+        _token.token_address = self.ibet_token_address_1
+        _token.issuer_address = self.issuer_address_1
+        _token.type = TokenType.IBET_STRAIGHT_BOND
+        _token.tx_hash = ""
+        _token.abi = {}
+        _token.version = TokenVersion.V_25_09
+        _token.set_ibet_wst_deployed("ethereum", True)
+        _token.set_ibet_wst_address("ethereum", self.ibet_wst_address_1)
+        _token.ibet_wst_name = None
+        async_db.add(_token)
+        await async_db.commit()
+
+        # Mock
+        bond_1 = IbetStraightBondContract()
+        token_attr = {
+            "issuer_address": self.issuer_address_1,
+            "token_address": self.ibet_token_address_1,
+            "name": "テスト債券-test",
+            "symbol": "TEST-test",
+            "total_supply": 9999999,
+            "contact_information": "test1",
+            "privacy_policy": "test2",
+            "tradable_exchange_contract_address": "0x1234567890123456789012345678901234567890",
+            "status": False,
+            "personal_info_contract_address": "0x1234567890123456789012345678901234567891",
+            "require_personal_info_registered": True,
+            "transferable": True,
+            "is_offering": True,
+            "transfer_approval_required": True,
+            "face_value": 9999998,
+            "face_value_currency": "JPY",
+            "interest_rate": 99.999,
+            "interest_payment_date": [
+                "99991231",
+                "99991231",
+                "99991231",
+                "99991231",
+                "99991231",
+                "99991231",
+                "99991231",
+                "99991231",
+                "99991231",
+                "99991231",
+                "99991231",
+                "99991231",
+            ],
+            "interest_payment_currency": "JPY",
+            "redemption_date": "99991231",
+            "redemption_value": 9999997,
+            "redemption_value_currency": "JPY",
+            "return_date": "99991230",
+            "return_amount": "return_amount-test",
+            "base_fx_rate": 123.456789,
+            "purpose": "purpose-test",
+            "memo": "memo-test",
+            "is_redeemed": True,
+        }
+        bond_1.__dict__ = token_attr
+        mock_IbetStraightBondContract_get.side_effect = [bond_1]
+
+        # Request target API
+        resp = await async_client.get(self.api_url)
+
+        # Assertion
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "result_set": {
+                "count": 1,
+                "offset": None,
+                "limit": None,
+                "total": 1,
+            },
+            "tokens": [
+                {
+                    "issuer_address": self.issuer_address_1,
+                    "ibet_wst_address": self.ibet_wst_address_1,
+                    "ibet_wst_name": None,
+                    "ibet_token_address": self.ibet_token_address_1,
+                    "ibet_token_type": TokenType.IBET_STRAIGHT_BOND,
+                    "ibet_token_attributes": token_attr,
+                    "created": "2025-01-31T21:34:56+09:00",
+                }
+            ],
+        }
+
     # <Normal_3>
     # Multiple records
     # - This test case checks that both IbetStraightBond and IbetShare tokens can be retrieved correctly.

--- a/tests/app/test_ibet_wst_ListIbetWSTTrades.py
+++ b/tests/app/test_ibet_wst_ListIbetWSTTrades.py
@@ -237,6 +237,62 @@ class TestListIbetWSTTrades:
             ],
         }
 
+    # <Normal_1_3>
+    # Fetch rejected trades via the state filter.
+    async def test_normal_1_3(self, async_client: AsyncClient, async_db: AsyncSession):
+        trade1 = {
+            "ibet_wst_address": self.ibet_wst_address_1,
+            "index": 1,
+            "seller_st_account_address": self.user_address_1,
+            "buyer_st_account_address": self.user_address_2,
+            "sc_token_address": self.sc_token_address_1,
+            "seller_sc_account_address": self.user_address_1,
+            "buyer_sc_account_address": self.user_address_2,
+            "st_value": 1000,
+            "sc_value": 2000,
+            "state": "Rejected",
+            "memo": "test1",
+        }
+        trade2 = {
+            "ibet_wst_address": self.ibet_wst_address_1,
+            "index": 2,
+            "seller_st_account_address": self.user_address_2,
+            "buyer_st_account_address": self.user_address_1,
+            "sc_token_address": self.sc_token_address_1,
+            "seller_sc_account_address": self.user_address_2,
+            "buyer_sc_account_address": self.user_address_1,
+            "st_value": 3000,
+            "sc_value": 4000,
+            "state": "Pending",
+            "memo": "test2",
+        }
+        await self.insert_trade_eth(async_db, trade1)
+        await self.insert_trade_eth(async_db, trade2)
+
+        resp = await async_client.get(
+            self.apiurl.format(ibet_wst_address=self.ibet_wst_address_1),
+            params={"state": "Rejected"},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "result_set": {"count": 1, "offset": None, "limit": None, "total": 2},
+            "trades": [
+                {
+                    "index": 1,
+                    "seller_st_account_address": self.user_address_1,
+                    "buyer_st_account_address": self.user_address_2,
+                    "sc_token_address": self.sc_token_address_1,
+                    "seller_sc_account_address": self.user_address_1,
+                    "buyer_sc_account_address": self.user_address_2,
+                    "st_value": 1000,
+                    "sc_value": 2000,
+                    "state": "Rejected",
+                    "memo": "test1",
+                }
+            ],
+        }
+
     # <Normal_2_1>
     # Search filtering: seller_st_account_address
     async def test_normal_2_1(self, async_client: AsyncClient, async_db: AsyncSession):
@@ -811,9 +867,11 @@ class TestListIbetWSTTrades:
                 {
                     "type": "literal_error",
                     "loc": ["query", "state"],
-                    "msg": "Input should be 'Pending', 'Executed' or 'Cancelled'",
+                    "msg": "Input should be 'Pending', 'Executed', 'Cancelled' or 'Rejected'",
                     "input": "InvalidState",
-                    "ctx": {"expected": "'Pending', 'Executed' or 'Cancelled'"},
+                    "ctx": {
+                        "expected": "'Pending', 'Executed', 'Cancelled' or 'Rejected'"
+                    },
                 },
             ],
         }


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

This pull request primarily adds support for a new "Rejected" state to IbetWST trades, ensuring the new state is handled consistently across the application logic, API schema, and test coverage. Additionally, it updates token filtering logic to exclude legacy tokens missing an IbetWST name and adds corresponding tests.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
None

## 🔄 Changes

<!-- List the major changes in this PR. -->

**Support for "Rejected" trade state:**

* Added "Rejected" as a valid value for the `state` field in the `IbetWSTTrade` model and the `ListIbetWSTTradesQuery` filter, allowing trades to be marked and queried as rejected. 
* Enhanced tests to cover the new "Rejected" state, including retrieval and filtering of rejected trades and validation error messaging for invalid states. 

**Token filtering improvements:**

* Updated the `list_all_ibet_wst_tokens` API logic to only include tokens with a non-null `ibet_wst_name`, excluding legacy tokens with missing names.
* Added a test case to ensure tokens lacking an IbetWST name are excluded from API results.


## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
