### PR TITLE
Exclude failed endpoints in web3 failover

### DIFF
--- a/app/utils/ava_contract_utils.py
+++ b/app/utils/ava_contract_utils.py
@@ -137,17 +137,25 @@ class AvaFailOverHTTPProvider(ResolvedEndpointCacheMixin, AsyncHTTPProvider):
     def _get_cache_ttl(self) -> float:
         return float(AVA_WEB3_REQUEST_WAIT_TIME)
 
-    async def _resolve_endpoint_uri(self, db_session: AsyncSession) -> URI | None:
+    async def _resolve_endpoint_uri(
+        self, db_session: AsyncSession, failed_endpoint_uris: set[URI] | None = None
+    ) -> URI | None:
         cached_endpoint_uri = self._get_cached_endpoint_uri()
-        if cached_endpoint_uri is not None:
+        if cached_endpoint_uri is not None and cached_endpoint_uri not in (
+            failed_endpoint_uris or set()
+        ):
             return cached_endpoint_uri
 
+        stmt = select(AvalancheNode).where(AvalancheNode.is_synced.is_(True))
+        if failed_endpoint_uris:
+            stmt = stmt.where(
+                AvalancheNode.endpoint_uri.not_in(
+                    [str(uri) for uri in failed_endpoint_uris]
+                )
+            )
         node: AvalancheNode | None = (
             await db_session.scalars(
-                select(AvalancheNode)
-                .where(AvalancheNode.is_synced.is_(True))
-                .order_by(AvalancheNode.priority, AvalancheNode.id)
-                .limit(1)
+                stmt.order_by(AvalancheNode.priority, AvalancheNode.id).limit(1)
             )
         ).first()
         if node is None or node.endpoint_uri is None:
@@ -163,6 +171,7 @@ class AvaFailOverHTTPProvider(ResolvedEndpointCacheMixin, AsyncHTTPProvider):
         db_session = AsyncSession(autocommit=False, autoflush=True, bind=async_engine)
         try:
             if self.fail_over_mode:
+                failed_endpoint_uris: set[URI] = set()
                 cached_endpoint_uri = self._get_cached_endpoint_uri()
                 if cached_endpoint_uri is not None:
                     self.endpoint_uri = cached_endpoint_uri
@@ -170,8 +179,9 @@ class AvaFailOverHTTPProvider(ResolvedEndpointCacheMixin, AsyncHTTPProvider):
                         return await super().make_request(method, params)
                     except ClientError, JSONDecodeError:
                         self._clear_cached_endpoint_uri()
