### PR TITLE
Handle RPC timeout in failover providers

### DIFF
--- a/app/utils/ava_contract_utils.py
+++ b/app/utils/ava_contract_utils.py
@@ -63,6 +63,7 @@ LOG = log.get_logger()
 
 ContractArtifact: TypeAlias = dict[str, Any]
 EventArgumentFilters: TypeAlias = dict[str, Any] | None
+_ASYNC_RETRYABLE_RPC_EXCEPTIONS = (ClientError, TimeoutError, JSONDecodeError)
 
 
 class _AvaWeb3Context:
@@ -177,7 +178,7 @@ class AvaFailOverHTTPProvider(ResolvedEndpointCacheMixin, AsyncHTTPProvider):
                     self.endpoint_uri = cached_endpoint_uri
                     try:
                         return await super().make_request(method, params)
-                    except ClientError, JSONDecodeError:
+                    except _ASYNC_RETRYABLE_RPC_EXCEPTIONS:
                         self._clear_cached_endpoint_uri()
                         failed_endpoint_uris.add(cached_endpoint_uri)
                         LOG.warning(
@@ -212,7 +213,7 @@ class AvaFailOverHTTPProvider(ResolvedEndpointCacheMixin, AsyncHTTPProvider):
                     try:
                         # Send request
                         return await super().make_request(method, params)
-                    except ClientError, JSONDecodeError:
+                    except _ASYNC_RETRYABLE_RPC_EXCEPTIONS:
                         # JSONDecodeError may occur when sending a request during geth shutdown, etc.
                         self._clear_cached_endpoint_uri()
                         failed_endpoint_uris.add(endpoint_uri)

--- a/app/utils/eth_contract_utils.py
+++ b/app/utils/eth_contract_utils.py
@@ -63,6 +63,7 @@ LOG = log.get_logger()
 
 ContractArtifact: TypeAlias = dict[str, Any]
 EventArgumentFilters: TypeAlias = dict[str, Any] | None
+_ASYNC_RETRYABLE_RPC_EXCEPTIONS = (ClientError, TimeoutError, JSONDecodeError)
 
 
 class _EthWeb3Context:
@@ -177,7 +178,7 @@ class EthFailOverHTTPProvider(ResolvedEndpointCacheMixin, AsyncHTTPProvider):
                     self.endpoint_uri = cached_endpoint_uri
                     try:
                         return await super().make_request(method, params)
-                    except ClientError, JSONDecodeError:
+                    except _ASYNC_RETRYABLE_RPC_EXCEPTIONS:
                         self._clear_cached_endpoint_uri()
                         failed_endpoint_uris.add(cached_endpoint_uri)
                         LOG.warning(
@@ -210,7 +211,7 @@ class EthFailOverHTTPProvider(ResolvedEndpointCacheMixin, AsyncHTTPProvider):
                     try:
                         # Send request
                         return await super().make_request(method, params)
-                    except ClientError, JSONDecodeError:
+                    except _ASYNC_RETRYABLE_RPC_EXCEPTIONS:
                         # JSONDecodeError may occur when sending a request during geth shutdown, etc.
                         self._clear_cached_endpoint_uri()
                         failed_endpoint_uris.add(endpoint_uri)

--- a/app/utils/ibet_web3_utils.py
+++ b/app/utils/ibet_web3_utils.py
@@ -27,7 +27,7 @@ from weakref import WeakKeyDictionary
 
 from aiohttp import ClientError, ClientTimeout
 from eth_typing import URI
-from requests.exceptions import ConnectionError, HTTPError
+from requests.exceptions import ConnectionError, HTTPError, Timeout as RequestsTimeout
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
@@ -55,6 +55,13 @@ LOG = log.get_logger()
 # do not accidentally share the same provider/session.
 AsyncWeb3TimeoutKey = tuple[Any, Any, Any, Any]
 AsyncWeb3CacheMap = dict[AsyncWeb3TimeoutKey, AsyncWeb3[Any]]
+_SYNC_RETRYABLE_RPC_EXCEPTIONS = (
+    ConnectionError,
+    HTTPError,
+    RequestsTimeout,
+    JSONDecodeError,
+)
+_ASYNC_RETRYABLE_RPC_EXCEPTIONS = (ClientError, TimeoutError, JSONDecodeError)
 
 
 class Web3Wrapper:
@@ -247,7 +254,7 @@ class FailOverHTTPProvider(ResolvedEndpointCacheMixin, HTTPProvider):
                     self.endpoint_uri = cached_endpoint_uri
                     try:
                         return super().make_request(method, params)
-                    except ConnectionError, JSONDecodeError, HTTPError:
+                    except _SYNC_RETRYABLE_RPC_EXCEPTIONS:
                         self._clear_cached_endpoint_uri()
                         failed_endpoint_uris.add(cached_endpoint_uri)
                         LOG.warning(
@@ -273,7 +280,7 @@ class FailOverHTTPProvider(ResolvedEndpointCacheMixin, HTTPProvider):
                     self.endpoint_uri = endpoint_uri
                     try:
                         return super().make_request(method, params)
-                    except ConnectionError, JSONDecodeError, HTTPError:
+                    except _SYNC_RETRYABLE_RPC_EXCEPTIONS:
                         # NOTE:
                         #  JSONDecodeError will be raised if a request is sent
                         #  while Quorum is terminating.
@@ -353,7 +360,7 @@ class AsyncFailOverHTTPProvider(ResolvedEndpointCacheMixin, AsyncHTTPProvider):
                     self.endpoint_uri = cached_endpoint_uri
                     try:
                         return await super().make_request(method, params)
-                    except ClientError, JSONDecodeError:
+                    except _ASYNC_RETRYABLE_RPC_EXCEPTIONS:
                         self._clear_cached_endpoint_uri()
                         failed_endpoint_uris.add(cached_endpoint_uri)
                         LOG.warning(
@@ -379,7 +386,7 @@ class AsyncFailOverHTTPProvider(ResolvedEndpointCacheMixin, AsyncHTTPProvider):
                     self.endpoint_uri = endpoint_uri
                     try:
                         return await super().make_request(method, params)
-                    except ClientError, JSONDecodeError:
+                    except _ASYNC_RETRYABLE_RPC_EXCEPTIONS:
                         # NOTE:
                         #  JSONDecodeError will be raised if a request is sent
                         #  while Quorum is terminating.

--- a/tests/app/utils/test_ava_failover_http_provider.py
+++ b/tests/app/utils/test_ava_failover_http_provider.py
@@ -158,6 +158,47 @@ class TestAvaFailOverHTTPProvider:
         assert make_request.await_count == 2
         assert fake_session.close.await_count == 1
 
+    # Normal_5
+    # - Test that cached primary endpoint timeout falls back to the standby endpoint
+    async def test_normal_5(self):
+        provider = _AvaFailOverHTTPProviderForTest(
+            fail_over_mode=True,
+            session_manager=KeepAliveHTTPSessionManager(),
+        )
+        primary_endpoint = URI("http://primary.example:8545")
+        standby_endpoint = URI("http://standby.example:8545")
+        provider.seed_cached_endpoint_uri(primary_endpoint)
+        method = RPCEndpoint("eth_chainId")
+        fake_session = MagicMock()
+        fake_session.scalars = AsyncMock(
+            side_effect=[
+                MagicMock(first=MagicMock(return_value=object())),
+                MagicMock(
+                    first=MagicMock(
+                        return_value=SimpleNamespace(endpoint_uri=str(standby_endpoint))
+                    )
+                ),
+            ]
+        )
+        fake_session.close = AsyncMock()
+
+        with (
+            patch(
+                "app.utils.ava_contract_utils.AsyncSession", return_value=fake_session
+            ),
+            patch(
+                "web3.providers.rpc.async_rpc.AsyncHTTPProvider.make_request",
+                AsyncMock(side_effect=[TimeoutError(), {"result": "ok"}]),
+            ) as make_request,
+        ):
+            response = await provider.make_request(method, [])
+
+        assert response == {"result": "ok"}
+        assert provider.endpoint_uri == standby_endpoint
+        assert fake_session.scalars.await_count == 2
+        assert make_request.await_count == 2
+        assert fake_session.close.await_count == 1
+
     ########################################################
     # Error
     ########################################################

--- a/tests/app/utils/test_eth_failover_http_provider.py
+++ b/tests/app/utils/test_eth_failover_http_provider.py
@@ -158,6 +158,47 @@ class TestEthFailOverHTTPProvider:
         assert make_request.await_count == 2
         assert fake_session.close.await_count == 1
 
+    # Normal_5
+    # - Test that cached primary endpoint timeout falls back to the standby endpoint
+    async def test_normal_5(self):
+        provider = _EthFailOverHTTPProviderForTest(
+            fail_over_mode=True,
+            session_manager=KeepAliveHTTPSessionManager(),
+        )
+        primary_endpoint = URI("http://primary.example:8545")
+        standby_endpoint = URI("http://standby.example:8545")
+        provider.seed_cached_endpoint_uri(primary_endpoint)
+        method = RPCEndpoint("eth_chainId")
+        fake_session = MagicMock()
+        fake_session.scalars = AsyncMock(
+            side_effect=[
+                MagicMock(first=MagicMock(return_value=object())),
+                MagicMock(
+                    first=MagicMock(
+                        return_value=SimpleNamespace(endpoint_uri=str(standby_endpoint))
+                    )
+                ),
+            ]
+        )
+        fake_session.close = AsyncMock()
+
+        with (
+            patch(
+                "app.utils.eth_contract_utils.AsyncSession", return_value=fake_session
+            ),
+            patch(
+                "web3.providers.rpc.async_rpc.AsyncHTTPProvider.make_request",
+                AsyncMock(side_effect=[TimeoutError(), {"result": "ok"}]),
+            ) as make_request,
+        ):
+            response = await provider.make_request(method, [])
+
+        assert response == {"result": "ok"}
+        assert provider.endpoint_uri == standby_endpoint
+        assert fake_session.scalars.await_count == 2
+        assert make_request.await_count == 2
+        assert fake_session.close.await_count == 1
+
     ########################################################
     # Error
     ########################################################

--- a/tests/app/utils/test_ibet_failover_http_provider.py
+++ b/tests/app/utils/test_ibet_failover_http_provider.py
@@ -21,7 +21,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from eth_typing import URI
-from requests.exceptions import ConnectionError
+from requests.exceptions import ConnectionError, Timeout as RequestsTimeout
 from web3.types import RPCEndpoint
 
 from app.utils.ibet_web3_utils import AsyncFailOverHTTPProvider, FailOverHTTPProvider
@@ -104,6 +104,42 @@ class TestFailOverHTTPProvider:
             patch(
                 "web3.providers.rpc.rpc.HTTPProvider.make_request",
                 side_effect=[ConnectionError(), {"result": "ok"}],
+            ) as make_request,
+        ):
+            response = provider.make_request(method, [])
+
+        assert response == {"result": "ok"}
+        assert provider.endpoint_uri == standby_endpoint
+        assert fake_session.scalars.call_count == 2
+        assert make_request.call_count == 2
+        assert fake_session.close.call_count == 1
+
+    # <Normal_3>
+    # Cached primary endpoint timeout falls back to the standby endpoint.
+    def test_normal_3(self, monkeypatch: pytest.MonkeyPatch):
+        provider = _FailOverHTTPProviderForTest()
+        primary_endpoint = URI("http://primary.example:8545")
+        standby_endpoint = URI("http://standby.example:8545")
+        provider.seed_cached_endpoint_uri(primary_endpoint)
+        fake_session = MagicMock()
+        fake_session.scalars.side_effect = [
+            MagicMock(first=MagicMock(return_value=object())),
+            MagicMock(
+                first=MagicMock(
+                    return_value=SimpleNamespace(endpoint_uri=str(standby_endpoint))
+                )
+            ),
+        ]
+        fake_session.close = MagicMock()
+
+        monkeypatch.setattr(FailOverHTTPProvider, "fail_over_mode", True)
+        method = RPCEndpoint("eth_chainId")
+
+        with (
+            patch("app.utils.ibet_web3_utils.Session", return_value=fake_session),
+            patch(
+                "web3.providers.rpc.rpc.HTTPProvider.make_request",
+                side_effect=[RequestsTimeout(), {"result": "ok"}],
             ) as make_request,
         ):
             response = provider.make_request(method, [])
@@ -200,6 +236,49 @@ class TestAsyncFailOverHTTPProvider:
                         {"result": "ok"},
                     ]
                 ),
+            ) as make_request,
+        ):
+            response = await provider.make_request(method, [])
+
+        assert response == {"result": "ok"}
+        assert provider.endpoint_uri == standby_endpoint
+        assert fake_session.scalars.await_count == 2
+        assert make_request.await_count == 2
+        assert fake_session.close.await_count == 1
+
+    # <Normal_3>
+    # Cached primary endpoint timeout falls back to the standby endpoint.
+    async def test_normal_3(self, monkeypatch: pytest.MonkeyPatch):
+        provider = _AsyncFailOverHTTPProviderForTest(
+            session_manager=KeepAliveHTTPSessionManager()
+        )
+        primary_endpoint = URI("http://primary.example:8545")
+        standby_endpoint = URI("http://standby.example:8545")
+        provider.seed_cached_endpoint_uri(primary_endpoint)
+        fake_session = MagicMock()
+        fake_session.scalars = AsyncMock(
+            side_effect=[
+                MagicMock(first=MagicMock(return_value=object())),
+                MagicMock(
+                    first=MagicMock(
+                        return_value=SimpleNamespace(endpoint_uri=str(standby_endpoint))
+                    )
+                ),
+            ]
+        )
+        fake_session.close = AsyncMock()
+
+        monkeypatch.setattr(AsyncFailOverHTTPProvider, "fail_over_mode", True)
+        method = RPCEndpoint("eth_chainId")
+
+        with (
+            patch(
+                "app.utils.ibet_web3_utils.AsyncSession",
+                return_value=fake_session,
+            ),
+            patch(
+                "web3.providers.rpc.async_rpc.AsyncHTTPProvider.make_request",
+                AsyncMock(side_effect=[TimeoutError(), {"result": "ok"}]),
             ) as make_request,
         ):
             response = await provider.make_request(method, [])


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

This pull request improves the reliability of the failover HTTP provider logic by expanding the list of retryable exceptions for both synchronous and asynchronous RPC requests.

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
- Related to: #1066

## 🔄 Changes

<!-- List the major changes in this PR. -->

**Exception handling improvements:**

* Introduced `_ASYNC_RETRYABLE_RPC_EXCEPTIONS` and `_SYNC_RETRYABLE_RPC_EXCEPTIONS` constants in `app/utils/ava_contract_utils.py`, `app/utils/eth_contract_utils.py`, and `app/utils/ibet_web3_utils.py` to centralize the definition of exceptions that should trigger failover, including `TimeoutError` and `requests.exceptions.Timeout`. 
* Updated all failover provider `make_request` methods to use these new exception constants, ensuring consistent and maintainable error handling across sync and async code. 

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