-                        LOG.info(
-                            f"Retry web3 request due to connection fail: method={method}, params={params}"
+                        failed_endpoint_uris.add(cached_endpoint_uri)
+                        LOG.warning(
+                            f"Retry web3 request due to connection fail: endpoint={cached_endpoint_uri}, method={method}, params={params}"
                         )
 
                 # If the block synchronization monitoring process has not started yet, connect to the primary node.
@@ -184,7 +194,9 @@ class AvaFailOverHTTPProvider(ResolvedEndpointCacheMixin, AsyncHTTPProvider):
 
                 counter = 0
                 while counter <= AVA_WEB3_REQUEST_RETRY_COUNT:
-                    endpoint_uri = await self._resolve_endpoint_uri(db_session)
+                    endpoint_uri = await self._resolve_endpoint_uri(
+                        db_session, failed_endpoint_uris
+                    )
                     if endpoint_uri is None:
                         counter += 1
                         # If the number of retries is within the limit, retry.
@@ -203,8 +215,9 @@ class AvaFailOverHTTPProvider(ResolvedEndpointCacheMixin, AsyncHTTPProvider):
                     except ClientError, JSONDecodeError:
                         # JSONDecodeError may occur when sending a request during geth shutdown, etc.
                         self._clear_cached_endpoint_uri()
-                        LOG.info(
-                            f"Retry web3 request due to connection fail: method={method}, params={params}"
+                        failed_endpoint_uris.add(endpoint_uri)
+                        LOG.warning(
+                            f"Retry web3 request due to connection fail: endpoint={endpoint_uri}, method={method}, params={params}"
                         )
                         counter += 1
                         # If the number of retries is within the limit, retry.

--- a/app/utils/eth_contract_utils.py
+++ b/app/utils/eth_contract_utils.py
@@ -137,17 +137,25 @@ class EthFailOverHTTPProvider(ResolvedEndpointCacheMixin, AsyncHTTPProvider):
     def _get_cache_ttl(self) -> float:
         return float(ETH_WEB3_REQUEST_WAIT_TIME)
 
-    async def _resolve_endpoint_uri(self, db_session: AsyncSession) -> URI | None:
+    async def _resolve_endpoint_uri(
+        self, db_session: AsyncSession, failed_endpoint_uris: set[URI] | None = None
+    ) -> URI | None:
         cached_endpoint_uri = self._get_cached_endpoint_uri()
-        if cached_endpoint_uri is not None:
+        if cached_endpoint_uri is not None and cached_endpoint_uri not in (
+            failed_endpoint_uris or set()
+        ):
             return cached_endpoint_uri
 
+        stmt = select(EthereumNode).where(EthereumNode.is_synced.is_(True))
+        if failed_endpoint_uris:
+            stmt = stmt.where(
+                EthereumNode.endpoint_uri.not_in(
+                    [str(uri) for uri in failed_endpoint_uris]
+                )
+            )
         node: EthereumNode | None = (
             await db_session.scalars(
-                select(EthereumNode)
-                .where(EthereumNode.is_synced.is_(True))
-                .order_by(EthereumNode.priority, EthereumNode.id)
-                .limit(1)
+                stmt.order_by(EthereumNode.priority, EthereumNode.id).limit(1)
             )
         ).first()
         if node is None or node.endpoint_uri is None:
@@ -163,6 +171,7 @@ class EthFailOverHTTPProvider(ResolvedEndpointCacheMixin, AsyncHTTPProvider):
         db_session = AsyncSession(autocommit=False, autoflush=True, bind=async_engine)
         try:
             if self.fail_over_mode:
+                failed_endpoint_uris: set[URI] = set()
                 cached_endpoint_uri = self._get_cached_endpoint_uri()
                 if cached_endpoint_uri is not None:
                     self.endpoint_uri = cached_endpoint_uri
@@ -170,8 +179,9 @@ class EthFailOverHTTPProvider(ResolvedEndpointCacheMixin, AsyncHTTPProvider):
                         return await super().make_request(method, params)
                     except ClientError, JSONDecodeError:
                         self._clear_cached_endpoint_uri()
-                        LOG.info(
-                            f"Retry web3 request due to connection fail: method={method}, params={params}"
+                        failed_endpoint_uris.add(cached_endpoint_uri)
+                        LOG.warning(
+                            f"Retry web3 request due to connection fail: endpoint={cached_endpoint_uri}, method={method}, params={params}"
                         )
 
                 # If the block synchronization monitoring process has not started yet, connect to the primary node.
@@ -182,7 +192,9 @@ class EthFailOverHTTPProvider(ResolvedEndpointCacheMixin, AsyncHTTPProvider):
 
                 counter = 0
                 while counter <= ETH_WEB3_REQUEST_RETRY_COUNT:
-                    endpoint_uri = await self._resolve_endpoint_uri(db_session)
+                    endpoint_uri = await self._resolve_endpoint_uri(
+                        db_session, failed_endpoint_uris
+                    )
                     if endpoint_uri is None:
                         counter += 1
                         # If the number of retries is within the limit, retry.
@@ -201,8 +213,9 @@ class EthFailOverHTTPProvider(ResolvedEndpointCacheMixin, AsyncHTTPProvider):
                     except ClientError, JSONDecodeError:
                         # JSONDecodeError may occur when sending a request during geth shutdown, etc.
                         self._clear_cached_endpoint_uri()
-                        LOG.info(
-                            f"Retry web3 request due to connection fail: method={method}, params={params}"
+                        failed_endpoint_uris.add(endpoint_uri)
+                        LOG.warning(
+                            f"Retry web3 request due to connection fail: endpoint={endpoint_uri}, method={method}, params={params}"
                         )
                         counter += 1
                         # If the number of retries is within the limit, retry.

--- a/app/utils/ibet_web3_utils.py
+++ b/app/utils/ibet_web3_utils.py
@@ -211,16 +211,22 @@ class FailOverHTTPProvider(ResolvedEndpointCacheMixin, HTTPProvider):
     def _get_cache_ttl(self) -> float:
         return float(WEB3_REQUEST_WAIT_TIME)
 
-    def _resolve_endpoint_uri(self, db_session: Session) -> URI | None:
+    def _resolve_endpoint_uri(
+        self, db_session: Session, failed_endpoint_uris: set[URI] | None = None
+    ) -> URI | None:
         cached_endpoint_uri = self._get_cached_endpoint_uri()
-        if cached_endpoint_uri is not None:
+        if cached_endpoint_uri is not None and cached_endpoint_uri not in (
+            failed_endpoint_uris or set()
+        ):
             return cached_endpoint_uri
 
+        stmt = select(Node).where(Node.is_synced == True)
+        if failed_endpoint_uris:
+            stmt = stmt.where(
+                Node.endpoint_uri.not_in([str(uri) for uri in failed_endpoint_uris])
+            )
         node = db_session.scalars(
-            select(Node)
-            .where(Node.is_synced == True)
-            .order_by(Node.priority, Node.id)
-            .limit(1)
+            stmt.order_by(Node.priority, Node.id).limit(1)
         ).first()
         if node is None or node.endpoint_uri is None:
             return None
@@ -233,6 +239,7 @@ class FailOverHTTPProvider(ResolvedEndpointCacheMixin, HTTPProvider):
         db_session = Session(autocommit=False, autoflush=True, bind=engine)
         try:
             if FailOverHTTPProvider.fail_over_mode is True:
+                failed_endpoint_uris: set[URI] = set()
                 # Try cached endpoint first to avoid unnecessary DB query,
                 # and fallback to resolving from DB if it fails.
                 cached_endpoint_uri = self._get_cached_endpoint_uri()
@@ -242,8 +249,9 @@ class FailOverHTTPProvider(ResolvedEndpointCacheMixin, HTTPProvider):
                         return super().make_request(method, params)
                     except ConnectionError, JSONDecodeError, HTTPError:
                         self._clear_cached_endpoint_uri()
-                        LOG.info(
-                            f"Retry web3 request due to connection fail: method={method}, params={params}"
+                        failed_endpoint_uris.add(cached_endpoint_uri)
+                        LOG.warning(
+                            f"Retry web3 request due to connection fail: endpoint={cached_endpoint_uri}, method={method}, params={params}"
                         )
 
                 # If never running the block monitoring processor,
@@ -253,7 +261,9 @@ class FailOverHTTPProvider(ResolvedEndpointCacheMixin, HTTPProvider):
                     return super().make_request(method, params)
                 counter = 0
                 while counter <= WEB3_REQUEST_RETRY_COUNT:
-                    endpoint_uri = self._resolve_endpoint_uri(db_session)
+                    endpoint_uri = self._resolve_endpoint_uri(
+                        db_session, failed_endpoint_uris
+                    )
                     if endpoint_uri is None:
                         counter += 1
                         if counter <= WEB3_REQUEST_RETRY_COUNT:
@@ -268,6 +278,10 @@ class FailOverHTTPProvider(ResolvedEndpointCacheMixin, HTTPProvider):
                         #  JSONDecodeError will be raised if a request is sent
                         #  while Quorum is terminating.
                         self._clear_cached_endpoint_uri()
+                        failed_endpoint_uris.add(endpoint_uri)
+                        LOG.warning(
+                            f"Retry web3 request due to connection fail: endpoint={endpoint_uri}, method={method}, params={params}"
+                        )
                         counter += 1
                         if counter <= WEB3_REQUEST_RETRY_COUNT:
                             time.sleep(WEB3_REQUEST_WAIT_TIME)
@@ -303,18 +317,22 @@ class AsyncFailOverHTTPProvider(ResolvedEndpointCacheMixin, AsyncHTTPProvider):
     def _get_cache_ttl(self) -> float:
         return float(WEB3_REQUEST_WAIT_TIME)
 
-    async def _resolve_endpoint_uri(self, db_session: AsyncSession) -> URI | None:
+    async def _resolve_endpoint_uri(
+        self, db_session: AsyncSession, failed_endpoint_uris: set[URI] | None = None
+    ) -> URI | None:
         cached_endpoint_uri = self._get_cached_endpoint_uri()
-        if cached_endpoint_uri is not None:
+        if cached_endpoint_uri is not None and cached_endpoint_uri not in (
+            failed_endpoint_uris or set()
+        ):
             return cached_endpoint_uri
 
-        node = (
-            await db_session.scalars(
-                select(Node)
-                .where(Node.is_synced == True)
-                .order_by(Node.priority, Node.id)
-                .limit(1)
+        stmt = select(Node).where(Node.is_synced == True)
+        if failed_endpoint_uris:
+            stmt = stmt.where(
+                Node.endpoint_uri.not_in([str(uri) for uri in failed_endpoint_uris])
             )
+        node = (
+            await db_session.scalars(stmt.order_by(Node.priority, Node.id).limit(1))
         ).first()
         if node is None or node.endpoint_uri is None:
             return None
@@ -327,6 +345,7 @@ class AsyncFailOverHTTPProvider(ResolvedEndpointCacheMixin, AsyncHTTPProvider):
         db_session = AsyncSession(autocommit=False, autoflush=True, bind=async_engine)
         try:
             if AsyncFailOverHTTPProvider.fail_over_mode is True:
+                failed_endpoint_uris: set[URI] = set()
                 # Try cached endpoint first to avoid unnecessary DB query,
                 # and fallback to resolving from DB if it fails.
                 cached_endpoint_uri = self._get_cached_endpoint_uri()
@@ -336,8 +355,9 @@ class AsyncFailOverHTTPProvider(ResolvedEndpointCacheMixin, AsyncHTTPProvider):
                         return await super().make_request(method, params)
                     except ClientError, JSONDecodeError:
                         self._clear_cached_endpoint_uri()
-                        LOG.info(
-                            f"Retry web3 request due to connection fail: method={method}, params={params}"
+                        failed_endpoint_uris.add(cached_endpoint_uri)
+                        LOG.warning(
+                            f"Retry web3 request due to connection fail: endpoint={cached_endpoint_uri}, method={method}, params={params}"
                         )
 
                 # If never running the block monitoring processor,
@@ -347,7 +367,9 @@ class AsyncFailOverHTTPProvider(ResolvedEndpointCacheMixin, AsyncHTTPProvider):
                     return await super().make_request(method, params)
                 counter = 0
                 while counter <= WEB3_REQUEST_RETRY_COUNT:
-                    endpoint_uri = await self._resolve_endpoint_uri(db_session)
+                    endpoint_uri = await self._resolve_endpoint_uri(
+                        db_session, failed_endpoint_uris
+                    )
                     if endpoint_uri is None:
                         counter += 1
                         if counter <= WEB3_REQUEST_RETRY_COUNT:
@@ -362,6 +384,10 @@ class AsyncFailOverHTTPProvider(ResolvedEndpointCacheMixin, AsyncHTTPProvider):
                         #  JSONDecodeError will be raised if a request is sent
                         #  while Quorum is terminating.
                         self._clear_cached_endpoint_uri()
+                        failed_endpoint_uris.add(endpoint_uri)
+                        LOG.warning(
+                            f"Retry web3 request due to connection fail: endpoint={endpoint_uri}, method={method}, params={params}"
+                        )
                         counter += 1
                         if counter <= WEB3_REQUEST_RETRY_COUNT:
                             await asyncio.sleep(WEB3_REQUEST_WAIT_TIME)

--- a/batch/indexer_block_tx_data.py
+++ b/batch/indexer_block_tx_data.py
@@ -157,8 +157,8 @@ async def main():
     while True:
         try:
             await processor.process()
-        except ServiceUnavailableError:
-            LOG.warning("An external service was unavailable")
+        except ServiceUnavailableError as ex:
+            LOG.error(f"All blockchain nodes are unavailable: {ex}")
         except SQLAlchemyError as sa_err:
             LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
         except Exception:

--- a/batch/indexer_dvp_delivery.py
+++ b/batch/indexer_dvp_delivery.py
@@ -879,8 +879,8 @@ async def main():
     while True:
         try:
             await processor.sync_new_logs()
-        except ServiceUnavailableError:
-            LOG.warning("An external service was unavailable")
+        except ServiceUnavailableError as ex:
+            LOG.error(f"All blockchain nodes are unavailable: {ex}")
         except SQLAlchemyError as sa_err:
             LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
         except Exception as ex:

--- a/batch/indexer_e2e_messaging.py
+++ b/batch/indexer_e2e_messaging.py
@@ -337,8 +337,8 @@ async def main():
         start_time = time.time()
         try:
             await processor.process()
-        except ServiceUnavailableError:
-            LOG.warning("An external service was unavailable")
+        except ServiceUnavailableError as ex:
+            LOG.error(f"All blockchain nodes are unavailable: {ex}")
         except SQLAlchemyError as sa_err:
             LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
         except Exception as ex:

--- a/batch/indexer_issue_redeem.py
+++ b/batch/indexer_issue_redeem.py
@@ -298,8 +298,8 @@ async def main():
     while True:
         try:
             await processor.sync_new_logs()
-        except ServiceUnavailableError:
-            LOG.warning("An external service was unavailable")
+        except ServiceUnavailableError as ex:
+            LOG.error(f"All blockchain nodes are unavailable: {ex}")
         except SQLAlchemyError as sa_err:
             LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
         except Exception:

--- a/batch/indexer_personal_info.py
+++ b/batch/indexer_personal_info.py
@@ -332,8 +332,8 @@ async def main():
     while True:
         try:
             await processor.process()
-        except ServiceUnavailableError:
-            LOG.warning("An external service was unavailable")
+        except ServiceUnavailableError as ex:
+            LOG.error(f"All blockchain nodes are unavailable: {ex}")
         except SQLAlchemyError as sa_err:
             LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
         except Exception:

--- a/batch/indexer_position_bond.py
+++ b/batch/indexer_position_bond.py
@@ -1938,8 +1938,8 @@ async def main():
     while True:
         try:
             await processor.sync_new_logs()
-        except ServiceUnavailableError:
-            LOG.warning("An external service was unavailable")
+        except ServiceUnavailableError as ex:
+            LOG.error(f"All blockchain nodes are unavailable: {ex}")
         except SQLAlchemyError as sa_err:
             LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
         except Exception:

--- a/batch/indexer_position_share.py
+++ b/batch/indexer_position_share.py
@@ -1938,8 +1938,8 @@ async def main():
     while True:
         try:
             await processor.sync_new_logs()
-        except ServiceUnavailableError:
-            LOG.warning("An external service was unavailable")
+        except ServiceUnavailableError as ex:
+            LOG.error(f"All blockchain nodes are unavailable: {ex}")
         except SQLAlchemyError as sa_err:
             LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
         except Exception:

--- a/batch/indexer_token_cache.py
+++ b/batch/indexer_token_cache.py
@@ -88,8 +88,8 @@ async def main():
     while True:
         try:
             await processor.process()
-        except ServiceUnavailableError:
-            LOG.warning("An external service was unavailable")
+        except ServiceUnavailableError as ex:
+            LOG.error(f"All blockchain nodes are unavailable: {ex}")
         except SQLAlchemyError as sa_err:
             LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
         except Exception:

--- a/batch/indexer_token_holders.py
+++ b/batch/indexer_token_holders.py
@@ -684,8 +684,8 @@ async def main():
     while True:
         try:
             await processor.collect()
-        except ServiceUnavailableError:
-            LOG.warning("An external service was unavailable")
+        except ServiceUnavailableError as ex:
+            LOG.error(f"All blockchain nodes are unavailable: {ex}")
         except SQLAlchemyError as sa_err:
             LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
         except Exception:

--- a/batch/indexer_transfer.py
+++ b/batch/indexer_transfer.py
@@ -449,8 +449,8 @@ async def main():
     while True:
         try:
             await processor.sync_new_logs()
-        except ServiceUnavailableError:
-            LOG.warning("An external service was unavailable")
+        except ServiceUnavailableError as ex:
+            LOG.error(f"All blockchain nodes are unavailable: {ex}")
         except SQLAlchemyError as sa_err:
             LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
         except Exception:

--- a/batch/indexer_transfer_approval.py
+++ b/batch/indexer_transfer_approval.py
@@ -798,8 +798,8 @@ async def main():
     while True:
         try:
             await processor.sync_new_logs()
-        except ServiceUnavailableError:
-            LOG.warning("An external service was unavailable")
+        except ServiceUnavailableError as ex:
+            LOG.error(f"All blockchain nodes are unavailable: {ex}")
         except SQLAlchemyError as sa_err:
             LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
         except Exception as ex:

--- a/batch/indexer_wst_ava_trades.py
+++ b/batch/indexer_wst_ava_trades.py
@@ -27,6 +27,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import BatchAsyncSessionLocal
+from app.exceptions import ServiceUnavailableError
 from app.model.db import (
     Account,
     IbetWSTBlockchain,
@@ -348,6 +349,8 @@ async def main():
     while True:
         try:
             await processor.sync_events()
+        except ServiceUnavailableError as ex:
+            LOG.error(f"All blockchain nodes are unavailable: {ex}")
         except SQLAlchemyError as sa_err:
             LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
         except Exception:

--- a/batch/indexer_wst_eth_trades.py
+++ b/batch/indexer_wst_eth_trades.py
@@ -27,6 +27,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import BatchAsyncSessionLocal
+from app.exceptions import ServiceUnavailableError
 from app.model.db import (
     Account,
     IbetWSTBlockchain,
@@ -348,6 +349,8 @@ async def main():
     while True:
         try:
             await processor.sync_events()
+        except ServiceUnavailableError as ex:
+            LOG.error(f"All blockchain nodes are unavailable: {ex}")
         except SQLAlchemyError as sa_err:
             LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
         except Exception:

--- a/batch/processor_batch_create_child_account.py
+++ b/batch/processor_batch_create_child_account.py
@@ -28,6 +28,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import BatchAsyncSessionLocal
+from app.exceptions import ServiceUnavailableError
 from app.model.db import (
     Account,
     ChildAccount,
@@ -142,6 +143,8 @@ async def main():
         while not is_shutdown.is_set():
             try:
                 await processor.process()
+            except ServiceUnavailableError as ex:
+                LOG.error(f"All blockchain nodes are unavailable: {ex}")
             except SQLAlchemyError as sa_err:
                 LOG.error(
                     f"A database error has occurred: code={sa_err.code}\n{sa_err}"

--- a/batch/processor_batch_issue_redeem.py
+++ b/batch/processor_batch_issue_redeem.py
@@ -30,7 +30,11 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import BatchAsyncSessionLocal
-from app.exceptions import ContractRevertError, SendTransactionError
+from app.exceptions import (
+    ContractRevertError,
+    SendTransactionError,
+    ServiceUnavailableError,
+)
 from app.model.db import (
     Account,
     BatchIssueRedeem,
@@ -455,6 +459,8 @@ async def main():
         while not is_shutdown.is_set():
             try:
                 await processor.process()
+            except ServiceUnavailableError as ex:
+                LOG.error(f"All blockchain nodes are unavailable: {ex}")
             except SQLAlchemyError as sa_err:
                 LOG.error(
                     f"A database error has occurred: code={sa_err.code}\n{sa_err}"

--- a/batch/processor_batch_register_personal_info.py
+++ b/batch/processor_batch_register_personal_info.py
@@ -449,8 +449,8 @@ class Worker:
         while not self.is_shutdown.is_set():
             try:
                 await self.processor.process()
-            except ServiceUnavailableError:
-                LOG.warning("An external service was unavailable")
+            except ServiceUnavailableError as ex:
+                LOG.error(f"All blockchain nodes are unavailable: {ex}")
             except SQLAlchemyError as sa_err:
                 LOG.error(
                     f"A database error has occurred: code={sa_err.code}\n{sa_err}"

--- a/batch/processor_bulk_transfer.py
+++ b/batch/processor_bulk_transfer.py
@@ -590,8 +590,8 @@ class Worker:
         while not self.is_shutdown.is_set():
             try:
                 await self.processor.process()
-            except ServiceUnavailableError:
-                LOG.warning("An external service was unavailable")
+            except ServiceUnavailableError as ex:
+                LOG.error(f"All blockchain nodes are unavailable: {ex}")
             except SQLAlchemyError as sa_err:
                 LOG.error(
                     f"A database error has occurred: code={sa_err.code}\n{sa_err}"

--- a/batch/processor_create_ledger.py
+++ b/batch/processor_create_ledger.py
@@ -164,8 +164,8 @@ async def main():
         while not is_shutdown.is_set():
             try:
                 await processor.process()
-            except ServiceUnavailableError:
-                LOG.warning("An external service was unavailable")
+            except ServiceUnavailableError as ex:
+                LOG.error(f"All blockchain nodes are unavailable: {ex}")
             except SQLAlchemyError as sa_err:
                 LOG.error(
                     f"A database error has occurred: code={sa_err.code}\n{sa_err}"

--- a/batch/processor_create_utxo.py
+++ b/batch/processor_create_utxo.py
@@ -719,8 +719,8 @@ async def main():
         latest_synced = True
         try:
             latest_synced = await processor.process()
-        except ServiceUnavailableError:
-            LOG.warning("An external service was unavailable")
+        except ServiceUnavailableError as ex:
+            LOG.error(f"All blockchain nodes are unavailable: {ex}")
         except SQLAlchemyError as sa_err:
             LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
         except Exception:

--- a/batch/processor_dvp_async_tx.py
+++ b/batch/processor_dvp_async_tx.py
@@ -30,7 +30,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from web3.exceptions import TimeExhausted
 
 from app.database import BatchAsyncSessionLocal
-from app.exceptions import SendTransactionError
+from app.exceptions import SendTransactionError, ServiceUnavailableError
 from app.model.db import (
     Account,
     DVPAsyncProcess,
@@ -386,6 +386,8 @@ async def main():
         while not is_shutdown.is_set():
             try:
                 await processor.process()
+            except ServiceUnavailableError as ex:
+                LOG.error(f"All blockchain nodes are unavailable: {ex}")
             except SQLAlchemyError as sa_err:
                 LOG.error(
                     f"A database error has occurred: code={sa_err.code}\n{sa_err}"

--- a/batch/processor_generate_rsa_key.py
+++ b/batch/processor_generate_rsa_key.py
@@ -29,6 +29,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import BatchAsyncSessionLocal
+from app.exceptions import ServiceUnavailableError
 from app.model.db import Account, AccountRsaKeyTemporary, AccountRsaStatus
 from app.utils.e2ee_utils import E2EEUtils
 from batch import free_malloc
@@ -140,6 +141,8 @@ async def main():
     while True:
         try:
             await processor.process()
+        except ServiceUnavailableError as ex:
+            LOG.error(f"All blockchain nodes are unavailable: {ex}")
         except SQLAlchemyError as sa_err:
             LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
         except Exception as ex:

--- a/batch/processor_modify_personal_info.py
+++ b/batch/processor_modify_personal_info.py
@@ -320,8 +320,8 @@ async def main():
         while not is_shutdown.is_set():
             try:
                 await processor.process()
-            except ServiceUnavailableError:
-                LOG.warning("An external service was unavailable")
+            except ServiceUnavailableError as ex:
+                LOG.error(f"All blockchain nodes are unavailable: {ex}")
             except SQLAlchemyError as sa_err:
                 LOG.error(
                     f"A database error has occurred: code={sa_err.code}\n{sa_err}"

--- a/batch/processor_rotate_e2e_messaging_rsa_key.py
+++ b/batch/processor_rotate_e2e_messaging_rsa_key.py
@@ -213,8 +213,8 @@ async def main():
         start_time = time.time()
         try:
             await processor.process()
-        except ServiceUnavailableError:
-            LOG.warning("An external service was unavailable")
+        except ServiceUnavailableError as ex:
+            LOG.error(f"All blockchain nodes are unavailable: {ex}")
         except SQLAlchemyError as sa_err:
             LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
         except Exception as ex:

--- a/batch/processor_scheduled_events.py
+++ b/batch/processor_scheduled_events.py
@@ -355,8 +355,8 @@ class Worker:
             started_at = time.time()
             try:
                 await self.processor.process()
-            except ServiceUnavailableError:
-                LOG.warning("An external service was unavailable")
+            except ServiceUnavailableError as ex:
+                LOG.error(f"All blockchain nodes are unavailable: {ex}")
             except SQLAlchemyError as sa_err:
                 LOG.error(
                     f"A database error has occurred: code={sa_err.code}\n{sa_err}"

--- a/batch/processor_update_token.py
+++ b/batch/processor_update_token.py
@@ -401,8 +401,8 @@ async def main():
         while not is_shutdown.is_set():
             try:
                 await processor.process()
-            except ServiceUnavailableError:
-                LOG.warning("An external service was unavailable")
+            except ServiceUnavailableError as ex:
+                LOG.error(f"All blockchain nodes are unavailable: {ex}")
             except SQLAlchemyError as sa_err:
                 LOG.error(
                     f"A database error has occurred: code={sa_err.code}\n{sa_err}"

--- a/batch/processor_wst_ava_bridge_to_ibet.py
+++ b/batch/processor_wst_ava_bridge_to_ibet.py
@@ -29,7 +29,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import BatchAsyncSessionLocal
-from app.exceptions import ContractRevertError
+from app.exceptions import ContractRevertError, ServiceUnavailableError
 from app.model.db import (
     Account,
     AvaToIbetBridgeTx,
@@ -192,6 +192,8 @@ async def main():
     while True:
         try:
             await bridge_tx_processor.send_ibet_tx()
+        except ServiceUnavailableError as ex:
+            LOG.error(f"All blockchain nodes are unavailable: {ex}")
         except SQLAlchemyError as sa_err:
             LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
         except Exception:

--- a/batch/processor_wst_ava_monitor_bridge_events.py
+++ b/batch/processor_wst_ava_monitor_bridge_events.py
@@ -34,6 +34,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import BatchAsyncSessionLocal
+from app.exceptions import ServiceUnavailableError
 from app.model.db import (
     Account,
     AvaIbetWSTTx,
@@ -546,6 +547,8 @@ async def main():
     while True:
         try:
             await bridge_processor.run()
+        except ServiceUnavailableError as ex:
+            LOG.error(f"All blockchain nodes are unavailable: {ex}")
         except SQLAlchemyError as sa_err:
             LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
         except Exception:

--- a/batch/processor_wst_ava_monitor_txreceipt.py
+++ b/batch/processor_wst_ava_monitor_txreceipt.py
@@ -30,6 +30,7 @@ from web3.logs import DISCARD
 from web3.types import TxReceipt
 
 from app.database import BatchAsyncSessionLocal
+from app.exceptions import ServiceUnavailableError
 from app.model.db import (
     AvaIbetWSTTx,
     IbetWSTBlockchain,
@@ -472,6 +473,8 @@ async def main():
     while True:
         try:
             await processor.run()
+        except ServiceUnavailableError as ex:
+            LOG.error(f"All blockchain nodes are unavailable: {ex}")
         except SQLAlchemyError as sa_err:
             LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
         except Exception as ex:

--- a/batch/processor_wst_ava_send_tx.py
+++ b/batch/processor_wst_ava_send_tx.py
@@ -30,6 +30,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from web3.types import Nonce
 
 from app.database import BatchAsyncSessionLocal
+from app.exceptions import ServiceUnavailableError
 from app.model.db import (
     Account,
     AvaIbetWSTTx,
@@ -469,6 +470,8 @@ async def main():
     while True:
         try:
             await processor.run()
+        except ServiceUnavailableError as ex:
+            LOG.error(f"All blockchain nodes are unavailable: {ex}")
         except SQLAlchemyError as sa_err:
             LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
         except Exception as ex:

--- a/batch/processor_wst_eth_bridge_to_ibet.py
+++ b/batch/processor_wst_eth_bridge_to_ibet.py
@@ -29,7 +29,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import BatchAsyncSessionLocal
-from app.exceptions import ContractRevertError
+from app.exceptions import ContractRevertError, ServiceUnavailableError
 from app.model.db import (
     Account,
     EthToIbetBridgeTx,
@@ -189,6 +189,8 @@ async def main():
     while True:
         try:
             await bridge_tx_processor.send_ibet_tx()
+        except ServiceUnavailableError as ex:
+            LOG.error(f"All blockchain nodes are unavailable: {ex}")
         except SQLAlchemyError as sa_err:
             LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
         except Exception:

--- a/batch/processor_wst_eth_monitor_bridge_events.py
+++ b/batch/processor_wst_eth_monitor_bridge_events.py
@@ -34,6 +34,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import BatchAsyncSessionLocal
+from app.exceptions import ServiceUnavailableError
 from app.model.db import (
     Account,
     EthIbetWSTTx,
@@ -553,6 +554,8 @@ async def main():
     while True:
         try:
             await bridge_processor.run()
+        except ServiceUnavailableError as ex:
+            LOG.error(f"All blockchain nodes are unavailable: {ex}")
         except SQLAlchemyError as sa_err:
             LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
         except Exception:

--- a/batch/processor_wst_eth_monitor_txreceipt.py
+++ b/batch/processor_wst_eth_monitor_txreceipt.py
@@ -30,6 +30,7 @@ from web3.logs import DISCARD
 from web3.types import TxReceipt
 
 from app.database import BatchAsyncSessionLocal
+from app.exceptions import ServiceUnavailableError
 from app.model.db import (
     EthIbetWSTTx,
     IbetWSTBlockchain,
@@ -472,6 +473,8 @@ async def main():
     while True:
         try:
             await processor.run()
+        except ServiceUnavailableError as ex:
+            LOG.error(f"All blockchain nodes are unavailable: {ex}")
         except SQLAlchemyError as sa_err:
             LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
         except Exception as ex:

--- a/batch/processor_wst_eth_send_tx.py
+++ b/batch/processor_wst_eth_send_tx.py
@@ -30,6 +30,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from web3.types import Nonce
 
 from app.database import BatchAsyncSessionLocal
+from app.exceptions import ServiceUnavailableError
 from app.model.db import (
     Account,
     EthIbetWSTTx,
@@ -469,6 +470,8 @@ async def main():
     while True:
         try:
             await processor.run()
+        except ServiceUnavailableError as ex:
+            LOG.error(f"All blockchain nodes are unavailable: {ex}")
         except SQLAlchemyError as sa_err:
             LOG.error(f"A database error has occurred: code={sa_err.code}\n{sa_err}")
         except Exception as ex:

--- a/tests/app/utils/test_ava_failover_http_provider.py
+++ b/tests/app/utils/test_ava_failover_http_provider.py
@@ -17,11 +17,13 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
+from json.decoder import JSONDecodeError
 from types import SimpleNamespace
 from unittest import mock
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from eth_typing import URI
 from sqlalchemy.ext.asyncio import AsyncSession
 from web3 import AsyncWeb3
 from web3.types import RPCEndpoint
@@ -31,6 +33,11 @@ from app.model.db import AvalancheNode
 from app.utils.ava_contract_utils import AvaFailOverHTTPProvider
 from app.utils.web3_provider_utils import KeepAliveHTTPSessionManager
 from avalanche_config import AVA_WEB3_HTTP_PROVIDER
+
+
+class _AvaFailOverHTTPProviderForTest(AvaFailOverHTTPProvider):
+    def seed_cached_endpoint_uri(self, endpoint_uri: URI) -> None:
+        self._set_cached_endpoint_uri(endpoint_uri)
 
 
 @pytest.mark.asyncio
@@ -104,6 +111,52 @@ class TestAvaFailOverHTTPProvider:
         assert fake_session.scalars.await_count == 2
         assert make_request.await_count == 2
         assert fake_session.close.await_count == 2
+
+    # Normal_4
+    # - Test that cached primary endpoint failure falls back to the standby endpoint
+    async def test_normal_4(self):
+        provider = _AvaFailOverHTTPProviderForTest(
+            fail_over_mode=True,
+            session_manager=KeepAliveHTTPSessionManager(),
+        )
+        primary_endpoint = URI("http://primary.example:8545")
+        standby_endpoint = URI("http://standby.example:8545")
+        provider.seed_cached_endpoint_uri(primary_endpoint)
+        method = RPCEndpoint("eth_chainId")
+        fake_session = MagicMock()
+        fake_session.scalars = AsyncMock(
+            side_effect=[
+                MagicMock(first=MagicMock(return_value=object())),
+                MagicMock(
+                    first=MagicMock(
+                        return_value=SimpleNamespace(endpoint_uri=str(standby_endpoint))
+                    )
+                ),
+            ]
+        )
+        fake_session.close = AsyncMock()
+
+        with (
+            patch(
+                "app.utils.ava_contract_utils.AsyncSession", return_value=fake_session
+            ),
+            patch(
+                "web3.providers.rpc.async_rpc.AsyncHTTPProvider.make_request",
+                AsyncMock(
+                    side_effect=[
+                        JSONDecodeError("decode failed", "", 0),
+                        {"result": "ok"},
+                    ]
+                ),
+            ) as make_request,
+        ):
+            response = await provider.make_request(method, [])
+
+        assert response == {"result": "ok"}
+        assert provider.endpoint_uri == standby_endpoint
+        assert fake_session.scalars.await_count == 2
+        assert make_request.await_count == 2
+        assert fake_session.close.await_count == 1
 
     ########################################################
     # Error

--- a/tests/app/utils/test_eth_failover_http_provider.py
+++ b/tests/app/utils/test_eth_failover_http_provider.py
@@ -17,11 +17,13 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
+from json.decoder import JSONDecodeError
 from types import SimpleNamespace
 from unittest import mock
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from eth_typing import URI
 from sqlalchemy.ext.asyncio import AsyncSession
 from web3 import AsyncWeb3
 from web3.types import RPCEndpoint
@@ -31,6 +33,11 @@ from app.model.db import EthereumNode
 from app.utils.eth_contract_utils import EthFailOverHTTPProvider
 from app.utils.web3_provider_utils import KeepAliveHTTPSessionManager
 from eth_config import ETH_WEB3_HTTP_PROVIDER
+
+
+class _EthFailOverHTTPProviderForTest(EthFailOverHTTPProvider):
+    def seed_cached_endpoint_uri(self, endpoint_uri: URI) -> None:
+        self._set_cached_endpoint_uri(endpoint_uri)
 
 
 @pytest.mark.asyncio
@@ -104,6 +111,52 @@ class TestEthFailOverHTTPProvider:
         assert fake_session.scalars.await_count == 2
         assert make_request.await_count == 2
         assert fake_session.close.await_count == 2
+
+    # Normal_4
+    # - Test that cached primary endpoint failure falls back to the standby endpoint
+    async def test_normal_4(self):
+        provider = _EthFailOverHTTPProviderForTest(
+            fail_over_mode=True,
+            session_manager=KeepAliveHTTPSessionManager(),
+        )
+        primary_endpoint = URI("http://primary.example:8545")
+        standby_endpoint = URI("http://standby.example:8545")
+        provider.seed_cached_endpoint_uri(primary_endpoint)
+        method = RPCEndpoint("eth_chainId")
+        fake_session = MagicMock()
+        fake_session.scalars = AsyncMock(
+            side_effect=[
+                MagicMock(first=MagicMock(return_value=object())),
+                MagicMock(
+                    first=MagicMock(
+                        return_value=SimpleNamespace(endpoint_uri=str(standby_endpoint))
+                    )
+                ),
+            ]
+        )
+        fake_session.close = AsyncMock()
+
+        with (
+            patch(
+                "app.utils.eth_contract_utils.AsyncSession", return_value=fake_session
+            ),
+            patch(
+                "web3.providers.rpc.async_rpc.AsyncHTTPProvider.make_request",
+                AsyncMock(
+                    side_effect=[
+                        JSONDecodeError("decode failed", "", 0),
+                        {"result": "ok"},
+                    ]
+                ),
+            ) as make_request,
+        ):
+            response = await provider.make_request(method, [])
+
+        assert response == {"result": "ok"}
+        assert provider.endpoint_uri == standby_endpoint
+        assert fake_session.scalars.await_count == 2
+        assert make_request.await_count == 2
+        assert fake_session.close.await_count == 1
 
     ########################################################
     # Error

--- a/tests/app/utils/test_ibet_failover_http_provider.py
+++ b/tests/app/utils/test_ibet_failover_http_provider.py
@@ -15,15 +15,28 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
+from json.decoder import JSONDecodeError
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from eth_typing import URI
+from requests.exceptions import ConnectionError
 from web3.types import RPCEndpoint
 
 from app.utils.ibet_web3_utils import AsyncFailOverHTTPProvider, FailOverHTTPProvider
 from app.utils.web3_provider_utils import KeepAliveHTTPSessionManager
 from config import WEB3_HTTP_PROVIDER
+
+
+class _FailOverHTTPProviderForTest(FailOverHTTPProvider):
+    def seed_cached_endpoint_uri(self, endpoint_uri: URI) -> None:
+        self._set_cached_endpoint_uri(endpoint_uri)
+
+
+class _AsyncFailOverHTTPProviderForTest(AsyncFailOverHTTPProvider):
+    def seed_cached_endpoint_uri(self, endpoint_uri: URI) -> None:
+        self._set_cached_endpoint_uri(endpoint_uri)
 
 
 class TestFailOverHTTPProvider:
@@ -64,6 +77,42 @@ class TestFailOverHTTPProvider:
         assert fake_session.scalars.call_count == 2
         assert make_request.call_count == 2
         assert fake_session.close.call_count == 2
+
+    # <Normal_2>
+    # Cached primary endpoint failure falls back to the standby endpoint.
+    def test_normal_2(self, monkeypatch: pytest.MonkeyPatch):
+        provider = _FailOverHTTPProviderForTest()
+        primary_endpoint = URI("http://primary.example:8545")
+        standby_endpoint = URI("http://standby.example:8545")
+        provider.seed_cached_endpoint_uri(primary_endpoint)
+        fake_session = MagicMock()
+        fake_session.scalars.side_effect = [
+            MagicMock(first=MagicMock(return_value=object())),
+            MagicMock(
+                first=MagicMock(
+                    return_value=SimpleNamespace(endpoint_uri=str(standby_endpoint))
+                )
+            ),
+        ]
+        fake_session.close = MagicMock()
+
+        monkeypatch.setattr(FailOverHTTPProvider, "fail_over_mode", True)
+        method = RPCEndpoint("eth_chainId")
+
+        with (
+            patch("app.utils.ibet_web3_utils.Session", return_value=fake_session),
+            patch(
+                "web3.providers.rpc.rpc.HTTPProvider.make_request",
+                side_effect=[ConnectionError(), {"result": "ok"}],
+            ) as make_request,
+        ):
+            response = provider.make_request(method, [])
+
+        assert response == {"result": "ok"}
+        assert provider.endpoint_uri == standby_endpoint
+        assert fake_session.scalars.call_count == 2
+        assert make_request.call_count == 2
+        assert fake_session.close.call_count == 1
 
 
 @pytest.mark.asyncio
@@ -112,3 +161,51 @@ class TestAsyncFailOverHTTPProvider:
         assert fake_session.scalars.await_count == 2
         assert make_request.await_count == 2
         assert fake_session.close.await_count == 2
+
+    # <Normal_2>
+    # Cached primary endpoint failure falls back to the standby endpoint.
+    async def test_normal_2(self, monkeypatch: pytest.MonkeyPatch):
+        provider = _AsyncFailOverHTTPProviderForTest(
+            session_manager=KeepAliveHTTPSessionManager()
+        )
+        primary_endpoint = URI("http://primary.example:8545")
+        standby_endpoint = URI("http://standby.example:8545")
+        provider.seed_cached_endpoint_uri(primary_endpoint)
+        fake_session = MagicMock()
+        fake_session.scalars = AsyncMock(
+            side_effect=[
+                MagicMock(first=MagicMock(return_value=object())),
+                MagicMock(
+                    first=MagicMock(
+                        return_value=SimpleNamespace(endpoint_uri=str(standby_endpoint))
+                    )
+                ),
+            ]
+        )
+        fake_session.close = AsyncMock()
+
+        monkeypatch.setattr(AsyncFailOverHTTPProvider, "fail_over_mode", True)
+        method = RPCEndpoint("eth_chainId")
+
+        with (
+            patch(
+                "app.utils.ibet_web3_utils.AsyncSession",
+                return_value=fake_session,
+            ),
+            patch(
+                "web3.providers.rpc.async_rpc.AsyncHTTPProvider.make_request",
+                AsyncMock(
+                    side_effect=[
+                        JSONDecodeError("decode failed", "", 0),
+                        {"result": "ok"},
+                    ]
+                ),
+            ) as make_request,
+        ):
+            response = await provider.make_request(method, [])
+
+        assert response == {"result": "ok"}
+        assert provider.endpoint_uri == standby_endpoint
+        assert fake_session.scalars.await_count == 2
+        assert make_request.await_count == 2
+        assert fake_session.close.await_count == 1

--- a/tests/batch/test_indexer_dvp_delivery.py
+++ b/tests/batch/test_indexer_dvp_delivery.py
@@ -2546,7 +2546,7 @@ class TestProcessor:
             await main_func()
 
         assert 1 == caplog.record_tuples.count(
-            (LOG.name, logging.WARNING, "An external service was unavailable")
+            (LOG.name, logging.ERROR, "All blockchain nodes are unavailable: ")
         )
         caplog.clear()
 

--- a/tests/batch/test_indexer_issue_redeem.py
+++ b/tests/batch/test_indexer_issue_redeem.py
@@ -862,7 +862,7 @@ class TestProcessor:
         ):
             await main_func()
         assert 1 == caplog.record_tuples.count(
-            (LOG.name, logging.WARNING, "An external service was unavailable")
+            (LOG.name, logging.ERROR, "All blockchain nodes are unavailable: ")
         )
         caplog.clear()
 

--- a/tests/batch/test_indexer_position_bond.py
+++ b/tests/batch/test_indexer_position_bond.py
@@ -6105,7 +6105,7 @@ class TestProcessor:
         ):
             await main_func()
         assert 1 == caplog.record_tuples.count(
-            (LOG.name, logging.WARNING, "An external service was unavailable")
+            (LOG.name, logging.ERROR, "All blockchain nodes are unavailable: ")
         )
         caplog.clear()
 

--- a/tests/batch/test_indexer_position_share.py
+++ b/tests/batch/test_indexer_position_share.py
@@ -6157,7 +6157,7 @@ class TestProcessor:
         ):
             await main_func()
         assert 1 == caplog.record_tuples.count(
-            (LOG.name, logging.WARNING, "An external service was unavailable")
+            (LOG.name, logging.ERROR, "All blockchain nodes are unavailable: ")
         )
         caplog.clear()
 

--- a/tests/batch/test_indexer_token_cache.py
+++ b/tests/batch/test_indexer_token_cache.py
@@ -415,7 +415,7 @@ class TestProcessor:
         ):
             await main_func()
         assert 1 == caplog.record_tuples.count(
-            (LOG.name, logging.WARNING, "An external service was unavailable")
+            (LOG.name, logging.ERROR, "All blockchain nodes are unavailable: ")
         )
         caplog.clear()
 

--- a/tests/batch/test_indexer_transfer.py
+++ b/tests/batch/test_indexer_transfer.py
@@ -1802,7 +1802,7 @@ class TestProcessor:
         ):
             await main_func()
         assert 1 == caplog.record_tuples.count(
-            (LOG.name, logging.WARNING, "An external service was unavailable")
+            (LOG.name, logging.ERROR, "All blockchain nodes are unavailable: ")
         )
         caplog.clear()
 

--- a/tests/batch/test_indexer_transfer_approval.py
+++ b/tests/batch/test_indexer_transfer_approval.py
@@ -1713,7 +1713,7 @@ class TestProcessor:
         ):
             await main_func()
         assert 1 == caplog.record_tuples.count(
-            (LOG.name, logging.WARNING, "An external service was unavailable")
+            (LOG.name, logging.ERROR, "All blockchain nodes are unavailable: ")
         )
         caplog.clear()
 


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

This pull request improves the failover and retry logic for blockchain node requests across multiple utility modules, ensuring that failed endpoints are not retried within the same request cycle and enhancing error logging for better observability. 

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
None

## 🔄 Changes

<!-- List the major changes in this PR. -->

**Failover and Retry Logic Improvements:**

* Updated the `_resolve_endpoint_uri` methods in `app/utils/ava_contract_utils.py`, `app/utils/eth_contract_utils.py`, and `app/utils/ibet_web3_utils.py` (both sync and async) to accept a `failed_endpoint_uris` set, and to exclude any endpoints that have already failed during the current request cycle. This prevents repeated attempts to use endpoints that are known to be down. 
* In the `make_request` methods of these modules, introduced tracking of failed endpoints in a set, passing this set to `_resolve_endpoint_uri` on each retry, and adding the failed endpoint to the set after each failure. 

**Logging and Observability Enhancements:**

* Changed log messages from `LOG.info` to `LOG.warning` when retrying due to a failed endpoint, and included the failed endpoint URI in the log for better traceability. 
* Updated batch job exception handling in several scripts (`batch/indexer_block_tx_data.py`, `batch/indexer_dvp_delivery.py`, `batch/indexer_e2e_messaging.py`, `batch/indexer_issue_redeem.py`, `batch/indexer_personal_info.py`) to log an error with details when all blockchain nodes are unavailable, instead of a generic warning. 

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
